### PR TITLE
fix: guard invalid user lookups

### DIFF
--- a/pkg/models/kanban.go
+++ b/pkg/models/kanban.go
@@ -147,7 +147,9 @@ func (b *Bucket) ReadAll(s *xorm.Session, auth web.Auth, _ string, _ int, _ int)
 	}
 
 	for _, bb := range buckets {
-		bb.CreatedBy = users[bb.CreatedByID]
+		if createdBy, has := users[bb.CreatedByID]; has {
+			bb.CreatedBy = createdBy
+		}
 	}
 
 	return buckets, len(buckets), int64(len(buckets)), nil
@@ -196,7 +198,9 @@ func GetTasksInBucketsForView(s *xorm.Session, view *ProjectView, projects []*Pr
 	}
 
 	for _, bb := range buckets {
-		bb.CreatedBy = users[bb.CreatedByID]
+		if createdBy, has := users[bb.CreatedByID]; has {
+			bb.CreatedBy = createdBy
+		}
 	}
 
 	tasks := []*Task{}

--- a/pkg/models/label_task.go
+++ b/pkg/models/label_task.go
@@ -291,7 +291,9 @@ func GetLabelsByTaskIDs(s *xorm.Session, opts *LabelByTaskIDsOptions) (ls []*Lab
 
 	// Put it all together
 	for in, l := range labels {
-		labels[in].CreatedBy = users[l.CreatedByID]
+		if createdBy, has := users[l.CreatedByID]; has {
+			labels[in].CreatedBy = createdBy
+		}
 	}
 
 	// Get the total number of entries

--- a/pkg/models/link_sharing.go
+++ b/pkg/models/link_sharing.go
@@ -252,7 +252,9 @@ func (share *LinkSharing) ReadAll(s *xorm.Session, a web.Auth, search string, pa
 	}
 
 	for _, s := range shares {
-		s.SharedBy = users[s.SharedByID]
+		if sharedBy, has := users[s.SharedByID]; has {
+			s.SharedBy = sharedBy
+		}
 		s.Password = ""
 	}
 

--- a/pkg/models/listeners.go
+++ b/pkg/models/listeners.go
@@ -873,12 +873,14 @@ func reloadEventData(s *xorm.Session, event map[string]interface{}, projectID in
 		d := doer.(map[string]interface{})
 		if rawDoerID, has := d["id"]; has {
 			doerID = getIDAsInt64(rawDoerID)
-			fullDoer, err := user.GetUserByID(s, doerID)
-			if err != nil && !user.IsErrUserDoesNotExist(err) {
-				return nil, 0, err
-			}
-			if err == nil {
-				event["doer"] = fullDoer
+			if doerID > 0 {
+				fullDoer, err := user.GetUserByID(s, doerID)
+				if err != nil && !user.IsErrUserDoesNotExist(err) {
+					return nil, 0, err
+				}
+				if err == nil {
+					event["doer"] = fullDoer
+				}
 			}
 		}
 	}

--- a/pkg/models/project.go
+++ b/pkg/models/project.go
@@ -306,13 +306,9 @@ func (p *Project) ReadOne(s *xorm.Session, a web.Auth) (err error) {
 	}
 
 	// Get project owner
-	if p.OwnerID > 0 {
-		p.Owner, err = user.GetUserByID(s, p.OwnerID)
-		if user.IsErrUserDoesNotExist(err) {
-			p.Owner = nil
-		} else if err != nil {
-			return err
-		}
+	p.Owner, err = user.GetUserByID(s, p.OwnerID)
+	if err != nil && !user.IsErrUserDoesNotExist(err) {
+		return err
 	}
 
 	// Check if the project is archived and set it to archived if it is not already archived individually.

--- a/pkg/models/project.go
+++ b/pkg/models/project.go
@@ -307,7 +307,9 @@ func (p *Project) ReadOne(s *xorm.Session, a web.Auth) (err error) {
 
 	// Get project owner
 	p.Owner, err = user.GetUserByID(s, p.OwnerID)
-	if err != nil && !user.IsErrUserDoesNotExist(err) {
+	if user.IsErrUserDoesNotExist(err) {
+		p.Owner = nil
+	} else if err != nil {
 		return err
 	}
 

--- a/pkg/models/project.go
+++ b/pkg/models/project.go
@@ -306,9 +306,13 @@ func (p *Project) ReadOne(s *xorm.Session, a web.Auth) (err error) {
 	}
 
 	// Get project owner
-	p.Owner, err = user.GetUserByID(s, p.OwnerID)
-	if err != nil {
-		return err
+	if p.OwnerID > 0 {
+		p.Owner, err = user.GetUserByID(s, p.OwnerID)
+		if user.IsErrUserDoesNotExist(err) {
+			p.Owner = nil
+		} else if err != nil {
+			return err
+		}
 	}
 
 	// Check if the project is archived and set it to archived if it is not already archived individually.

--- a/pkg/models/task_attachment.go
+++ b/pkg/models/task_attachment.go
@@ -186,7 +186,9 @@ func (ta *TaskAttachment) ReadAll(s *xorm.Session, a web.Auth, _ string, page in
 	}
 
 	for _, r := range attachments {
-		r.CreatedBy = users[r.CreatedByID]
+		if createdBy, has := users[r.CreatedByID]; has {
+			r.CreatedBy = createdBy
+		}
 
 		// If the actual file does not exist, don't try to load it as that would fail with nil panic
 		if _, exists := fs[r.FileID]; !exists {
@@ -395,7 +397,9 @@ func getTaskAttachmentsByTaskIDs(s *xorm.Session, taskIDs []int64) (attachments 
 	}
 
 	for _, a := range attachments {
-		a.CreatedBy = users[a.CreatedByID]
+		if createdBy, has := users[a.CreatedByID]; has {
+			a.CreatedBy = createdBy
+		}
 		a.File = fs[a.FileID]
 	}
 

--- a/pkg/models/tasks.go
+++ b/pkg/models/tasks.go
@@ -616,7 +616,7 @@ func addMoreInfoToTasks(s *xorm.Session, taskMap map[int64]*Task, a web.Auth, vi
 	var projectIDs []int64
 	for _, i := range taskMap {
 		taskIDs = append(taskIDs, i.ID)
-		if i.CreatedByID > 0 {
+		if i.CreatedByID != 0 {
 			userIDs = append(userIDs, i.CreatedByID)
 		}
 		projectIDs = append(projectIDs, i.ProjectID)
@@ -704,7 +704,9 @@ func addMoreInfoToTasks(s *xorm.Session, taskMap map[int64]*Task, a web.Auth, vi
 	for _, task := range taskMap {
 
 		// Make created by user objects
-		task.CreatedBy = users[task.CreatedByID]
+		if createdBy, has := users[task.CreatedByID]; has {
+			task.CreatedBy = createdBy
+		}
 
 		// Add the reminders
 		task.Reminders = taskReminders[task.ID]

--- a/pkg/models/tasks.go
+++ b/pkg/models/tasks.go
@@ -616,7 +616,9 @@ func addMoreInfoToTasks(s *xorm.Session, taskMap map[int64]*Task, a web.Auth, vi
 	var projectIDs []int64
 	for _, i := range taskMap {
 		taskIDs = append(taskIDs, i.ID)
-		userIDs = append(userIDs, i.CreatedByID)
+		if i.CreatedByID > 0 {
+			userIDs = append(userIDs, i.CreatedByID)
+		}
 		projectIDs = append(projectIDs, i.ProjectID)
 	}
 

--- a/pkg/models/webhooks.go
+++ b/pkg/models/webhooks.go
@@ -187,7 +187,9 @@ func (w *Webhook) ReadAll(s *xorm.Session, a web.Auth, _ string, page int, perPa
 
 	for _, webhook := range ws {
 		webhook.Secret = ""
-		webhook.CreatedBy = users[webhook.CreatedByID]
+		if createdBy, has := users[webhook.CreatedByID]; has {
+			webhook.CreatedBy = createdBy
+		}
 	}
 
 	return ws, len(ws), total, err


### PR DESCRIPTION
Might resolve https://community.vikunja.io/t/webhook-project-error/3305/26

## Summary
- avoid user lookup if doer id is invalid when reloading event data
- handle projects with invalid owners gracefully
- skip CreatedBy lookup for tasks when no creator is set

## Testing
- `mage lint:fix`

------
https://chatgpt.com/codex/tasks/task_e_685db7c7e45883228a48bf14522620c5