### PR TITLE
Fix ambiguous done column in task sorting

### DIFF
--- a/pkg/models/task_search.go
+++ b/pkg/models/task_search.go
@@ -124,11 +124,12 @@ func getOrderByDBStatement(opts *taskSearchOptions) (orderby string, err error) 
 		}
 
 		var prefix string
-		if param.sortBy == taskPropertyPosition {
+		switch param.sortBy {
+		case taskPropertyPosition:
 			prefix = "task_positions."
-		}
-
-		if param.sortBy == taskPropertyID || param.sortBy == taskPropertyCreated || param.sortBy == taskPropertyUpdated || param.sortBy == taskPropertyIndex {
+		case taskPropertyBucketID:
+			prefix = "task_buckets."
+		default:
 			prefix = "tasks."
 		}
 


### PR DESCRIPTION
Resolves https://github.com/go-vikunja/vikunja/issues/1009

## Summary
- prefix all task fields with the tasks table when constructing SQL ORDER BY clauses
- ensure bucket sorting uses the proper table alias

## Testing
- `mage lint:fix`
- `mage test:feature`


------
https://chatgpt.com/codex/tasks/task_e_685aff1610cc83228e66a9646309697d