### PR TITLE
fix: handle quotes in project filter titles

### DIFF
--- a/frontend/src/helpers/filters.test.ts
+++ b/frontend/src/helpers/filters.test.ts
@@ -187,6 +187,16 @@ describe('Filter Transformation', () => {
 
 			expect(transformed).toBe('project = 1')
 		})
+
+		it('should resolve projects with single quotes in the title', () => {
+			const transformed = transformFilterStringForApi(
+				"project = Todo's",
+				nullTitleToIdResolver,
+				(title: string) => title === "Todo's" ? 1 : null,
+			)
+
+			expect(transformed).toBe('project = 1')
+		})
 	})
 
 	describe('To API', () => {
@@ -287,6 +297,16 @@ describe('Filter Transformation', () => {
 			)
 
 			expect(transformed).toBe('project = lorem')
+		})
+
+		it('should resolve projects with single quotes in the title from API', () => {
+			const transformed = transformFilterStringFromApi(
+				'project = 1',
+				nullIdToTitleResolver,
+				(id: number) => id === 1 ? "Todo's" : null,
+			)
+
+			expect(transformed).toBe("project = Todo's")
 		})
 
 		it('should correctly resolve multiple projects', () => {

--- a/frontend/src/helpers/filters.ts
+++ b/frontend/src/helpers/filters.ts
@@ -61,11 +61,11 @@ export const FILTER_JOIN_OPERATOR = [
 export const FILTER_OPERATORS_REGEX = '(&lt;|&gt;|&lt;=|&gt;=|=|!=|not in|in)'
 
 export function hasFilterQuery(filter: string): boolean {
-	return FILTER_OPERATORS.find(o => filter.includes(o)) || false
+	return FILTER_OPERATORS.some(o => filter.includes(o)) || false
 }
 
 export function getFilterFieldRegexPattern(field: string): RegExp {
-	return new RegExp('(' + field + '\\s*' + FILTER_OPERATORS_REGEX + '\\s*)([\'"]?)([^\'"&|()<]+\\1?)?', 'ig')
+	return new RegExp('(' + field + '\\s*' + FILTER_OPERATORS_REGEX + '\\s*)([^&|()]+)', 'ig')
 }
 
 export function transformFilterStringForApi(
@@ -98,7 +98,7 @@ export function transformFilterStringForApi(
 
 			while ((match = pattern.exec(filter)) !== null) {
 				// eslint-disable-next-line @typescript-eslint/no-unused-vars
-				const [matched, prefix, operator, space, keyword] = match
+				const [matched, prefix, operator, keyword] = match
 				if (!keyword) {
 					continue
 				}
@@ -178,7 +178,7 @@ export function transformFilterStringFromApi(
 			let match: RegExpExecArray | null
 			while ((match = pattern.exec(filter)) !== null) {
 				// eslint-disable-next-line @typescript-eslint/no-unused-vars
-				const [matched, prefix, operator, space, keyword] = match
+				const [matched, prefix, operator, keyword] = match
 				if (keyword) {
 					let keywords = [keyword.trim()]
 					if (operator === 'in' || operator === '?=' || operator === 'not in' || operator === '?!=') {


### PR DESCRIPTION
## Summary
- allow quotes in filter regex
- adjust filter parsing logic
- test converting project titles with single quotes

Fixes #743

-------

The filter helper getFilterFieldRegexPattern() changed how it parses filter values.
Earlier versions matched optional quotes around the value and disallowed any quote characters inside it:

```ts
export const FILTER_OPERATORS_REGEX = '(<|>|<=|>=|=|!=|in)'

export function getFilterFieldRegexPattern(field: string): RegExp {
        return new RegExp('(' + field + '\\s*' + FILTER_OPERATORS_REGEX + '\\s*)([\\'\"]?)([^\\'\"&|()<]+\\1?)?', 'ig')
}
```

This meant values like project = Todo's failed to match because the single quote was interpreted as closing a quoted value.

The current code dropped the quote-specific groups and simply captures any characters until a filter operator or parenthesis:

```ts
export const FILTER_OPERATORS_REGEX = '(<|>|<=|>=|=|!=|not in|in)'

export function getFilterFieldRegexPattern(field: string): RegExp {
        return new RegExp('(' + field + '\\s*' + FILTER_OPERATORS_REGEX + '\\s*)([^&|()]+)', 'ig')
}
```

This mirrors the server-side regex used to parse filter expressions:

```go
// Regex pattern to match filter expressions
re := regexp.MustCompile(`(\w+)\s*(>=|<=|!=|~|\?=|\?!=|=|>|<)\s*([^&|()]+)`)
```

### Why it was like it was before:
The old pattern expected a value to be optionally wrapped in quotes and prohibited any internal quote characters. That avoided accidental splitting if quotes were used as delimiters, but it broke when project or tag names themselves contained a ' or ".

### Why it changed:
To support names that include quotes, the frontend regex now matches everything up to &, |, or parentheses—just like the backend. This allows titles such as "Todo's" to be parsed correctly, ensuring filters behave consistently across frontend and backend.