### PR TITLE
Show frontend version separately if different

### DIFF
--- a/frontend/src/i18n/lang/en.json
+++ b/frontend/src/i18n/lang/en.json
@@ -1236,7 +1236,9 @@
   },
   "about": {
     "title": "About",
-    "version": "Version: {version}"
+    "version": "Version: {version}",
+    "frontendVersion": "Frontend version: {version}",
+    "apiVersion": "API version: {version}"
   },
   "time": {
     "units": {

--- a/frontend/src/views/About.vue
+++ b/frontend/src/views/About.vue
@@ -12,9 +12,13 @@
 			@close="$router.back()"
 		>
 			<div class="p-4">
-				<p>
+				<p v-if="versionsEqual">
 					{{ $t('about.version', {version: apiVersion}) }}
 				</p>
+				<template v-else>
+					<p>{{ $t('about.frontendVersion', {version: frontendVersion}) }}</p>
+					<p>{{ $t('about.apiVersion', {version: apiVersion}) }}</p>
+				</template>
 			</div>
 			<template #footer>
 				<XButton
@@ -31,8 +35,11 @@
 <script setup lang="ts">
 import {computed} from 'vue'
 
+import {VERSION as frontendVersion} from '@/version.json'
+
 import {useConfigStore} from '@/stores/config'
 
 const configStore = useConfigStore()
 const apiVersion = computed(() => configStore.version)
+const versionsEqual = computed(() => apiVersion.value === frontendVersion)
 </script>


### PR DESCRIPTION
## Summary
- display Vikunja version in About dialog
- also show frontend and API version separately when they differ
- add new translation keys for these strings

## Testing
- `pnpm lint:fix`


------
https://chatgpt.com/codex/tasks/task_e_68515814bb6c8322ac4810db6d960460