### PR TITLE
Fix ambiguous column in task search

### DIFF
--- a/pkg/models/api_tokens.go
+++ b/pkg/models/api_tokens.go
@@ -137,7 +137,7 @@ func (t *APIToken) ReadAll(s *xorm.Session, a web.Auth, search string, page int,
 	if search != "" {
 		where = builder.And(
 			where,
-			db.ILIKE("title", search),
+			db.ILIKE("api_tokens.title", search),
 		)
 	}
 

--- a/pkg/models/task_search.go
+++ b/pkg/models/task_search.go
@@ -281,7 +281,7 @@ func (d *dbTaskSearcher) Search(opts *taskSearchOptions) (tasks []*Task, totalCo
 	if opts.search != "" {
 		where =
 			builder.Or(
-				db.ILIKE("title", opts.search),
+				db.ILIKE("tasks.title", opts.search),
 				db.ILIKE("description", opts.search),
 			)
 


### PR DESCRIPTION
## Summary
- avoid ambiguous `title` column errors when searching tasks

## Testing
- `mage lint:fix`
- `pnpm lint:fix` in frontend
- `mage test:feature`


------
https://chatgpt.com/codex/tasks/task_e_685aff9dea2c8322919f78e89847e283