### PR TITLE
feat(auth): add ForceUserInfo option to OpenID provider

### DIFF
--- a/config-raw.json
+++ b/config-raw.json
@@ -709,6 +709,11 @@
                                             "key": "emailfallback",
                                             "default_value": "false",
                                             "comment": "This option allows to look for a local account where the OIDC user's email match the Vikunja local email. Allowed value is either `true` or `false`. That option can be combined with `usernamefallback`.\nUse with caution, this can allow the 3rd party provider to connect to *any* local account and therefore potential account hijaking."
+                                        },
+                                        {
+                                            "key": "forceuserinfo",
+                                            "default_value": "false",
+                                            "comment": "This option forces the use of the OpenID Connect UserInfo endpoint to retrieve user information instead of relying on claims from the ID token. When set to `true`, user data (email, name, username) will always be obtained from the UserInfo endpoint even if the information is available in the token claims. This is useful for providers that don't include complete user information in their tokens or when you need the most up-to-date user data. Allowed value is either `true` or `false`."
                                         }
                                     ]
                                 }

--- a/pkg/modules/auth/openid/openid_test.go
+++ b/pkg/modules/auth/openid/openid_test.go
@@ -311,7 +311,7 @@ func TestMergeClaims(t *testing.T) {
 		}
 
 		// Test with ForceUserInfo enabled
-		err := mergeClaims(tokenClaims, userinfoClaims, "test-provider", true)
+		err := mergeClaims(tokenClaims, userinfoClaims, true)
 		require.NoError(t, err)
 
 		// Verify userinfo data was used
@@ -336,7 +336,7 @@ func TestMergeClaims(t *testing.T) {
 		}
 
 		// Test with ForceUserInfo disabled
-		err := mergeClaims(tokenClaims, userinfoClaims, "test-provider", false)
+		err := mergeClaims(tokenClaims, userinfoClaims, false)
 		require.NoError(t, err)
 
 		// Verify token data was preserved
@@ -360,7 +360,7 @@ func TestMergeClaims(t *testing.T) {
 		}
 
 		// Test with ForceUserInfo disabled, but missing values in token
-		err := mergeClaims(tokenClaims, userinfoClaims, "test-provider", false)
+		err := mergeClaims(tokenClaims, userinfoClaims, false)
 		require.NoError(t, err)
 
 		// Verify token email was kept, but missing fields were filled from userinfo
@@ -386,7 +386,7 @@ func TestMergeClaims(t *testing.T) {
 		}
 
 		// Test with ForceUserInfo disabled
-		err := mergeClaims(tokenClaims, userinfoClaims, "test-provider", false)
+		err := mergeClaims(tokenClaims, userinfoClaims, false)
 		require.NoError(t, err)
 
 		// Verify nickname was used for preferred_username
@@ -409,7 +409,7 @@ func TestMergeClaims(t *testing.T) {
 		}
 
 		// Test with ForceUserInfo disabled
-		err := mergeClaims(tokenClaims, userinfoClaims, "test-provider", false)
+		err := mergeClaims(tokenClaims, userinfoClaims, false)
 
 		// Verify error is returned for missing email
 		require.Error(t, err)

--- a/pkg/modules/auth/openid/openid_test.go
+++ b/pkg/modules/auth/openid/openid_test.go
@@ -292,3 +292,127 @@ func TestGetOrCreateUser(t *testing.T) {
 		assert.Equal(t, 11, int(u.ID), "user id 11 expected")
 	})
 }
