### PR TITLE
fix(quick actions): quote label when it contains spaces

### DIFF
--- a/frontend/src/components/quick-actions/QuickActions.vue
+++ b/frontend/src/components/quick-actions/QuickActions.vue
@@ -484,7 +484,11 @@ async function doAction(type: ACTION_TYPE, item: DoAction) {
 			searchInput.value?.focus()
 			break
 		case ACTION_TYPE.LABELS:
-			query.value = '*' + item.title
+			if (/\s/.test(item.title)) {
+				query.value = '*"' + item.title + '"'
+			} else {
+				query.value = '*' + item.title
+			}
 			searchInput.value?.focus()
 			searchTasks()
 			break


### PR DESCRIPTION
Resolves https://github.com/go-vikunja/vikunja/issues/943

## Summary
- handle spaces when selecting labels in quick actions

## Testing
- `mage lint:fix`
- `pnpm lint:fix`
- `CI=true pnpm test:unit`

------
https://chatgpt.com/codex/tasks/task_e_685b0d3ccc508322806a5f12323c5acf