### PR TITLE
feat!(config): store sqlite file relative to rootpath

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -366,7 +366,7 @@ func InitDefaultConfig() {
 	DatabaseUser.setDefault("vikunja")
 	DatabasePassword.setDefault("")
 	DatabaseDatabase.setDefault("vikunja")
-	DatabasePath.setDefault("./vikunja.db")
+	DatabasePath.setDefault(filepath.Join(ServiceRootpath.GetString(), "vikunja.db"))
 	DatabaseMaxOpenConnections.setDefault(100)
 	DatabaseMaxIdleConnections.setDefault(50)
 	DatabaseMaxConnectionLifetime.setDefault(10000)

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -178,8 +179,9 @@ func initPostgresEngine() (engine *xorm.Engine, err error) {
 
 func initSqliteEngine() (engine *xorm.Engine, err error) {
 	path := config.DatabasePath.GetString()
-	if path == "" {
-		path = "./db.db"
+
+	if path != "memory" && !filepath.IsAbs(path) {
+		path = filepath.Join(config.ServiceRootpath.GetString(), path)
 	}
 
 	if path == "memory" {


### PR DESCRIPTION
Resolves https://github.com/go-vikunja/vikunja/issues/896

## Summary
- make sqlite database path relative to `service.rootpath`
- update default database path
- remove redundant fallback

## Testing
- `mage lint:fix`


------
https://chatgpt.com/codex/tasks/task_e_684bc25cd0e0832287406c8b81ef107a