### PR TITLE
test: reuse integration setup

### DIFF
--- a/pkg/integrations/api_tokens_test.go
+++ b/pkg/integrations/api_tokens_test.go
@@ -33,11 +33,10 @@ import (
 
 func TestAPIToken(t *testing.T) {
 	t.Run("valid token", func(t *testing.T) {
-		e, err := setupTestEnv()
-		require.NoError(t, err)
+		require.NoError(t, db.LoadFixtures())
 		req := httptest.NewRequest(http.MethodGet, "/api/v1/tasks/all", nil)
 		res := httptest.NewRecorder()
-		c := e.NewContext(req, res)
+		c := testRouter.NewContext(req, res)
 		h := routes.SetupTokenMiddleware()(func(c echo.Context) error {
 			u, err := auth.GetAuthFromClaims(c)
 			if err != nil {
@@ -53,11 +52,10 @@ func TestAPIToken(t *testing.T) {
 		assert.Contains(t, res.Body.String(), `"username":"user1"`)
 	})
 	t.Run("invalid token", func(t *testing.T) {
-		e, err := setupTestEnv()
-		require.NoError(t, err)
+		require.NoError(t, db.LoadFixtures())
 		req := httptest.NewRequest(http.MethodGet, "/api/v1/tasks/all", nil)
 		res := httptest.NewRecorder()
-		c := e.NewContext(req, res)
+		c := testRouter.NewContext(req, res)
 		h := routes.SetupTokenMiddleware()(func(c echo.Context) error {
 			return c.String(http.StatusOK, "test")
 		})
@@ -66,11 +64,10 @@ func TestAPIToken(t *testing.T) {
 		require.Error(t, h(c))
 	})
 	t.Run("expired token", func(t *testing.T) {
-		e, err := setupTestEnv()
-		require.NoError(t, err)
+		require.NoError(t, db.LoadFixtures())
 		req := httptest.NewRequest(http.MethodGet, "/api/v1/tasks/all", nil)
 		res := httptest.NewRecorder()
-		c := e.NewContext(req, res)
+		c := testRouter.NewContext(req, res)
 		h := routes.SetupTokenMiddleware()(func(c echo.Context) error {
 			return c.String(http.StatusOK, "test")
 		})
@@ -79,11 +76,10 @@ func TestAPIToken(t *testing.T) {
 		require.Error(t, h(c))
 	})
 	t.Run("valid token, invalid scope", func(t *testing.T) {
-		e, err := setupTestEnv()
-		require.NoError(t, err)
+		require.NoError(t, db.LoadFixtures())
 		req := httptest.NewRequest(http.MethodGet, "/api/v1/projects", nil)
 		res := httptest.NewRecorder()
-		c := e.NewContext(req, res)
+		c := testRouter.NewContext(req, res)
 		h := routes.SetupTokenMiddleware()(func(c echo.Context) error {
 			return c.String(http.StatusOK, "test")
 		})
@@ -92,11 +88,10 @@ func TestAPIToken(t *testing.T) {
 		require.Error(t, h(c))
 	})
 	t.Run("jwt", func(t *testing.T) {
-		e, err := setupTestEnv()
-		require.NoError(t, err)
+		require.NoError(t, db.LoadFixtures())
 		req := httptest.NewRequest(http.MethodGet, "/api/v1/tasks/all", nil)
 		res := httptest.NewRecorder()
-		c := e.NewContext(req, res)
+		c := testRouter.NewContext(req, res)
 		h := routes.SetupTokenMiddleware()(func(c echo.Context) error {
 			return c.String(http.StatusOK, "test")
 		})
@@ -112,18 +107,17 @@ func TestAPIToken(t *testing.T) {
 		require.NoError(t, h(c))
 	})
 	t.Run("nonexisting route", func(t *testing.T) {
-		e, err := setupTestEnv()
-		require.NoError(t, err)
+		require.NoError(t, db.LoadFixtures())
 		req := httptest.NewRequest(http.MethodGet, "/api/v1/nonexisting", nil)
 		res := httptest.NewRecorder()
-		c := e.NewContext(req, res)
+		c := testRouter.NewContext(req, res)
 		h := routes.SetupTokenMiddleware()(func(c echo.Context) error {
 			return c.String(http.StatusNotFound, "test")
 		})
 
 		req.Header.Set(echo.HeaderAuthorization, "Bearer tk_a5e6f92ddbad68f49ee2c63e52174db0235008c8") // Token 2
 
-		err = h(c)
+		err := h(c)
 		require.NoError(t, err)
 		assert.Equal(t, 404, c.Response().Status)
 	})

--- a/pkg/integrations/integrations.go
+++ b/pkg/integrations/integrations.go
@@ -100,11 +100,8 @@ func createRequest(e *echo.Echo, method string, payload string, queryParam url.V
 }
 
 func bootstrapTestRequest(t *testing.T, method string, payload string, queryParam url.Values, urlParams map[string]string) (c echo.Context, rec *httptest.ResponseRecorder) {
-	// Setup
-	e, err := setupTestEnv()
-	require.NoError(t, err)
-
-	c, rec = createRequest(e, method, payload, queryParam, urlParams)
+	require.NoError(t, db.LoadFixtures())
+	c, rec = createRequest(testRouter, method, payload, queryParam, urlParams)
 	return
 }
 
@@ -155,9 +152,9 @@ func newTestRequestWithLinkShare(t *testing.T, method string, handler echo.Handl
 	return
 }
 
-func newCaldavTestRequestWithUser(t *testing.T, e *echo.Echo, method string, handler echo.HandlerFunc, user *user.User, payload string, queryParams url.Values, urlParams map[string]string) (rec *httptest.ResponseRecorder, err error) {
+func newCaldavTestRequestWithUser(t *testing.T, method string, handler echo.HandlerFunc, user *user.User, payload string, queryParams url.Values, urlParams map[string]string) (rec *httptest.ResponseRecorder, err error) {
 	var c echo.Context
-	c, rec = createRequest(e, method, payload, queryParams, urlParams)
+	c, rec = createRequest(testRouter, method, payload, queryParams, urlParams)
 	c.Request().Header.Set(echo.HeaderContentType, echo.MIMETextPlain)
 
 	result, _ := caldav.BasicAuth(user.Username, "12345678", c)

--- a/pkg/integrations/main_test.go
+++ b/pkg/integrations/main_test.go
@@ -1,0 +1,36 @@
+// Vikunja is a to-do list application to facilitate your life.
+// Copyright 2018-present Vikunja and contributors. All rights reserved.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public Licensee as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public Licensee for more details.
+//
+// You should have received a copy of the GNU Affero General Public Licensee
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package integrations
+
+import (
+	"os"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+)
+
+var testRouter *echo.Echo
+
+// TestMain is the main test function used to bootstrap the test env
+func TestMain(m *testing.M) {
+	var err error
+	testRouter, err = setupTestEnv()
+	if err != nil {
+		panic(err)
+	}
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
## Summary
- reuse integration test environment via TestMain
- load fixtures before each request without rebuilding router
- adapt CalDAV and API token tests to new setup