### PR TITLE
chore(dev): use unstable devenv image for devcontainer

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -19,7 +19,7 @@
     4173,
     3456
   ],
-  "image": "ghcr.io/cachix/devenv/devcontainer:latest",
+  "image": "ghcr.io/cachix/devenv/devcontainer:main",
   "overrideCommand": false,
   "portsAttributes": {
     "3456": {
@@ -29,5 +29,5 @@
       "label": "Vikunja Frontend dev server"
     }
   },
-  "updateContentCommand": "sudo setfacl -k /tmp && devenv test"
+  "updateContentCommand": "devenv test"
 }

--- a/devenv.nix
+++ b/devenv.nix
@@ -46,8 +46,8 @@ in {
 	devcontainer = {
 		enable = true;
 		settings = {
-			updateContentCommand = "sudo setfacl -k /tmp && devenv test";
 			forwardPorts = [ 4173 3456 ];
+			image = "ghcr.io/cachix/devenv/devcontainer:main";
 			portsAttributes = {
 				"4173" = {
 					label = "Vikunja Frontend dev server";


### PR DESCRIPTION
Using latest until the fix lands in stable, see https://github.com/cachix/devenv/issues/1896#issuecomment-2994354350