### PR TITLE
Skip modify of user/group when PUID/GUID not changed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,8 +35,8 @@ ENV PUID 1000
 ENV PGID 1000
 
 RUN apk --update --no-cache add tzdata tini shadow && \
-    addgroup vikunja && \
-    adduser -s /bin/sh -D -G vikunja vikunja -h /app/vikunja -H
+    addgroup vikunja --gid "$PGID" && \
+    adduser -s /bin/sh -D -G vikunja vikunja --uid "$PUID" -h /app/vikunja -H
 COPY docker/entrypoint.sh /entrypoint.sh
 RUN chmod 0755 /entrypoint.sh && mkdir files
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -2,7 +2,8 @@
 set -e
 
 if [ -n "$PUID" ] && [ "$PUID" -ne 0 ] && \
-   [ -n "$PGID" ] && [ "$PGID" -ne 0 ] ; then
+   [ -n "$PGID" ] && [ "$PGID" -ne 0 ] && \
+   ([ "$PUID" -ne "$(id -u vikunja)" ] || [ "$PGID" -ne "$(id -g vikunja)" ]) ; then
   echo "info: creating the new user vikunja with $PUID:$PGID"
   groupmod -g "$PGID" -o vikunja
   usermod -u "$PUID" -o vikunja


### PR DESCRIPTION
With this change, you can run the API image as non-root. To run as non-root you must use 1000:1000.