### PR TITLE
Allow filtering tests from mage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,9 +15,9 @@ The project consists of:
 
 ### Backend (Go)
 - **Build**: `mage build` - Builds the Go binary
-- **Test**: `mage test:feature` - Runs feature tests
+- **Test Features**: `mage test:feature` - Runs feature tests
 - **Test Web**: `mage test:web` - Runs web tests
-- **Test All**: `mage test:all` - Runs all tests
+- You can run specific tests with `mage test:filter <filter>` where `<filter>` is a go test filter string.
 - **Lint**: `mage lint` - Runs golangci-lint
 - **Lint Fix**: `mage lint:fix` - Runs golangci-lint with auto-fix
 - **Generate Swagger Docs**: `mage generate:swagger-docs` - Updates API documentation (Generally you won't need to run this unless the user tells you to. It is updated automatically in the CI workflow)

--- a/magefile.go
+++ b/magefile.go
@@ -377,31 +377,41 @@ func Fmt() {
 type Test mg.Namespace
 
 // Runs the feature tests
-func (Test) Feature() {
+func (Test) Feature(filter string) {
 	mg.Deps(initVars)
 	setApiPackages()
 	// We run everything sequentially and not in parallel to prevent issues with real test databases
-	args := append([]string{"test", Goflags[0], "-p", "1", "-coverprofile", "cover.out", "-timeout", "45m"}, ApiPackages...)
+	args := []string{"test", Goflags[0], "-p", "1", "-coverprofile", "cover.out", "-timeout", "45m"}
+	if strings.TrimSpace(filter) != "" {
+		args = append(args, "-run", filter)
+	}
+	args = append(args, ApiPackages...)
 	runAndStreamOutput("go", args...)
 }
 
 // Runs the tests and builds the coverage html file from coverage output
 func (Test) Coverage() {
 	mg.Deps(initVars)
-	mg.Deps(Test.Feature)
+	Test{}.Feature("")
 	runAndStreamOutput("go", "tool", "cover", "-html=cover.out", "-o", "cover.html")
 }
 
 // Runs the web tests
-func (Test) Web() {
+func (Test) Web(filter string) {
 	mg.Deps(initVars)
 	// We run everything sequentially and not in parallel to prevent issues with real test databases
-	runAndStreamOutput("go", "test", Goflags[0], "-p", "1", "-timeout", "45m", PACKAGE+"/pkg/webtests")
+	args := []string{"test", Goflags[0], "-p", "1", "-timeout", "45m"}
+	if strings.TrimSpace(filter) != "" {
+		args = append(args, "-run", filter)
+	}
+	args = append(args, PACKAGE+"/pkg/webtests")
+	runAndStreamOutput("go", args...)
 }
 
 func (Test) All() {
 	mg.Deps(initVars)
-	mg.Deps(Test.Feature, Test.Web)
+	Test{}.Feature("")
+	Test{}.Web("")
 }
 
 type Check mg.Namespace

--- a/magefile.go
+++ b/magefile.go
@@ -377,41 +377,40 @@ func Fmt() {
 type Test mg.Namespace
 
 // Runs the feature tests
-func (Test) Feature(filter string) {
+func (Test) Feature() {
 	mg.Deps(initVars)
 	setApiPackages()
 	// We run everything sequentially and not in parallel to prevent issues with real test databases
-	args := []string{"test", Goflags[0], "-p", "1", "-coverprofile", "cover.out", "-timeout", "45m"}
-	if strings.TrimSpace(filter) != "" {
-		args = append(args, "-run", filter)
-	}
-	args = append(args, ApiPackages...)
+	args := append([]string{"test", Goflags[0], "-p", "1", "-coverprofile", "cover.out", "-timeout", "45m"}, ApiPackages...)
 	runAndStreamOutput("go", args...)
 }
 
 // Runs the tests and builds the coverage html file from coverage output
 func (Test) Coverage() {
 	mg.Deps(initVars)
-	Test{}.Feature("")
+	mg.Deps(Test.Feature)
 	runAndStreamOutput("go", "tool", "cover", "-html=cover.out", "-o", "cover.html")
 }
 
 // Runs the web tests
-func (Test) Web(filter string) {
+func (Test) Web() {
 	mg.Deps(initVars)
 	// We run everything sequentially and not in parallel to prevent issues with real test databases
-	args := []string{"test", Goflags[0], "-p", "1", "-timeout", "45m"}
-	if strings.TrimSpace(filter) != "" {
-		args = append(args, "-run", filter)
-	}
-	args = append(args, PACKAGE+"/pkg/webtests")
+	args := []string{"test", Goflags[0], "-p", "1", "-timeout", "45m", PACKAGE + "/pkg/webtests"}
+	runAndStreamOutput("go", args...)
+}
+
+func (Test) Filter(filter string) {
+	mg.Deps(initVars)
+	setApiPackages()
+	// We run everything sequentially and not in parallel to prevent issues with real test databases
+	args := append([]string{"test", Goflags[0], "-p", "1", "-timeout", "45m", "-run", filter}, ApiPackages...)
 	runAndStreamOutput("go", args...)
 }
 
 func (Test) All() {
 	mg.Deps(initVars)
-	Test{}.Feature("")
-	Test{}.Web("")
+	mg.Deps(Test.Feature, Test.Web)
 }
 
 type Check mg.Namespace


### PR DESCRIPTION
## Summary
- add optional filter argument to `test:feature` and `test:web`
- use the new functions in `test:coverage` and `test:all`

## Testing
- `mage lint:fix`

------
https://chatgpt.com/codex/tasks/task_e_686578079a18832280b21cd91c4ca7d9