### PR TITLE
feat: add email filter to user list command

### DIFF
--- a/pkg/cmd/user.go
+++ b/pkg/cmd/user.go
@@ -143,11 +143,11 @@ var userListCmd = &cobra.Command{
 
 		if userFlagEmail != "" {
 			u, err := user.GetUserWithEmail(s, &user.User{Email: userFlagEmail})
-			if err != nil {
-				if !user.IsErrUserDoesNotExist(err) {
-					log.Fatalf("Error getting user: %s", err)
-				}
-			} else {
+			if err != nil && !user.IsErrUserDoesNotExist(err) {
+				log.Fatalf("Error getting user: %s", err)
+			}
+
+			if u != nil {
 				users = []*user.User{u}
 			}
 		} else {


### PR DESCRIPTION
## Summary
- allow filtering the `user list` CLI command by email
- simplify error handling for read-only command

## Testing
- `mage lint:fix`
- `mage test:feature`


------
https://chatgpt.com/codex/tasks/task_e_68508ac3a6f48322b93f2881ab6bd413