### PR TITLE
fix(docs): improve swagger output by setting swaggertype and enums

### DIFF
--- a/pkg/models/project_view.go
+++ b/pkg/models/project_view.go
@@ -139,7 +139,7 @@ type ProjectView struct {
 	ViewKind ProjectViewKind `xorm:"not null" json:"view_kind" swaggertype:"string" enums:"list,gantt,table,kanban"`
 
 	// The filter query to match tasks by. Check out https://vikunja.io/docs/filters for a full explanation.
-	Filter *TaskCollection `xorm:"json null default null" query:"filter" json:"filter" swaggertype:"string"`
+	Filter *TaskCollection `xorm:"json null default null" query:"filter" json:"filter"`
 	// The position of this view in the list. The list of all views will be sorted by this parameter.
 	Position float64 `xorm:"double null" json:"position"`
 

--- a/pkg/models/project_view.go
+++ b/pkg/models/project_view.go
@@ -66,6 +66,10 @@ func (p *ProjectViewKind) UnmarshalJSON(bytes []byte) error {
 	return nil
 }
 
+// NOTE: When adding or changing enum values for ProjectViewKind,
+// make sure to update the corresponding `enums` tag in the ProjectView struct
+// to keep the OpenAPI documentation in sync.
+
 const (
 	ProjectViewKindList ProjectViewKind = iota
 	ProjectViewKindGantt
@@ -74,6 +78,10 @@ const (
 )
 
 type BucketConfigurationModeKind int
+
+// NOTE: When adding or changing enum values for BucketConfigurationModeKind,
+// make sure to update the corresponding `enums` tag in the ProjectView struct
+// to keep the OpenAPI documentation in sync.
 
 const (
 	BucketConfigurationModeNone BucketConfigurationModeKind = iota

--- a/pkg/models/project_view.go
+++ b/pkg/models/project_view.go
@@ -128,15 +128,15 @@ type ProjectView struct {
 	// The project this view belongs to
 	ProjectID int64 `xorm:"not null index" json:"project_id" param:"project"`
 	// The kind of this view. Can be `list`, `gantt`, `table` or `kanban`.
-	ViewKind ProjectViewKind `xorm:"not null" json:"view_kind"`
+	ViewKind ProjectViewKind `xorm:"not null" json:"view_kind" swaggertype:"string" enums:"list,gantt,table,kanban"`
 
 	// The filter query to match tasks by. Check out https://vikunja.io/docs/filters for a full explanation.
-	Filter *TaskCollection `xorm:"json null default null" query:"filter" json:"filter"`
+	Filter *TaskCollection `xorm:"json null default null" query:"filter" json:"filter" swaggertype:"string"`
 	// The position of this view in the list. The list of all views will be sorted by this parameter.
 	Position float64 `xorm:"double null" json:"position"`
 
 	// The bucket configuration mode. Can be `none`, `manual` or `filter`. `manual` allows to move tasks between buckets as you normally would. `filter` creates buckets based on a filter for each bucket.
-	BucketConfigurationMode BucketConfigurationModeKind `xorm:"default 0" json:"bucket_configuration_mode"`
+	BucketConfigurationMode BucketConfigurationModeKind `xorm:"default 0" json:"bucket_configuration_mode" swaggertype:"string" enums:"none,manual,filter,manual"`
 	// When the bucket configuration mode is not `manual`, this field holds the options of that configuration.
 	BucketConfiguration []*ProjectViewBucketConfiguration `xorm:"json" json:"bucket_configuration"`
 	// The ID of the bucket where new tasks without a bucket are added to. By default, this is the leftmost bucket in a view.


### PR DESCRIPTION
Added `swaggertype:"string"` and `enums` tags to fields in ProjectView to ensure correct type representation in Swagger docs.

Affected fields:
- ViewKind
- Filter
- BucketConfigurationMode