### PR TITLE
fix: set default timezone when placeholder used

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -596,7 +596,7 @@ func InitConfig() {
 		MigrationMicrosoftTodoRedirectURL.Set(ServicePublicURL.GetString() + "migrate/microsoft-todo")
 	}
 
-	if DefaultSettingsTimezone.GetString() == "" {
+	if tz := DefaultSettingsTimezone.GetString(); tz == "" || tz == "<time zone set at service.timezone>" {
 		DefaultSettingsTimezone.Set(ServiceTimeZone.GetString())
 	}
 


### PR DESCRIPTION
I guess this is just convenience. But foremost the DX should be fixed for this.