### PR TITLE
fix(editor): pasted link capturing trailing text

### DIFF
--- a/frontend/src/components/input/editor/TipTap.vue
+++ b/frontend/src/components/input/editor/TipTap.vue
@@ -182,6 +182,7 @@ import XButton from '@/components/input/Button.vue'
 import {isEditorContentEmpty} from '@/helpers/editorContentEmpty'
 import inputPrompt from '@/helpers/inputPrompt'
 import {setLinkInEditor} from '@/components/input/editor/setLinkInEditor'
+import StopLinkOnSpace from './stopLinkOnSpace'
 
 const props = withDefaults(defineProps<{
 	modelValue: string,
@@ -464,11 +465,12 @@ const extensions : Extensions = [
 		},
 	}),
 
-	Commands.configure({
-		suggestion: suggestionSetup(t),
-	}),
-	
-	PasteHandler,
+        Commands.configure({
+                suggestion: suggestionSetup(t),
+        }),
+
+        PasteHandler,
+       StopLinkOnSpace,
 ]
 
 // Add a custom extension for the Escape key

--- a/frontend/src/components/input/editor/stopLinkOnSpace.ts
+++ b/frontend/src/components/input/editor/stopLinkOnSpace.ts
@@ -1,0 +1,16 @@
+import {Extension} from '@tiptap/core'
+
+export default Extension.create({
+    name: 'stopLinkOnSpace',
+
+    addKeyboardShortcuts() {
+        return {
+            Space: ({editor}) => {
+                if (editor.isActive('link')) {
+                    editor.commands.unsetLink()
+                }
+                return false
+            },
+        }
+    },
+})


### PR DESCRIPTION
Resolves https://github.com/go-vikunja/vikunja/issues/677

## Summary
- ensure space terminates links after pasting
- stop link mark on space in editor

## Testing
- `pnpm lint:fix`


------
https://chatgpt.com/codex/tasks/task_e_68487ef2e8888322be8d3e49ebbd428d