### PR TITLE
fix: don't panic when using api token when not correctly put into context

### DIFF
--- a/pkg/routes/api_tokens.go
+++ b/pkg/routes/api_tokens.go
@@ -25,6 +25,7 @@ import (
 	"code.vikunja.io/api/pkg/db"
 	"code.vikunja.io/api/pkg/log"
 	"code.vikunja.io/api/pkg/models"
+	"code.vikunja.io/api/pkg/user"
 
 	echojwt "github.com/labstack/echo-jwt/v4"
 	"github.com/labstack/echo/v4"
@@ -87,7 +88,13 @@ func checkAPITokenAndPutItInContext(tokenHeaderValue string, c echo.Context) err
 		return echo.NewHTTPError(http.StatusUnauthorized)
 	}
 
+	u, err := user.GetUserByID(s, token.OwnerID)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError).SetInternal(err)
+	}
+
 	c.Set("api_token", token)
+	c.Set("api_user", u)
 
 	return nil
 }

--- a/pkg/user/error.go
+++ b/pkg/user/error.go
@@ -632,3 +632,30 @@ const ErrorCodeUsernameReserved = 1026
 func (err ErrUsernameReserved) HTTPError() web.HTTPError {
 	return web.HTTPError{HTTPCode: http.StatusBadRequest, Code: ErrorCodeUsernameReserved, Message: "This username is reserved and cannot be used."}
 }
+
+// ErrInvalidUserContext represents an error where the user context is invalid or missing
+type ErrInvalidUserContext struct {
+	Reason string
+}
+
+// IsErrInvalidUserContext checks if an error is a ErrInvalidUserContext.
+func IsErrInvalidUserContext(err error) bool {
+	_, ok := err.(ErrInvalidUserContext)
+	return ok
+}
+
+func (err ErrInvalidUserContext) Error() string {
+	return fmt.Sprintf("Invalid user context: %s", err.Reason)
+}
+
+// ErrorCodeInvalidUserContext holds the unique world-error code of this error
+const ErrorCodeInvalidUserContext = 1027
+
+// HTTPError holds the http error description
+func (err ErrInvalidUserContext) HTTPError() web.HTTPError {
+	return web.HTTPError{
+		HTTPCode: http.StatusUnauthorized,
+		Code:     ErrorCodeInvalidUserContext,
+		Message:  "Invalid user context. Please make sure the passed token is valid and try again.",
+	}
+}

--- a/pkg/user/user.go
+++ b/pkg/user/user.go
@@ -419,6 +419,10 @@ func CheckUserPassword(user *User, password string) error {
 
 // GetCurrentUserFromDB gets a user from jwt claims and returns the full user from the db.
 func GetCurrentUserFromDB(s *xorm.Session, c echo.Context) (user *User, err error) {
+	if apiUser, ok := c.Get("api_user").(*User); ok {
+		return apiUser, nil
+	}
+
 	u, err := GetCurrentUser(c)
 	if err != nil {
 		return nil, err
@@ -429,6 +433,10 @@ func GetCurrentUserFromDB(s *xorm.Session, c echo.Context) (user *User, err erro
 
 // GetCurrentUser returns the current user based on its jwt token
 func GetCurrentUser(c echo.Context) (user *User, err error) {
+	if apiUser, ok := c.Get("api_user").(*User); ok {
+		return apiUser, nil
+	}
+
 	jwtinf := c.Get("user").(*jwt.Token)
 	claims := jwtinf.Claims.(jwt.MapClaims)
 	return GetUserFromClaims(claims)


### PR DESCRIPTION
## Summary
- prevent panic by loading the token owner into request context
- use the context user object in `GetCurrentUser`

## Testing
- `mage lint:fix`

------
https://chatgpt.com/codex/tasks/task_e_687577d0cec88322a07b3eabd96decf9