### PR TITLE
tasks: also delete corresponding task positions

### DIFF
--- a/pkg/models/tasks.go
+++ b/pkg/models/tasks.go
@@ -956,6 +956,10 @@ func (t *Task) Update(s *xorm.Session, a web.Auth) (err error) {
 		if err != nil {
 			return err
 		}
+		_, err = s.Where("task_id = ?", t.ID).Delete(&TaskPosition{})
+		if err != nil {
+			return err
+		}
 
 		for _, view := range views {
 			var bucketID = view.DoneBucketID


### PR DESCRIPTION
Closes #348

When moving a project, the old task bucket entries (project, saved filters) will be removed, but not the corresponding position. This has the effect that the saved_filter event hook UpdateTaskInSavedFilterViews wrongly assumes that the task doesn't need to be re-added to the saved filter since the position part still exists.

cc @kolaente 