### PR TITLE
Enable iOS CalDAV support for recurring tasks

### DIFF
--- a/pkg/caldav/caldav.go
+++ b/pkg/caldav/caldav.go
@@ -168,10 +168,29 @@ PRIORITY:` + strconv.Itoa(mapPriorityToCaldav(t.Priority))
 		}
 
 		if t.RepeatAfter > 0 || t.RepeatMode == models.TaskRepeatModeMonth {
-			if t.RepeatMode == models.TaskRepeatModeMonth {
+			switch {
+		
+			case t.RepeatMode == models.TaskRepeatModeMonth:
 				caldavtodos += `
-RRULE:FREQ=MONTHLY;BYMONTHDAY=` + t.DueDate.Format("02") // Day of the month
-			} else {
+RRULE:FREQ=MONTHLY;BYMONTHDAY=` + t.DueDate.Format("02")
+		
+			case t.RepeatAfter%604800 == 0:
+				weeks := t.RepeatAfter / 604800
+				if weeks < 1 {
+					weeks = 1
+				}
+				caldavtodos += `
+RRULE:FREQ=WEEKLY;INTERVAL=` + strconv.FormatInt(weeks, 10)
+		
+			case t.RepeatAfter%86400 == 0:
+				days := t.RepeatAfter / 86400
+				if days < 1 {
+					days = 1
+				}
+				caldavtodos += `
+RRULE:FREQ=DAILY;INTERVAL=` + strconv.FormatInt(days, 10)
+		
+			default:
 				caldavtodos += `
 RRULE:FREQ=SECONDLY;INTERVAL=` + strconv.FormatInt(t.RepeatAfter, 10)
 			}


### PR DESCRIPTION
This PR updates how Vikunja stores tasks in its CalDAV server. Specifically, it maps `RRULE:FREQ=SECONDLY` to the appropriate `DAILY` or `WEEKLY` interval frequency where possible.

**Why?**

Vikunja currently stores all CalDAV recurring tasks with `FREQ=SECONDLY` in its `RRULE` field unless the "Repeat mode" is set to "Monthly". This is [permissible ](https://datatracker.ietf.org/doc/html/rfc5545#section-3.3.10) and logical as tasks recurring daily or weekly can be represented as recurring every X seconds. Unfortunately, [iOS does not support](https://developer.apple.com/documentation/eventkit/ekrecurrencefrequency) CalDAV tasks with a `SECONDLY` interval frequency.

If you try and connect to Vikunja CalDAV from iOS and create, for example, a daily recurring task, iOS Reminders will break and refuse to show subsequent updates to the task list.

Please see [this iseeu](https://github.com/go-vikunja/vikunja/issues/728) to understand my debugging process.
