### PR TITLE
Add search benchmark

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -118,6 +118,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/huandu/go-clone v1.7.3 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/jaswdr/faker/v2 v2.5.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/laurent22/ical-go v0.1.1-0.20181107184520-7e5d6ade8eef // indirect

--- a/go.sum
+++ b/go.sum
@@ -246,6 +246,8 @@ github.com/jackc/puddle v0.0.0-20190413234325-e4ced69a3a2b/go.mod h1:m4B5Dj62Y0f
 github.com/jackc/puddle v0.0.0-20190608224051-11cab39313c9/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.1.3/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.3.0/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
+github.com/jaswdr/faker/v2 v2.5.0 h1:KUYfnleIZMSHNp/q+rDk7XEuqUUL5FhfT19iTTFqF5o=
+github.com/jaswdr/faker/v2 v2.5.0/go.mod h1:ROK8xwQV0hYOLDUtxCQgHGcl10jbVzIvqHxcIDdwY2Q=
 github.com/jcmturner/aescts/v2 v2.0.0 h1:9YKLH6ey7H4eDBXW8khjYslgyqG2xZikXP0EQFKrle8=
 github.com/jcmturner/aescts/v2 v2.0.0/go.mod h1:AiaICIRyfYg35RUkr8yESTqvSy7csK90qZ5xfvvsoNs=
 github.com/jcmturner/dnsutils/v2 v2.0.0 h1:lltnkeZGL0wILNvrNiVCR6Ro5PGU/SeBvVO/8c/iPbo=

--- a/pkg/models/task_search_bench_test.go
+++ b/pkg/models/task_search_bench_test.go
@@ -1,0 +1,145 @@
+// Vikunja is a to-do list application to facilitate your life.
+// Copyright 2018-present Vikunja and contributors. All rights reserved.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package models
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"strings"
+	"testing"
+
+	"code.vikunja.io/api/pkg/config"
+	"code.vikunja.io/api/pkg/db"
+	"code.vikunja.io/api/pkg/notifications"
+	"code.vikunja.io/api/pkg/user"
+
+	"github.com/jaswdr/faker/v2"
+)
+
+func initBenchmarkConfig() {
+	if os.Getenv("VIKUNJA_TESTS_USE_CONFIG") == "1" {
+		config.InitConfig()
+	} else {
+		config.InitDefaultConfig()
+		config.ServiceRootpath.Set(os.Getenv("VIKUNJA_SERVICE_ROOTPATH"))
+	}
+}
+
+// setupBenchmarkDB initializes an in-memory database without fixtures.
+func setupBenchmarkDB(b *testing.B) {
+	var err error
+	x, err = db.CreateTestEngine()
+	if err != nil {
+		b.Fatalf("failed to create test engine: %v", err)
+	}
+
+	tables := append(GetTables(), notifications.GetTables()...)
+	if err := x.Sync2(tables...); err != nil {
+		b.Fatalf("failed to sync tables: %v", err)
+	}
+}
+
+// createBenchmarkData creates projects and tasks used for search benchmarks.
+func createBenchmarkData(b *testing.B, needle string) *user.User {
+	s := db.NewSession()
+	defer s.Close()
+
+	f := faker.New()
+
+	u := &user.User{Username: "benchuser", Email: "bench@example.com", Password: "pass"}
+	if _, err := s.Insert(u); err != nil {
+		b.Fatalf("insert user: %v", err)
+	}
+
+	for i := 0; i < 10; i++ {
+		p := &Project{Title: fmt.Sprintf("Project %d", i), OwnerID: u.ID}
+		if _, err := s.Insert(p); err != nil {
+			b.Fatalf("insert project: %v", err)
+		}
+
+		for j := 0; j < 5000; j++ {
+			title := f.Lorem().Sentence(6)
+			if rand.Intn(100) == 0 { //nolint:gosec
+				title += " " + needle
+			}
+			desc := ""
+			if j%2 == 0 {
+				desc = f.Lorem().Paragraph(1)
+			}
+			if j%100 == 0 {
+				if desc == "" {
+					desc = f.Lorem().Paragraph(1)
+				}
+				words := strings.Split(desc, " ")
+				mid := len(words) / 2
+				words = append(words[:mid], append([]string{needle}, words[mid:]...)...)
+				desc = strings.Join(words, " ")
+			}
+			t := &Task{
+				Title:       title,
+				Description: desc,
+				ProjectID:   p.ID,
+				CreatedByID: u.ID,
+				Index:       int64(j + 1),
+			}
+			if _, err := s.Insert(t); err != nil {
+				b.Fatalf("insert task: %v", err)
+			}
+		}
+	}
+
+	return u
+}
+
+func benchmarkTaskSearch(b *testing.B) {
+	const needle = "benchmarkneedle"
+
+	initBenchmarkConfig()
+	setupBenchmarkDB(b)
+
+	auth := createBenchmarkData(b, needle)
+
+	if config.TypesenseEnabled.GetBool() {
+		InitTypesense()
+		if err := CreateTypesenseCollections(); err != nil {
+			b.Skipf("typesense server not available: %v", err)
+		}
+		if err := ReindexAllTasks(); err != nil {
+			b.Skipf("typesense server not available: %v", err)
+		}
+	}
+
+	tc := &TaskCollection{
+		Filter:         "done = false",
+		FilterTimezone: "UTC",
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		s := db.NewSession()
+		_, _, _, err := tc.ReadAll(s, auth, needle, 1, 50)
+		s.Close()
+		if err != nil {
+			b.Fatalf("search error: %v", err)
+		}
+	}
+}
+
+func BenchmarkTaskSearch(b *testing.B) {
+	benchmarkTaskSearch(b)
+}


### PR DESCRIPTION
## Summary
- add benchmark for task search
- setup benchmark data for multiple projects with faker
- compare db and Typesense search using TaskCollection
- add faker v2 dependency
- ensure benchmark setup uses default config and checks Typesense settings

## Testing
- `mage lint:fix`


------
https://chatgpt.com/codex/tasks/task_e_68501322aba083228311d707bb9c4305