### PR TITLE
fix: improve markdown paste detection

### DIFF
--- a/frontend/src/components/input/editor/TipTap.vue
+++ b/frontend/src/components/input/editor/TipTap.vue
@@ -358,22 +358,21 @@ const PasteHandler = Extension.create({
 							}
 						}
 						
-                                               const text = event.clipboardData?.getData('text/plain') || ''
+						const text = event.clipboardData?.getData('text/plain') || ''
+						if (!text) {
+							return false
+						}
 
-                                               if (!text) {
-                                                       return false
-                                               }
+						const hasMarkdownSyntax = new RegExp('[*`_\\[\\]#-]').test(text)
+						if (!hasMarkdownSyntax) {
+							return false
+						}
 
-                                               if (!(/[\\*`_\\[\\]#-]/.test(text))) {
-                                                       return false
-                                               }
+						const html = marked.parse(text)
 
-                                               const html = marked.parse(text)
-
-                                               this.editor.commands.insertContent(html)
-                                               // https://github.com/ueberdosis/tiptap/discussions/4118#discussioncomment-8931999
-                                               return true
-                                       },
+						this.editor.commands.insertContent(html)
+						return true
+					},
 				},
 			}),
 		]


### PR DESCRIPTION
Resolves https://community.vikunja.io/t/copy-doesnt-keep-formatting-anymore/3807

## Summary
- only convert pasted text to HTML if it contains markdown tokens

## Testing
- `pnpm lint:fix`


------
https://chatgpt.com/codex/tasks/task_e_684bd141536c8322b65ab0d9f62e0110