### PR TITLE
fix: close modals by pressing escape

### DIFF
--- a/frontend/src/components/misc/Modal.vue
+++ b/frontend/src/components/misc/Modal.vue
@@ -68,7 +68,7 @@
 <script lang="ts" setup>
 import CustomTransition from '@/components/misc/CustomTransition.vue'
 import BaseButton from '@/components/base/BaseButton.vue'
-import {ref, useAttrs, watchEffect} from 'vue'
+import {ref, useAttrs, watchEffect, onBeforeUnmount, watch} from 'vue'
 import {useScrollLock} from '@vueuse/core'
 
 const props = withDefaults(defineProps<{
@@ -85,7 +85,7 @@ const props = withDefaults(defineProps<{
 	variant: 'default',
 })
 
-defineEmits(['close', 'submit'])
+const emit = defineEmits(['close', 'submit'])
 
 defineOptions({
 	inheritAttrs: false,
@@ -97,7 +97,29 @@ const modal = ref<HTMLElement | null>(null)
 const scrollLock = useScrollLock(modal)
 
 watchEffect(() => {
-	scrollLock.value = props.enabled
+        scrollLock.value = props.enabled
+})
+
+function onKeydown(e: KeyboardEvent) {
+        if (e.key === 'Escape') {
+                emit('close')
+        }
+}
+
+watch(
+        () => props.enabled,
+        (value) => {
+                if (value) {
+                        window.addEventListener('keydown', onKeydown)
+                } else {
+                        window.removeEventListener('keydown', onKeydown)
+                }
+        },
+        {immediate: true},
+)
+
+onBeforeUnmount(() => {
+        window.removeEventListener('keydown', onKeydown)
 })
 </script>
 

--- a/frontend/src/components/misc/Modal.vue
+++ b/frontend/src/components/misc/Modal.vue
@@ -119,7 +119,7 @@ watch(
 )
 
 onBeforeUnmount(() => {
-        window.removeEventListener('keydown', onKeydown)
+	window.removeEventListener('keydown', onKeydown)
 })
 </script>
 

--- a/frontend/src/components/misc/Modal.vue
+++ b/frontend/src/components/misc/Modal.vue
@@ -101,21 +101,21 @@ watchEffect(() => {
 })
 
 function onKeydown(e: KeyboardEvent) {
-        if (e.key === 'Escape') {
-                emit('close')
-        }
+	if (e.key === 'Escape') {
+ 		emit('close')
+	}
 }
 
 watch(
-        () => props.enabled,
-        (value) => {
-                if (value) {
-                        window.addEventListener('keydown', onKeydown)
-                } else {
-                        window.removeEventListener('keydown', onKeydown)
-                }
-        },
-        {immediate: true},
+	() => props.enabled,
+	(value: boolean) => {
+ 		if (value) {
+			window.addEventListener('keydown', onKeydown)
+		} else {
+			window.removeEventListener('keydown', onKeydown)
+		}
+	},
+	{immediate: true},
 )
 
 onBeforeUnmount(() => {


### PR DESCRIPTION
Resolves https://github.com/go-vikunja/vikunja/issues/276

## Summary
- allow closing modal dialogs when pressing Escape
- keep event listener active even when an input has focus
- avoid attaching duplicate Escape handlers

## Testing
- `mage lint:fix`
- `pnpm lint:fix` *(fails: pnpm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6849dc07337c83229bc9b8f48b55c8ce