+
+// TestMergeClaims tests the mergeClaims function with different configurations including forceUserInfo
+func TestMergeClaims(t *testing.T) {
+	t.Run("ForceUserInfo enabled - should use userinfo values", func(t *testing.T) {
+		// Setup token claims
+		tokenClaims := &claims{
+			Email:             "token-email@example.com",
+			Name:              "Token Name",
+			PreferredUsername: "token_username",
+		}
+
+		// Setup userinfo claims
+		userinfoClaims := &claims{
+			Email:             "userinfo-email@example.com",
+			Name:              "UserInfo Name",
+			PreferredUsername: "userinfo_username",
+		}
+
+		// Test with ForceUserInfo enabled
+		err := mergeClaims(tokenClaims, userinfoClaims, "test-provider", true)
+		require.NoError(t, err)
+
+		// Verify userinfo data was used
+		assert.Equal(t, "userinfo-email@example.com", tokenClaims.Email)
+		assert.Equal(t, "UserInfo Name", tokenClaims.Name)
+		assert.Equal(t, "userinfo_username", tokenClaims.PreferredUsername)
+	})
+
+	t.Run("ForceUserInfo disabled - should use token values if present", func(t *testing.T) {
+		// Setup token claims with all values
+		tokenClaims := &claims{
+			Email:             "token-email@example.com",
+			Name:              "Token Name",
+			PreferredUsername: "token_username",
+		}
+
+		// Setup userinfo claims
+		userinfoClaims := &claims{
+			Email:             "userinfo-email@example.com",
+			Name:              "UserInfo Name",
+			PreferredUsername: "userinfo_username",
+		}
+
+		// Test with ForceUserInfo disabled
+		err := mergeClaims(tokenClaims, userinfoClaims, "test-provider", false)
+		require.NoError(t, err)
+
+		// Verify token data was preserved
+		assert.Equal(t, "token-email@example.com", tokenClaims.Email)
+		assert.Equal(t, "Token Name", tokenClaims.Name)
+		assert.Equal(t, "token_username", tokenClaims.PreferredUsername)
+	})
+
+	t.Run("Missing values - should use userinfo when token is missing values", func(t *testing.T) {
+		// Setup token claims with missing values
+		tokenClaims := &claims{
+			Email: "token-email@example.com",
+			// Missing Name and PreferredUsername
+		}
+
+		// Setup userinfo claims
+		userinfoClaims := &claims{
+			Email:             "userinfo-email@example.com",
+			Name:              "UserInfo Name",
+			PreferredUsername: "userinfo_username",
+		}
+
+		// Test with ForceUserInfo disabled, but missing values in token
+		err := mergeClaims(tokenClaims, userinfoClaims, "test-provider", false)
+		require.NoError(t, err)
+
+		// Verify token email was kept, but missing fields were filled from userinfo
+		assert.Equal(t, "token-email@example.com", tokenClaims.Email)
+		assert.Equal(t, "UserInfo Name", tokenClaims.Name)
+		assert.Equal(t, "userinfo_username", tokenClaims.PreferredUsername)
+	})
+
+	t.Run("Use nickname when preferred_username is missing", func(t *testing.T) {
+		// Setup token claims with missing preferred_username
+		tokenClaims := &claims{
+			Email: "token-email@example.com",
+			Name:  "Token Name",
+			// Missing PreferredUsername
+		}
+
+		// Setup userinfo claims with nickname but no preferred_username
+		userinfoClaims := &claims{
+			Email:    "userinfo-email@example.com",
+			Name:     "UserInfo Name",
+			Nickname: "userinfo_nickname",
+			// Missing PreferredUsername to test fallback to nickname
+		}
+
+		// Test with ForceUserInfo disabled
+		err := mergeClaims(tokenClaims, userinfoClaims, "test-provider", false)
+		require.NoError(t, err)
+
+		// Verify nickname was used for preferred_username
+		assert.Equal(t, "userinfo_nickname", tokenClaims.PreferredUsername)
+	})
+
+	t.Run("Error when email is missing", func(t *testing.T) {
+		// Setup token claims with missing email
+		tokenClaims := &claims{
+			// Missing Email
+			Name:              "Token Name",
+			PreferredUsername: "token_username",
+		}
+
+		// Setup userinfo claims also with missing email
+		userinfoClaims := &claims{
+			// Missing Email
+			Name:              "UserInfo Name",
+			PreferredUsername: "userinfo_username",
+		}
+
+		// Test with ForceUserInfo disabled
+		err := mergeClaims(tokenClaims, userinfoClaims, "test-provider", false)
+
+		// Verify error is returned for missing email
+		require.Error(t, err)
+		assert.IsType(t, &user.ErrNoOpenIDEmailProvided{}, err)
+	})
+}

--- a/pkg/modules/auth/openid/providers.go
+++ b/pkg/modules/auth/openid/providers.go
@@ -188,6 +188,8 @@ func getProviderFromMap(pi map[string]interface{}, key string) (provider *Provid
 		forceUserInfoTypedValue, ok := forceUserInfoValue.(bool)
 		if ok {
 			forceUserInfo = forceUserInfoTypedValue
+		} else {
+			log.Errorf("forceuserinfo is not a boolean for provider %s, value: %v", key, forceUserInfoValue)
 		}
 	}
 

--- a/pkg/modules/auth/openid/providers.go
+++ b/pkg/modules/auth/openid/providers.go
@@ -125,6 +125,7 @@ func getProviderFromMap(pi map[string]interface{}, key string) (provider *Provid
 			"scope",
 			"emailfallback",
 			"usernamefallback",
+			"forceuserinfo",
 		},
 		requiredKeys...,
 	)
@@ -180,6 +181,16 @@ func getProviderFromMap(pi map[string]interface{}, key string) (provider *Provid
 			usernameFallback = usernameFallbackTypedValue
 		}
 	}
+
+	var forceUserInfo = false
+	forceUserInfoValue, exists := pi["forceuserinfo"]
+	if exists {
+		forceUserInfoTypedValue, ok := forceUserInfoValue.(bool)
+		if ok {
+			forceUserInfo = forceUserInfoTypedValue
+		}
+	}
+
 	provider = &Provider{
 		Name:             name,
 		Key:              key,
@@ -190,6 +201,7 @@ func getProviderFromMap(pi map[string]interface{}, key string) (provider *Provid
 		Scope:            scope,
 		EmailFallback:    emailFallback,
 		UsernameFallback: usernameFallback,
+		ForceUserInfo:    forceUserInfo,
 	}
 
 	cl, is := pi["clientid"].(int)


### PR DESCRIPTION
# Add ForceUserInfo option to OpenID provider

## Problem
When using Casdoor as an OpenID provider, there's an inconsistency between the user information in the JWT token and the UserInfo endpoint. The token contains the user's unique ID in the `name` field, while the UserInfo endpoint correctly returns the user's display name.

## Solution
This PR adds a new `ForceUserInfo` option to the OpenID provider configuration. When enabled, it forces the use of the UserInfo endpoint to retrieve user information instead of relying on claims from the ID token.

## Impact
- Default behavior remains unchanged (backward compatible)
- New option allows administrators to force using UserInfo endpoint data
- Particularly useful for providers like Casdoor that don't fully comply with OIDC standards

## Related
I've opened an issue in the Casdoor repository (https://github.com/casdoor/casdoor/issues/3806) to discuss the root cause. However, changing Casdoor's token structure might cause significant compatibility issues for existing integrations, so it's unclear if this can be fixed at the provider level. This PR provides a workaround in Vikunja that doesn't affect existing functionality.

Docs PR: https://github.com/go-vikunja/website/pull/107