### PR TITLE
chore: remove browserslist:update script

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,7 +40,6 @@
     "test:e2e-dev": "start-server-and-test preview http://127.0.0.1:4173 'cypress open --e2e'",
     "test:unit": "vitest --dir ./src",
     "typecheck": "vue-tsc --build --force",
-    "browserslist:update": "pnpm dlx browserslist@latest --update-db",
     "fonts:update": "pnpm fonts:download && pnpm fonts:subset",
     "fonts:download": "./scripts/fonts-download.sh",
     "fonts:subset": "./scripts/fonts-subset.sh",


### PR DESCRIPTION
Not needed since we use renovate. See https://github.com/go-vikunja/vikunja/pull/656#issuecomment-2792207288 and https://github.com/go-vikunja/vikunja/blob/a09840b85288415bf3a4c8b71aba40db924c74c9/renovate.json#L24-L33