### PR TITLE
fix: show 404 on task detail page when the task does not exist

### DIFF
--- a/frontend/cypress/e2e/task/task.spec.ts
+++ b/frontend/cypress/e2e/task/task.spec.ts
@@ -189,7 +189,13 @@ describe('Task', () => {
 			LabelTaskFactory.truncate()
 			TaskAttachmentFactory.truncate()
 		})
+		it('Shows a 404 page for nonexisting tasks', () => {
 
+			cy.visit('/tasks/9999')
+
+			cy.contains('Not found')
+				.should('be.visible')
+		})
 		it('Shows all task details', () => {
 			const tasks = TaskFactory.create(1, {
 				id: 1,

--- a/frontend/src/views/tasks/TaskDetailView.vue
+++ b/frontend/src/views/tasks/TaskDetailView.vue
@@ -743,6 +743,13 @@ watch(
 			attachmentStore.set(task.value.attachments)
 			taskColor.value = task.value.hexColor
 			setActiveFields()
+		} catch (e) {
+			if (e?.response?.status === 404) {
+				router.replace({name: 'not-found'})
+				return
+			}
+
+			throw e
 		} finally {
 			await nextTick()
 			scrollToHeading()


### PR DESCRIPTION
## Summary
- redirect to the 404 page when loading a task that does not exist
- test that nonexistent tasks show the 404 page

## Testing
- `pnpm lint:fix`


------
https://chatgpt.com/codex/tasks/task_e_685b0e2d1c6883228a0df7c0a22e2f35