### PR TITLE
Fix frontend version in release builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -268,6 +268,13 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/setup-frontend
+      - name: Git describe
+        id: ghd
+        uses: proudust/gh-describe@v2
+      - name: Inject frontend version
+        working-directory: frontend
+        run: |
+          echo "{\"VERSION\": \"${{ steps.ghd.outputs.describe }}\"}" > src/version.json
       - name: Build frontend
         working-directory: frontend
         run: pnpm build


### PR DESCRIPTION
## Summary
- inject `RELEASE_VERSION` into `version.json` during frontend build job

## Testing
- `mage lint:fix`
- `pnpm lint:fix`

------
https://chatgpt.com/codex/tasks/task_e_685a53e368a48322b4a11db10e534ff3