### PR TITLE
feat: remove cypress install v2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -264,7 +264,6 @@ jobs:
       - name: Build frontend for test
         run: |
           cd frontend
-          pnpm cypress install
           pnpm build:test
       - name: Run api
         env:

--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,2 +1,6 @@
 # https://github.com/pnpm/pnpm/issues/8378#issuecomment-2636152421
 public-hoist-pattern[]=*eslint*
+
+# Make sure to install Cypress binary
+# https://github.com/cypress-io/github-action/blob/108b8684ae52e735ff7891524cbffbcd4be5b19f/README.md#pnpm
+side-effects-cache=false


### PR DESCRIPTION
Why cypress install was needed before: [see this issue](https://github.com/cypress-io/github-action/issues/1044#issuecomment-2663220655)

It's also mentioned [in the cypress github action readme](https://github.com/cypress-io/github-action/tree/v6/?tab=readme-ov-file#pnpm)

------

Supersedes: https://github.com/go-vikunja/vikunja/pull/637