### PR TITLE
Add avatar cache flushing

### DIFF
--- a/pkg/modules/auth/ldap/ldap.go
+++ b/pkg/modules/auth/ldap/ldap.go
@@ -28,6 +28,7 @@ import (
 	"code.vikunja.io/api/pkg/log"
 	"code.vikunja.io/api/pkg/models"
 	"code.vikunja.io/api/pkg/modules/auth"
+	"code.vikunja.io/api/pkg/modules/avatar"
 	"code.vikunja.io/api/pkg/modules/avatar/upload"
 	"code.vikunja.io/api/pkg/user"
 	"code.vikunja.io/api/pkg/utils"
@@ -187,6 +188,7 @@ func AuthenticateUserInLDAP(s *xorm.Session, username, password string, syncGrou
 			if err != nil {
 				return nil, err
 			}
+			avatar.FlushAllCaches(u)
 		}
 	}
 

--- a/pkg/modules/auth/openid/openid.go
+++ b/pkg/modules/auth/openid/openid.go
@@ -30,6 +30,7 @@ import (
 	"code.vikunja.io/api/pkg/log"
 	"code.vikunja.io/api/pkg/models"
 	"code.vikunja.io/api/pkg/modules/auth"
+	"code.vikunja.io/api/pkg/modules/avatar"
 	"code.vikunja.io/api/pkg/modules/avatar/upload"
 	"code.vikunja.io/api/pkg/user"
 	"code.vikunja.io/api/pkg/utils"
@@ -249,6 +250,8 @@ func syncUserAvatarFromOpenID(s *xorm.Session, u *user.User, pictureURL string) 
 	if err != nil {
 		return fmt.Errorf("error storing avatar: %w", err)
 	}
+
+	avatar.FlushAllCaches(u)
 
 	return nil
 }

--- a/pkg/modules/avatar/empty/empty.go
+++ b/pkg/modules/avatar/empty/empty.go
@@ -22,6 +22,9 @@ import "code.vikunja.io/api/pkg/user"
 type Provider struct {
 }
 
+// FlushCache is a no-op for the empty provider
+func (p *Provider) FlushCache(_ *user.User) error { return nil }
+
 const defaultAvatar string = `<?xml version="1.0" encoding="UTF-8"?>
 <svg width="128" height="128" version="1.1" viewBox="0 0 33.867 33.867" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:xlink="http://www.w3.org/1999/xlink">
 <metadata>

--- a/pkg/modules/avatar/gravatar/gravatar.go
+++ b/pkg/modules/avatar/gravatar/gravatar.go
@@ -41,6 +41,11 @@ type avatar struct {
 type Provider struct {
 }
 
+// FlushCache removes all gravatar cache entries for a user
+func (g *Provider) FlushCache(u *user.User) error {
+	return keyvalue.DelPrefix(keyPrefix + u.Username + "_")
+}
+
 const keyPrefix = "gravatar_avatar_"
 
 // GetAvatar implements getting the avatar for the user

--- a/pkg/modules/avatar/initials/initials.go
+++ b/pkg/modules/avatar/initials/initials.go
@@ -39,6 +39,14 @@ import (
 type Provider struct {
 }
 
+// FlushCache removes cached initials avatars for a user
+func (p *Provider) FlushCache(u *user.User) error {
+	if err := keyvalue.Del(getCacheKey("full", u.ID)); err != nil {
+		return err
+	}
+	return keyvalue.DelPrefix(getCacheKey("resized", u.ID))
+}
+
 var (
 	avatarBgColors = []*color.RGBA{
 		{R: 69, G: 189, B: 243, A: 255},

--- a/pkg/modules/avatar/ldap/ldap.go
+++ b/pkg/modules/avatar/ldap/ldap.go
@@ -28,3 +28,8 @@ func (p *Provider) GetAvatar(user *user.User, size int64) (avatar []byte, mimeTy
 
 	return up.GetAvatar(user, size)
 }
+
+func (p *Provider) FlushCache(u *user.User) error {
+	up := upload.Provider{}
+	return up.FlushCache(u)
+}

--- a/pkg/modules/avatar/marble/marble.go
+++ b/pkg/modules/avatar/marble/marble.go
@@ -27,6 +27,9 @@ import (
 type Provider struct {
 }
 
+// FlushCache is a no-op for the marble provider
+func (p *Provider) FlushCache(_ *user.User) error { return nil }
+
 const avatarSize = 80
 
 var colors = []string{

--- a/pkg/modules/avatar/openid/openid.go
+++ b/pkg/modules/avatar/openid/openid.go
@@ -28,3 +28,8 @@ func (p *Provider) GetAvatar(user *user.User, size int64) (avatar []byte, mimeTy
 
 	return up.GetAvatar(user, size)
 }
+
+func (p *Provider) FlushCache(u *user.User) error {
+	up := upload.Provider{}
+	return up.FlushCache(u)
+}

--- a/pkg/modules/avatar/upload/upload.go
+++ b/pkg/modules/avatar/upload/upload.go
@@ -36,6 +36,12 @@ import (
 type Provider struct {
 }
 
+// FlushCache removes cached avatars for a user
+func (p *Provider) FlushCache(u *user.User) error {
+	InvalidateCache(u)
+	return nil
+}
+
 // CachedAvatar represents a cached avatar with its content and mime type
 type CachedAvatar struct {
 	Content  []byte

--- a/pkg/routes/api/v1/avatar.go
+++ b/pkg/routes/api/v1/avatar.go
@@ -177,5 +177,7 @@ func UploadAvatar(c echo.Context) (err error) {
 		return handler.HandleHTTPError(err)
 	}
 
+	avatar.FlushAllCaches(u)
+
 	return c.JSON(http.StatusOK, models.Message{Message: "Avatar was uploaded successfully."})
 }


### PR DESCRIPTION
## Summary
- extend avatar provider interface with cache flush method
- implement cache flushing in all avatar providers
- add `FlushAllCaches` helper
- purge caches when avatar provider changes or avatars are uploaded or synced

## Testing
- `mage lint:fix`


------
https://chatgpt.com/codex/tasks/task_e_685e7bc334b083229a43b24f3e2afb6f