### PR TITLE
Fix background upload for unsupported formats

### DIFF
--- a/pkg/modules/background/handler/errors.go
+++ b/pkg/modules/background/handler/errors.go
@@ -1,0 +1,42 @@
+// Vikunja is a to-do list application to facilitate your life.
+// Copyright 2018-present Vikunja and contributors. All rights reserved.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package handler
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrFileUnsupportedImageFormat defines an error where an uploaded image format is not supported
+// by the imaging library
+//
+// This is returned when decoding the image fails because the format is unknown.
+type ErrFileUnsupportedImageFormat struct {
+	Mime string
+}
+
+// Error is the error implementation of ErrFileUnsupportedImageFormat
+func (err ErrFileUnsupportedImageFormat) Error() string {
+	return fmt.Sprintf("file is not a supported image format [Mime: %s]", err.Mime)
+}
+
+// IsErrFileUnsupportedImageFormat checks if an error is ErrFileUnsupportedImageFormat
+func IsErrFileUnsupportedImageFormat(err error) bool {
+	var errFileUnsupportedImageFormat ErrFileUnsupportedImageFormat
+	ok := errors.As(err, &errFileUnsupportedImageFormat)
+	return ok
+}


### PR DESCRIPTION
## Summary
- validate background upload mime types in handler
- detect unsupported formats in SaveBackgroundFile
- add ErrFileUnsupportedImageFormat in background handler
- reuse allowed mime list

## Testing
- `mage lint:fix`


------
https://chatgpt.com/codex/tasks/task_e_68760fb7797483229431bd2d0447f058