### PR TITLE
Fix ambiguous description search

### DIFF
--- a/pkg/models/task_collection_subtasks_move_test.go
+++ b/pkg/models/task_collection_subtasks_move_test.go
@@ -78,3 +78,21 @@ func TestTaskCollection_SubtaskRemainsAfterMove(t *testing.T) {
 	}
 	assert.True(t, found, "subtask should be returned after moving to another project")
 }
+
+func TestTaskSearchWithExpandSubtasks(t *testing.T) {
+	db.LoadAndAssertFixtures(t)
+	s := db.NewSession()
+	defer s.Close()
+
+	project, err := GetProjectSimpleByID(s, 36)
+	require.NoError(t, err)
+
+	opts := &taskSearchOptions{
+		search: "Caldav",
+		expand: []TaskCollectionExpandable{TaskCollectionExpandSubtasks},
+	}
+
+	tasks, _, _, err := getRawTasksForProjects(s, []*Project{project}, &user.User{ID: 15}, opts)
+	require.NoError(t, err)
+	require.NotEmpty(t, tasks)
+}

--- a/pkg/models/task_search.go
+++ b/pkg/models/task_search.go
@@ -283,7 +283,7 @@ func (d *dbTaskSearcher) Search(opts *taskSearchOptions) (tasks []*Task, totalCo
 		where =
 			builder.Or(
 				db.ILIKE("tasks.title", opts.search),
-				db.ILIKE("description", opts.search),
+				db.ILIKE("tasks.description", opts.search),
 			)
 
 		searchIndex := getTaskIndexFromSearchString(opts.search)


### PR DESCRIPTION
Resolves https://github.com/go-vikunja/vikunja/issues/1025

## Summary
- fully qualify `description` column in task search
- add regression test for task search with expand subtasks
- move new test into existing subtask collection test file

## Testing
- `mage lint:fix`
- `mage test:feature`


------
https://chatgpt.com/codex/tasks/task_e_685c1ccd6d708322ad9c39edd07b4831