### PR TITLE
fix(auth): fix regex in JWT decoding causing login issues for Chinese/Japanese user names

### DIFF
--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -284,8 +284,8 @@ export const useAuthStore = defineStore('auth', () => {
 			try {
 				const base64 = jwt
 					.split('.')[1]
-					.replace('/-/g', '+')
-					.replace('/_/g', '/')
+					.replace(/-/g, '+')
+					.replace(/_/g, '/')
 				const info = new UserModel(JSON.parse(atob(base64)))
 				const ts = Math.round((new Date()).getTime() / MILLISECONDS_A_SECOND)
 


### PR DESCRIPTION
This PR fixes https://github.com/go-vikunja/vikunja/issues/807 and I verified locally. It has no problem now.