### PR TITLE
fix: panic on restoring with numeric position fields

### DIFF
--- a/pkg/modules/dump/restore.go
+++ b/pkg/modules/dump/restore.go
@@ -190,6 +190,55 @@ func Restore(filename string) error {
 	return nil
 }
 
+func convertFieldValue(fieldName string, value interface{}, isFloat bool) (interface{}, error) {
+	// Check if this is a float field and the value is already a number
+	if isFloat {
+		switch v := value.(type) {
+		case float64:
+			// Already a float64, no need to process
+			return v, nil
+		case int:
+			// Convert int to float64
+			return float64(v), nil
+		case string:
+			// Try to decode from base64 string and convert to float
+			decoded, err := base64.StdEncoding.DecodeString(v)
+			if err != nil {
+				var corruptErr base64.CorruptInputError
+				if !errors.As(err, &corruptErr) {
+					return nil, fmt.Errorf("could not decode field '%s' %s: %w", fieldName, value, err)
+				}
+				// If it's a CorruptInputError, treat the string as raw data
+				decoded = []byte(v)
+			}
+			val, err := strconv.ParseFloat(string(decoded), 64)
+			if err != nil {
+				return nil, fmt.Errorf("could not parse double value for field '%s': %w", fieldName, err)
+			}
+			return val, nil
+		default:
+			return nil, fmt.Errorf("unexpected type for float field '%s': %T", fieldName, v)
+		}
+	}
+
+	// Handle JSON fields (non-float)
+	switch v := value.(type) {
+	case string:
+		decoded, err := base64.StdEncoding.DecodeString(v)
+		if err != nil {
+			var corruptErr base64.CorruptInputError
+			if !errors.As(err, &corruptErr) {
+				return nil, fmt.Errorf("could not decode field '%s' %s: %w", fieldName, value, err)
+			}
+			// If it's a CorruptInputError, treat the string as raw data
+			decoded = []byte(v)
+		}
+		return string(decoded), nil
+	default:
+		return nil, fmt.Errorf("expected string for JSON field '%s', got %T", fieldName, v)
+	}
+}
+
 func restoreTableData(tables map[string]*zip.File) error {
 	jsonFields := map[string][]string{
 		"api_tokens":    {"permissions"},
@@ -221,52 +270,11 @@ func restoreTableData(tables map[string]*zip.File) error {
 						continue
 					}
 
-					// Check if this is a float field and the value is already a number
-					if isFloat {
-						switch v := content[i][f].(type) {
-						case float64:
-							// Already a float64, no need to process
-							content[i][f] = v
-							continue
-						case int:
-							// Convert int to float64
-							content[i][f] = float64(v)
-							continue
-						case string:
-							// Try to decode from base64 string and convert to float
-							decoded, err := base64.StdEncoding.DecodeString(v)
-							if err != nil && !errors.Is(err, base64.CorruptInputError(0)) {
-								return fmt.Errorf("could not decode field '%s' %s: %w", f, content[i][f], err)
-							}
-							if err != nil && errors.Is(err, base64.CorruptInputError(0)) {
-								decoded = []byte(v)
-							}
-							val, err := strconv.ParseFloat(string(decoded), 64)
-							if err != nil {
-								return fmt.Errorf("could not parse double value for field '%s': %w", f, err)
-							}
-							content[i][f] = val
-							continue
-						default:
-							return fmt.Errorf("unexpected type for float field '%s': %T", f, v)
-						}
+					convertedValue, err := convertFieldValue(f, content[i][f], isFloat)
+					if err != nil {
+						return err
 					}
-
-					// Handle JSON fields (non-float)
-					var decoded []byte
-					switch v := content[i][f].(type) {
-					case string:
-						decoded, err = base64.StdEncoding.DecodeString(v)
-						if err != nil && !errors.Is(err, base64.CorruptInputError(0)) {
-							return fmt.Errorf("could not decode field '%s' %s: %w", f, content[i][f], err)
-						}
-						if err != nil && errors.Is(err, base64.CorruptInputError(0)) {
-							decoded = []byte(v)
-						}
-						content[i][f] = string(decoded)
-					default:
-						return fmt.Errorf("expected string for JSON field '%s', got %T", f, v)
-					}
+					content[i][f] = convertedValue
 				}
 			}
 			return nil

--- a/pkg/modules/dump/restore_test.go
+++ b/pkg/modules/dump/restore_test.go
@@ -1,0 +1,108 @@
+// Vikunja is a to-do list application to facilitate your life.
+// Copyright 2018-present Vikunja and contributors. All rights reserved.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package dump
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvertFieldValue(t *testing.T) {
+	t.Run("Float field conversions", func(t *testing.T) {
+		t.Run("should return float64 as-is", func(t *testing.T) {
+			result, err := convertFieldValue("position", 123.45, true)
+			require.NoError(t, err)
+			assert.InEpsilon(t, 123.45, result, 0.0001)
+		})
+
+		t.Run("should convert int to float64", func(t *testing.T) {
+			result, err := convertFieldValue("position", 42, true)
+			require.NoError(t, err)
+			assert.InEpsilon(t, 42.0, result, 0.0001)
+		})
+
+		t.Run("should decode base64 string and convert to float", func(t *testing.T) {
+			encoded := base64.StdEncoding.EncodeToString([]byte("123.45"))
+			result, err := convertFieldValue("position", encoded, true)
+			require.NoError(t, err)
+			assert.InEpsilon(t, 123.45, result, 0.0001)
+		})
+
+		t.Run("should handle non-base64 string and convert to float", func(t *testing.T) {
+			result, err := convertFieldValue("position", "67.89", true)
+			require.NoError(t, err)
+			assert.InEpsilon(t, 67.89, result, 0.0001)
+		})
+
+		t.Run("should return error for invalid float string", func(t *testing.T) {
+			_, err := convertFieldValue("position", "not-a-number", true)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "could not parse double value")
+		})
+
+		t.Run("should return error for unexpected type", func(t *testing.T) {
+			_, err := convertFieldValue("position", []int{1, 2, 3}, true)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "unexpected type for float field")
+		})
+	})
+
+	t.Run("JSON field conversions", func(t *testing.T) {
+		t.Run("should decode base64 string", func(t *testing.T) {
+			jsonData := `{"key": "value"}`
+			encoded := base64.StdEncoding.EncodeToString([]byte(jsonData))
+			result, err := convertFieldValue("permissions", encoded, false)
+			require.NoError(t, err)
+			assert.JSONEq(t, jsonData, result.(string))
+		})
+
+		t.Run("should handle non-base64 string", func(t *testing.T) {
+			jsonData := `{"key": "value"}`
+			result, err := convertFieldValue("permissions", jsonData, false)
+			require.NoError(t, err)
+			assert.JSONEq(t, jsonData, result.(string))
+		})
+
+		t.Run("should return error for non-string type", func(t *testing.T) {
+			_, err := convertFieldValue("permissions", 123, false)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "expected string for JSON field")
+		})
+	})
+
+	t.Run("Base64 error handling", func(t *testing.T) {
+		t.Run("should handle base64 decode error for float field", func(t *testing.T) {
+			invalidBase64 := "invalid base64 with spaces and special chars!!!"
+			result, err := convertFieldValue("position", invalidBase64, true)
+			// Should not error on decode, but should error on parse float
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "could not parse double value")
+			assert.Nil(t, result)
+		})
+
+		t.Run("should handle base64 decode error for JSON field", func(t *testing.T) {
+			// For JSON fields, CorruptInputError just returns the raw string
+			invalidBase64 := "invalid base64 with spaces and special chars!!!"
+			result, err := convertFieldValue("permissions", invalidBase64, false)
+			require.NoError(t, err)
+			assert.Equal(t, invalidBase64, result)
+		})
+	})
+}


