### PR TITLE
Add PGroonga full text search

### DIFF
--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -37,8 +37,13 @@ import (
 	_ "github.com/mattn/go-sqlite3"    // Because.
 )
 
-// We only want one instance of the engine, so we can reate it once and reuse it
-var x *xorm.Engine
+// We only want one instance of the engine, so we can create it once and reuse it
+var (
+	x *xorm.Engine
+	// pgroongaInstalled marks whether the pgroonga extension is available
+	// and can be used for full text search.
+	pgroongaInstalled bool
+)
 
 // CreateDBEngine initializes a db engine from the config
 func CreateDBEngine() (engine *xorm.Engine, err error) {
@@ -173,6 +178,8 @@ func initPostgresEngine() (engine *xorm.Engine, err error) {
 		return
 	}
 	engine.SetConnMaxLifetime(maxLifetime)
+
+	checkPGroonga(engine)
 	return
 }
 
@@ -238,4 +245,27 @@ func GetDialect() string {
 	}
 
 	return dialect
+}
+
+func checkPGroonga(engine *xorm.Engine) {
+	if engine.Dialect().URI().DBType != schemas.POSTGRES {
+		return
+	}
+
+	exists := false
+	if _, err := engine.SQL("SELECT EXISTS (SELECT 1 FROM pg_extension WHERE extname='pgroonga')").Get(&exists); err != nil {
+		log.Errorf("could not check for pgroonga extension: %v", err)
+		return
+	}
+
+	if !exists {
+		return
+	}
+
+	pgroongaInstalled = true
+	log.Debug("PGroonga extension detected, using &@ search operator")
+
+	if _, err := engine.Exec("CREATE INDEX IF NOT EXISTS idx_tasks_pgroonga ON tasks USING pgroonga (title, description)"); err != nil {
+		log.Criticalf("could not ensure pgroonga index: %v", err)
+	}
 }

--- a/pkg/db/helpers.go
+++ b/pkg/db/helpers.go
@@ -28,6 +28,9 @@ import (
 // See https://stackoverflow.com/q/7005302/10924593
 func ILIKE(column, search string) builder.Cond {
 	if Type() == schemas.POSTGRES {
+		if pgroongaInstalled && search != "" {
+			return builder.Expr(column+" &@ ?", search)
+		}
 		return builder.Expr(column+" ILIKE ?", "%"+search+"%")
 	}
 


### PR DESCRIPTION
## Summary
- add detection of PGroonga extension
- automatically create index for task title and description
- use PGroonga `&@` operator in `db.ILIKE` when available
- log PGroonga detection and use critical log on index creation failure
- remove now unnecessary `HasPGroonga` helper

## Testing
- `mage test:unit` *(fails: signal interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_684808f269808322b6390f4f02c92fc6