### PR TITLE
Fix CalDAV REPORT request to properly respond with VTODO objects

### DIFF
--- a/pkg/routes/caldav/listStorageProvider.go
+++ b/pkg/routes/caldav/listStorageProvider.go
@@ -600,7 +600,7 @@ func (vlra *VikunjaProjectResourceAdapter) CalculateEtag() string {
 
 // GetContent returns the content string of a resource (a task in our case)
 func (vlra *VikunjaProjectResourceAdapter) GetContent() string {
-	if vlra.project != nil && vlra.project.Tasks != nil {
+	if vlra.project != nil && vlra.projectTasks != nil {
 		return caldav.GetCaldavTodosForTasks(vlra.project, vlra.projectTasks)
 	}
 

--- a/pkg/webtests/caldav_test.go
+++ b/pkg/webtests/caldav_test.go
@@ -17,11 +17,14 @@
 package webtests
 
 import (
+	"encoding/xml"
 	"net/http"
+	"strings"
 	"testing"
 
 	"code.vikunja.io/api/pkg/routes/caldav"
 
+	ics "github.com/arran4/golang-ical"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -316,5 +319,78 @@ END:VCALENDAR`
 		assert.Equal(t, 200, rec.Result().StatusCode)
 		assert.Contains(t, rec.Body.String(), "UID:uid-caldav-test-child-task-another-list")
 		assert.Contains(t, rec.Body.String(), "RELATED-TO;RELTYPE=PARENT:uid-caldav-test-parent-task-another-list")
+	})
+}
+
+func TestCaldavReport(t *testing.T) {
+	t.Run("REPORT calendar-query returns all tasks", func(t *testing.T) {
+		e, _ := setupTestEnv()
+
+		// CalDAV REPORT request for calendar-query
+		reportBody := `<?xml version="1.0" encoding="utf-8" ?>
+<C:calendar-query xmlns:C="urn:ietf:params:xml:ns:caldav">
+    <D:prop xmlns:D="DAV:">
+        <D:getetag/>
+        <C:calendar-data/>
+    </D:prop>
+    <C:filter>
+        <C:comp-filter name="VCALENDAR">
+            <C:comp-filter name="VTODO"/>
+        </C:comp-filter>
+    </C:filter>
+</C:calendar-query>`
+
+		rec, err := newCaldavTestRequestWithUser(t, e, "REPORT", caldav.ProjectHandler, &testuser15, reportBody, nil, map[string]string{"project": "36"})
+		require.NoError(t, err)
+		assert.Equal(t, 207, rec.Result().StatusCode) // Multi-Status response
+
+		responseBody := rec.Body.String()
+
+		assert.Contains(t, responseBody, "multistatus")
+		assert.Contains(t, responseBody, "response")
+		assert.Contains(t, responseBody, "href")
+		assert.Contains(t, responseBody, "propstat")
+
+		// Parse XML to verify structure
+		type Multistatus struct {
+			Response []struct {
+				Href     string `xml:"href"`
+				Propstat struct {
+					Prop struct {
+						Getetag      string `xml:"getetag"`
+						CalendarData string `xml:"calendar-data"`
+					} `xml:"prop"`
+				} `xml:"propstat"`
+			} `xml:"response"`
+		}
+
+		var multistatus Multistatus
+		err = xml.Unmarshal([]byte(responseBody), &multistatus)
+		require.NoError(t, err)
+
+		assert.Equal(t, len(multistatus.Response), 5, "Should have all tasks from the project")
+
+		for i, response := range multistatus.Response {
+			assert.NotEmpty(t, response.Href, "Response %d should have an href", i)
+			assert.NotEmpty(t, response.Propstat.Prop.CalendarData, "Response %d should have calendar-data", i)
+			assert.NotEmpty(t, response.Propstat.Prop.Getetag, "Response %d should have an ETag", i)
+
+			calendarData := response.Propstat.Prop.CalendarData
+
+			cal, err := ics.ParseCalendar(strings.NewReader(calendarData))
+			require.NoError(t, err, "Response %d should contain valid iCalendar data", i)
+
+			require.Len(t, cal.Components, 1, "Response %d should contain exactly one VTODO component")
+
+			component := cal.Components[0]
+			require.IsType(t, &ics.VTodo{}, component)
+
+			vtodo, _ := component.(*ics.VTodo)
+			uid := vtodo.GetProperty(ics.ComponentPropertyUniqueId)
+			assert.NotEmpty(t, uid.Value, "Response %d VTODO UID should not be empty", i)
+
+			summary := vtodo.GetProperty(ics.ComponentPropertySummary)
+			assert.NotEmpty(t, summary.Value, "Response %d VTODO SUMMARY should not be empty", i)
+		}
 	})
 }


### PR DESCRIPTION
First off, thanks for this awesome project!

Currently, when the following request is made:
```xml
<?xml version="1.0" encoding="utf-8"?>
<C:calendar-query xmlns:D="DAV:" xmlns:C="urn:ietf:params:xml:ns:caldav">
  <D:prop>
    <C:calendar-data/>
  </D:prop>
  <C:filter>
    <C:comp-filter name="VCALENDAR">
      <C:comp-filter name="VTODO">
      </C:comp-filter>
    </C:comp-filter>
  </C:filter>
</C:calendar-query>
```

Vikunja responds with
```xml
<?xml version="1.0" encoding="UTF-8"?>
<D:multistatus xmlns:D="DAV:" xmlns:C="urn:ietf:params:xml:ns:caldav" xmlns:CS="http://calendarserver.org/ns/">
  <D:response>
    <D:href>/dav/projects/1/6cbf88d0-1129-438e-a1a3-5b9c1f92bd96.ics</D:href>
    <D:propstat>
      <D:prop>
        <C:calendar-data>BEGIN:VCALENDAR
VERSION:2.0
METHOD:PUBLISH
X-PUBLISHED-TTL:PT4H
X-WR-CALNAME:
PRODID:-//Vikunja Todo App//EN
END:VCALENDAR</C:calendar-data>
      </D:prop>
      <D:status>HTTP/1.1 200 OK</D:status>
    </D:propstat>
  </D:response>
  <D:response>
    ...
  </D:response>
</D:multistatus>  
```

As you can see, it does not include the `VTODO` element.
I've stumbled upon this when integrating Vikunja with Home Assistant via their [CalDAV integration](https://www.home-assistant.io/integrations/caldav/).
When marking an item as completed via Home Assistant, I saw an error:
```
Failed to perform the action todo/update_item. 'CalendarObjectResource' object has no attribute 'set_due'
```
This has been filed as a bug with Home Assistant previously: https://github.com/home-assistant/core/issues/122346.

As it turned out, they [fetch the TODO item](
https://github.com/home-assistant/core/blob/bc07030304581d7529f0fe49a7f5ac33d2e864d5/homeassistant/components/caldav/todo.py#L151) before updating it. Because the response doesn't include the actual `VTODO`, the library used by Home Assistant fails to unmarshal the response properly, resulting in the aforementioned error.

With this change, Vikunja will actually include the `VTODO` in the response, fixing the issue.
This should also be consistent with the spec. I've followed the example from [RFC 4791 Section 7.8.9](https://datatracker.ietf.org/doc/html/rfc4791#section-7.8.9).

Updated response example:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<D:multistatus xmlns:D="DAV:" xmlns:C="urn:ietf:params:xml:ns:caldav" xmlns:CS="http://calendarserver.org/ns/">
  <D:response>
    <D:href>/dav/projects/1/6cbf88d0-1129-438e-a1a3-5b9c1f92bd96.ics</D:href>
    <D:propstat>
      <D:prop>
        <C:calendar-data>BEGIN:VCALENDAR
VERSION:2.0
METHOD:PUBLISH
X-PUBLISHED-TTL:PT4H
X-WR-CALNAME:
PRODID:-//Vikunja Todo App//EN
BEGIN:VTODO
UID:6cbf88d0-1129-438e-a1a3-5b9c1f92bd96
DTSTAMP:20250708T063859Z
SUMMARY:Put out bins – Garbage/Compost
COMPLETED:20250708T063859Z
STATUS:COMPLETED
DUE:20250722T040000Z
CREATED:20250707T021855Z
PRIORITY:3
RRULE:FREQ=SECONDLY;INTERVAL=1209600
LAST-MODIFIED:20250708T063859Z
END:VTODO
END:VCALENDAR</C:calendar-data>
      </D:prop>
      <D:status>HTTP/1.1 200 OK</D:status>
    </D:propstat>
  </D:response>
  <D:response>
    ...
  </D:response>
</D:multistatus>  
```