### PR TITLE
fix: set correct date ranges

### DIFF
--- a/frontend/src/components/date/DatepickerWithRange.test.ts
+++ b/frontend/src/components/date/DatepickerWithRange.test.ts
@@ -1,0 +1,39 @@
+import {describe, it, expect, beforeEach} from 'vitest'
+import {mount} from '@vue/test-utils'
+import {setActivePinia, createPinia} from 'pinia'
+import {createI18n} from 'vue-i18n'
+import DatepickerWithRange from './DatepickerWithRange.vue'
+import en from '@/i18n/lang/en.json'
+
+const i18n = createI18n({legacy: false, locale: 'en', messages: {en}})
+
+function mountPicker() {
+    return mount(DatepickerWithRange, {
+        props: {modelValue: {dateFrom: '', dateTo: ''}},
+        global: {
+            plugins: [i18n],
+            stubs: ['RouterLink', 'Modal', 'XButton', 'BaseButton', 'Popup', 'flat-pickr'],
+        },
+    })
+}
+
+describe('DatepickerWithRange predefined ranges', () => {
+    beforeEach(() => {
+        setActivePinia(createPinia())
+    })
+    it('selects Last Week range', async () => {
+        const wrapper = mountPicker()
+        ;(wrapper.vm as any).setDateRange(['now/w-1w', 'now/w'])
+        await wrapper.vm.$nextTick()
+        const last = wrapper.emitted('update:modelValue')?.pop()?.[0]
+        expect(last).toEqual({dateFrom: 'now/w-1w', dateTo: 'now/w'})
+    })
+
+    it('selects Last Month range', async () => {
+        const wrapper = mountPicker()
+        ;(wrapper.vm as any).setDateRange(['now/M-1M', 'now/M'])
+        await wrapper.vm.$nextTick()
+        const last = wrapper.emitted('update:modelValue')?.pop()?.[0]
+        expect(last).toEqual({dateFrom: 'now/M-1M', dateTo: 'now/M'})
+    })
+})

--- a/frontend/src/components/date/dateRanges.ts
+++ b/frontend/src/components/date/dateRanges.ts
@@ -4,13 +4,13 @@ export const DATE_RANGES = {
 	// is the "from" date, the second one is the "to" date.
 	'today': ['now/d', 'now/d+1d'],
 
-	'lastWeek': ['now/w-1w', 'now/w-2w'],
+	'lastWeek': ['now/w-1w', 'now/w'],
 	'thisWeek': ['now/w', 'now/w+1w'],
 	'restOfThisWeek': ['now', 'now/w+1w'],
 	'nextWeek': ['now/w+1w', 'now/w+2w'],
 	'next7Days': ['now', 'now+7d'],
 
-	'lastMonth': ['now/M-1M', 'now/M-2M'],
+	'lastMonth': ['now/M-1M', 'now/M'],
 	'thisMonth': ['now/M', 'now/M+1M'],
 	'restOfThisMonth': ['now', 'now/M+1M'],
 	'nextMonth': ['now/M+1M', 'now/M+2M'],
@@ -26,7 +26,7 @@ export const DATE_VALUES = {
 	'endOfToday': 'now/d+1d',
 
 	'beginningOflastWeek': 'now/w-1w',
-	'endOfLastWeek': 'now/w-2w',
+	'endOfLastWeek': 'now/w',
 	'beginningOfThisWeek': 'now/w',
 	'endOfThisWeek': 'now/w+1w',
 	'startOfNextWeek': 'now/w+1w',
@@ -34,7 +34,7 @@ export const DATE_VALUES = {
 	'in7Days': 'now+7d',
 
 	'beginningOfLastMonth': 'now/M-1M',
-	'endOfLastMonth': 'now/M-2M',
+	'endOfLastMonth': 'now/M',
 	'startOfThisMonth': 'now/M',
 	'endOfThisMonth': 'now/M+1M',
 	'startOfNextMonth': 'now/M+1M',


### PR DESCRIPTION
Resolves https://github.com/go-vikunja/vikunja/issues/566



## Summary
- update date range definitions for last week and month
- add unit tests for DatepickerWithRange to ensure ranges resolve

## Testing
- `pnpm lint:fix`
- `pnpm test:unit`


------
https://chatgpt.com/codex/tasks/task_e_685b158fbbd483228ba1543b7ab31fc4