### PR DESCRIPTION
Hi @kolaente and @dpschen 

_Originally Discussed in Matrix-Channel: https://matrix.to/#/!dCRiCiLaCCFVNlDnYs:matrix.org/$5I7iNku1RBvsicb-rXsIvQwS8UDnj1dybljJmE0ePRk?via=matrix.org&via=tchncs.de&via=envs.net _

This PR aims to fix an issue, that happens when trying to import my dump from unstable (0.24.1-1524-77787459) to unstable (0.24.1-1524-77787459)

Here is the stacktrace:
```bash
2025-07-03T11:35:34+02:00: INFO ▶ 002 Running migrations…
2025-07-03T11:35:34+02:00: INFO ▶ 070 Ran all migrations successfully.
2025-07-03T11:35:34+02:00: WARNING      ▶ 071 Restoring a dump will wipe your current installation!
2025-07-03T11:35:34+02:00: WARNING      ▶ 072 To confirm, please type 'Yes, I understand' and confirm with enter:
Yes, I understand
2025-07-03T11:35:39+02:00: INFO ▶ 073 The config file has been restored to 'config.yml'.
2025-07-03T11:35:39+02:00: INFO ▶ 074 You can now make changes to it, hit enter when you're done.

2025-07-03T11:35:41+02:00: INFO ▶ 075 Restoring...
2025-07-03T11:35:41+02:00: INFO ▶ 076 Using config file: /etc/vikunja/config.yml
2025-07-03T11:35:41+02:00: INFO ▶ 11d Wiped database.
2025-07-03T11:35:44+02:00: INFO ▶ 246 Restored table unsplash_photos
2025-07-03T11:35:44+02:00: INFO ▶ 28b Restored table user_tokens
panic: interface conversion: interface {} is float64, not string

goroutine 1 [running]:
code.vikunja.io/api/pkg/modules/dump.restoreTableData.func1({0xc0001d4480, 0x1, 0xc0004e3f70?}, 0x1)
        /source/pkg/modules/dump/restore.go:225 +0x545
code.vikunja.io/api/pkg/modules/dump.restoreTableData(0xc00004fa90)
        /source/pkg/modules/dump/restore.go:257 +0x79f
code.vikunja.io/api/pkg/modules/dump.Restore({0x7ffc0d765e2a?, 0x0?})
        /source/pkg/modules/dump/restore.go:153 +0xd14
code.vikunja.io/api/pkg/cmd.init.func14(0xc000121a00?, {0xc0003cdac0?, 0x4?, 0x17b573b?})
        /source/pkg/cmd/restore.go:38 +0x35
github.com/spf13/cobra.(*Command).execute(0x2d518e0, {0xc0003cda90, 0x1, 0x1})
        /go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1019 +0xa91
github.com/spf13/cobra.(*Command).ExecuteC(0x2d53720)
        /go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1148 +0x46f
github.com/spf13/cobra.(*Command).Execute(...)
        /go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1071
code.vikunja.io/api/pkg/cmd.Execute()
        /source/pkg/cmd/cmd.go:44 +0x1a
main.main()
        /source/main.go:22 +0xf
```

I think there is an issue with how 0 and base64 in json are playing together in the restore func.

I ran the migration like 100 times to see which files never appear in the filst of successful migrations, which came down to

- buckets
- migrations
- projects
- project_views
- task_positions

all except migrations are in that array of specially treated files with the positions. Unsure if migrations file would need to be in that list too or not.

Please review this and check it out, this is untested and based on theory, I'm also not really a good go-developer.

But I'd appreciate a fix, so I could migrate my instance :)