### PR TITLE
Fix bug in link sharing for projects with no views

### DIFF
--- a/frontend/src/components/sharing/LinkSharing.vue
+++ b/frontend/src/components/sharing/LinkSharing.vue
@@ -284,7 +284,7 @@ watch(() => ([linkShares.value, availableViews.value]), ([newLinkShares, newProj
 	}
 
 	newLinkShares.forEach((linkShare) => {
-		selectedViews.value[linkShare.id] = newProjectViews[0].id
+		selectedViews.value[linkShare.id] = newProjectViews.length > 0 ? newProjectViews[0].id : null
 	})
 }, {
 	immediate:true,


### PR DESCRIPTION
fix: do not fail to load projects without views via link share

Resolves https://community.vikunja.io/t/undefined-error-when-sharing-an-empty-project/3126