### PR TITLE
Fix ambiguous index order

### DIFF
--- a/pkg/models/task_search.go
+++ b/pkg/models/task_search.go
@@ -128,7 +128,7 @@ func getOrderByDBStatement(opts *taskSearchOptions) (orderby string, err error) 
 			prefix = "task_positions."
 		}
 
-		if param.sortBy == taskPropertyID || param.sortBy == taskPropertyCreated || param.sortBy == taskPropertyUpdated {
+		if param.sortBy == taskPropertyID || param.sortBy == taskPropertyCreated || param.sortBy == taskPropertyUpdated || param.sortBy == taskPropertyIndex {
 			prefix = "tasks."
 		}
 


### PR DESCRIPTION
## Summary
- fix ambiguous `index` column in ORDER BY when listing tasks

## Testing
- `mage lint:fix`
- `pnpm lint:fix`

------
https://chatgpt.com/codex/tasks/task_e_685a720e2c348322bc3c2cedc4abd9a4