### PR TITLE
fix(types): readd DOM.Iterable types

### DIFF
--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -13,7 +13,7 @@
     "composite": true,
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
     "baseUrl": ".",
-    "lib": ["ESNext", "DOM", "WebWorker"],
+    "lib": ["ESNext", "DOM", "DOM.Iterable", "WebWorker"],
 
     "importHelpers": true,
     "sourceMap": true,


### PR DESCRIPTION
These types are included in @vue/tsconfig/tsconfig.dom.json but get overwritten by `compilerOptions/lib` in `tsconfig.app.json`