### PR TITLE
Fix quick add not creating task

### DIFF
--- a/frontend/src/components/quick-actions/QuickActions.vue
+++ b/frontend/src/components/quick-actions/QuickActions.vue
@@ -492,18 +492,17 @@ async function doAction(type: ACTION_TYPE, item: DoAction) {
 }
 
 async function doCmd() {
-	if (results.value.length === 1 && results.value[0].items.length === 1) {
-		const result = results.value[0]
-		doAction(result.type, result.items[0])
-		return
-	}
+       if (selectedCmd.value !== null && query.value !== '') {
+               closeQuickActions()
+               await selectedCmd.value.action()
+               return
+       }
 
-	if (selectedCmd.value === null || query.value === '') {
-		return
-	}
-
-	closeQuickActions()
-	await selectedCmd.value.action()
+       if (results.value.length === 1 && results.value[0].items.length === 1) {
+               const result = results.value[0]
+               doAction(result.type, result.items[0])
+               return
+       }
 }
 
 async function newTask() {


### PR DESCRIPTION
## Summary
- ensure quick add command executes before auto opening single search result

## Testing
- `pnpm lint:fix` in `frontend`
- `pnpm test:unit` (fails to exit automatically, interrupted after tests passed)


------
https://chatgpt.com/codex/tasks/task_e_68487df7117883228b89e7bb7828c5c4