### PR TITLE
fix(users): refresh initials avatar refresh after name change

### DIFF
--- a/frontend/src/models/user.ts
+++ b/frontend/src/models/user.ts
@@ -6,7 +6,7 @@ import type { IUserSettings } from '@/modelTypes/IUserSettings'
 import AvatarService from '@/services/avatar'
 
 const avatarService = new AvatarService()
-let avatarCache = new Map<string, string>()
+const avatarCache = new Map<string, string>()
 const pendingRequests = new Map<string, Promise<string>>()
 
 export async function fetchAvatarBlobUrl(user: IUser, size = 50) {

--- a/frontend/src/models/user.ts
+++ b/frontend/src/models/user.ts
@@ -6,7 +6,7 @@ import type { IUserSettings } from '@/modelTypes/IUserSettings'
 import AvatarService from '@/services/avatar'
 
 const avatarService = new AvatarService()
-const avatarCache = new Map<string, string>()
+let avatarCache = new Map<string, string>()
 const pendingRequests = new Map<string, Promise<string>>()
 
 export async function fetchAvatarBlobUrl(user: IUser, size = 50) {
@@ -25,6 +25,8 @@ export async function fetchAvatarBlobUrl(user: IUser, size = 50) {
 		return await pendingRequests.get(key) as string
 	}
 	
+	invalidateAvatarCache(user)
+	
 	// Create a new request
 	const requestPromise = avatarService.getBlobUrl(`/avatar/${user.username}?size=${size}`)
 		.then(url => {
@@ -41,15 +43,8 @@ export async function fetchAvatarBlobUrl(user: IUser, size = 50) {
 	return await requestPromise
 }
 
-export function invalidateAvatarCache(user: IUser, size?: number) {
+export function invalidateAvatarCache(user: IUser) {
 	if (!user || !user.username) {
-		return
-	}
-
-	if (typeof size === 'number') {
-		const key = `${user.username}-${size}`
-		avatarCache.delete(key)
-		pendingRequests.delete(key)
 		return
 	}
 

--- a/frontend/src/models/user.ts
+++ b/frontend/src/models/user.ts
@@ -41,6 +41,31 @@ export async function fetchAvatarBlobUrl(user: IUser, size = 50) {
 	return await requestPromise
 }
 
+export function invalidateAvatarCache(user: IUser, size?: number) {
+	if (!user || !user.username) {
+		return
+	}
+
+	if (typeof size === 'number') {
+		const key = `${user.username}-${size}`
+		avatarCache.delete(key)
+		pendingRequests.delete(key)
+		return
+	}
+
+	for (const key of Array.from(avatarCache.keys())) {
+		if (key.startsWith(`${user.username}-`)) {
+			avatarCache.delete(key)
+		}
+	}
+
+	for (const key of Array.from(pendingRequests.keys())) {
+		if (key.startsWith(`${user.username}-`)) {
+			pendingRequests.delete(key)
+		}
+	}
+}
+
 export function getDisplayName(user: IUser) {
 	if (user.name !== '') {
 		return user.name

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -150,6 +150,7 @@ export const useAuthStore = defineStore('auth', () => {
 		if (!info.value || !info.value.username) {
 			return
 		}
+		invalidateAvatarCache(info.value)
 		avatarUrl.value = await fetchAvatarBlobUrl(info.value, 40)
 	}
 
@@ -371,9 +372,9 @@ export const useAuthStore = defineStore('auth', () => {
 		settings,
 		showMessage = true,
 	}: {
-                settings: IUserSettings
-                showMessage : boolean
-        }) {
+		settings: IUserSettings,
+		showMessage: boolean,
+	}) {
 		const userSettingsService = new UserSettingsService()
 
 		const cancel = setModuleLoading(setIsLoadingGeneralSettings)
@@ -393,7 +394,6 @@ export const useAuthStore = defineStore('auth', () => {
 			if (oldName !== undefined && oldName !== settingsUpdate.name) {
 				const {avatarProvider} = await (new AvatarService()).get({})
 				if (avatarProvider === 'initials') {
-					invalidateAvatarCache(info.value as IUser)
 					await reloadAvatar()
 				}
 			}

--- a/pkg/routes/api/v1/user_settings.go
+++ b/pkg/routes/api/v1/user_settings.go
@@ -201,6 +201,8 @@ func UpdateGeneralUserSettings(c echo.Context) error {
 		return handler.HandleHTTPError(err)
 	}
 
+	invalidateAvatar := user.AvatarProvider == "initials" && user.Name != us.Name
+
 	user.Name = us.Name
 	user.EmailRemindersEnabled = us.EmailRemindersEnabled
 	user.DiscoverableByEmail = us.DiscoverableByEmail
@@ -222,6 +224,10 @@ func UpdateGeneralUserSettings(c echo.Context) error {
 	if err := s.Commit(); err != nil {
 		_ = s.Rollback()
 		return handler.HandleHTTPError(err)
+	}
+
+	if invalidateAvatar {
+		avatar.FlushAllCaches(user)
 	}
 
 	return c.JSON(http.StatusOK, &models.Message{Message: "The settings were updated successfully."})


### PR DESCRIPTION
## Summary
- expose an `invalidateAvatarCache` helper to force reloads
- refresh avatar when saving settings if initials provider is active

## Testing
- `pnpm lint:fix`

------
https://chatgpt.com/codex/tasks/task_e_685e9301a2288322b9f59e8938615542