### PR TITLE
feat: add keyvalue.Remember function

### DIFF
--- a/pkg/modules/avatar/initials/initials.go
+++ b/pkg/modules/avatar/initials/initials.go
@@ -135,13 +135,7 @@ func getCacheKey(prefix string, keys ...int64) string {
 func getAvatarForUser(u *user.User) (fullSizeAvatar *image.RGBA64, err error) {
 	cacheKey := getCacheKey("full", u.ID)
 
-	fullSizeAvatar = &image.RGBA64{}
-	exists, err := keyvalue.GetWithValue(cacheKey, fullSizeAvatar)
-	if err != nil {
-		return nil, err
-	}
-
-	if !exists {
+	result, err := keyvalue.Remember(cacheKey, func() (any, error) {
 		log.Debugf("Initials avatar for user %d not cached, creating...", u.ID)
 		avatarText := u.Name
 		if avatarText == "" {
@@ -150,17 +144,12 @@ func getAvatarForUser(u *user.User) (fullSizeAvatar *image.RGBA64, err error) {
 		firstRune := []rune(strings.ToUpper(avatarText))[0]
 		bg := avatarBgColors[int(u.ID)%len(avatarBgColors)] // Random color based on the user id
 
-		fullSizeAvatar, err = drawImage(firstRune, bg)
-		if err != nil {
-			return nil, err
-		}
-		err = keyvalue.Put(cacheKey, fullSizeAvatar)
-		if err != nil {
-			return nil, err
-		}
+		return drawImage(firstRune, bg)
+	})
+	if err != nil {
+		return nil, err
 	}
-
-	return fullSizeAvatar, nil
+	return result.(*image.RGBA64), nil
 }
 
 // CachedAvatar represents a cached avatar with its content and mime type
@@ -173,41 +162,33 @@ type CachedAvatar struct {
 func (p *Provider) GetAvatar(u *user.User, size int64) (avatar []byte, mimeType string, err error) {
 	cacheKey := getCacheKey("resized", u.ID, size)
 
-	var cachedAvatar CachedAvatar
-	exists, err := keyvalue.GetWithValue(cacheKey, &cachedAvatar)
+	result, err := keyvalue.Remember(cacheKey, func() (any, error) {
+		log.Debugf("Initials avatar for user %d and size %d not cached, creating...", u.ID, size)
+		fullAvatar, err := getAvatarForUser(u)
+		if err != nil {
+			return nil, err
+		}
+
+		img := imaging.Resize(fullAvatar, int(size), int(size), imaging.Lanczos)
+		buf := &bytes.Buffer{}
+		err = png.Encode(buf, img)
+		if err != nil {
+			return nil, err
+		}
+		avatar := buf.Bytes()
+		mimeType := "image/png"
+
+		cachedAvatar := CachedAvatar{
+			Content:  avatar,
+			MimeType: mimeType,
+		}
+
+		return cachedAvatar, nil
+	})
 	if err != nil {
 		return nil, "", err
 	}
 
-	if exists && len(cachedAvatar.Content) > 0 {
-		log.Debugf("Serving initials avatar for user %d and size %d from cache", u.ID, size)
-		return cachedAvatar.Content, cachedAvatar.MimeType, nil
-	}
-
-	log.Debugf("Initials avatar for user %d and size %d not cached, creating...", u.ID, size)
-	fullAvatar, err := getAvatarForUser(u)
-	if err != nil {
-		return nil, "", err
-	}
-
-	img := imaging.Resize(fullAvatar, int(size), int(size), imaging.Lanczos)
-	buf := &bytes.Buffer{}
-	err = png.Encode(buf, img)
-	if err != nil {
-		return nil, "", err
-	}
-	avatar = buf.Bytes()
-	mimeType = "image/png"
-
-	cachedAvatar = CachedAvatar{
-		Content:  avatar,
-		MimeType: mimeType,
-	}
-
-	err = keyvalue.Put(cacheKey, cachedAvatar)
-	if err != nil {
-		return nil, "", err
-	}
-
-	return avatar, mimeType, nil
+	cachedAvatar := result.(CachedAvatar)
+	return cachedAvatar.Content, cachedAvatar.MimeType, nil
 }

--- a/pkg/modules/background/unsplash/unsplash.go
+++ b/pkg/modules/background/unsplash/unsplash.go
@@ -122,22 +122,16 @@ func getImageID(fullURL string) string {
 
 // Gets an unsplash photo either from cache or directly from the unsplash api
 func getUnsplashPhotoInfoByID(photoID string) (photo *Photo, err error) {
-
-	photo = &Photo{}
-	exists, err := keyvalue.GetWithValue(cachePrefix+photoID, photo)
+	result, err := keyvalue.Remember(cachePrefix+photoID, func() (any, error) {
+		log.Debugf("Image information for unsplash photo %s not cached, requesting from unsplash...", photoID)
+		photo := &Photo{}
+		err := doGet("photos/"+photoID, photo)
+		return photo, err
+	})
 	if err != nil {
 		return nil, err
 	}
-
-	if !exists {
-		log.Debugf("Image information for unsplash photo %s not cached, requesting from unsplash...", photoID)
-		photo = &Photo{}
-		err = doGet("photos/"+photoID, photo)
-		if err != nil {
-			return
-		}
-	}
-	return
+	return result.(*Photo), nil
 }
 
 // Search is the implementation to search on unsplash

--- a/pkg/modules/keyvalue/keyvalue.go
+++ b/pkg/modules/keyvalue/keyvalue.go
@@ -86,3 +86,27 @@ func ListKeys(prefix string) ([]string, error) {
 func DelPrefix(prefix string) error {
 	return store.DelPrefix(prefix)
 }
+
+// Remember returns the value for a key if it exists.
+// If the key is not present, it executes fn to calculate the value,
+// stores it and then returns it.
+func Remember(key string, fn func() (any, error)) (any, error) {
+	val, exists, err := Get(key)
+	if err != nil {
+		return nil, err
+	}
+	if exists {
+		return val, nil
+	}
+
+	val, err = fn()
+	if err != nil {
+		return nil, err
+	}
+
+	if err := Put(key, val); err != nil {
+		return nil, err
+	}
+
+	return val, nil
+}

--- a/pkg/modules/keyvalue/keyvalue_test.go
+++ b/pkg/modules/keyvalue/keyvalue_test.go
@@ -1,0 +1,83 @@
+// Vikunja is a to-do list application to facilitate your life.
+// Copyright 2018-present Vikunja and contributors. All rights reserved.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package keyvalue
+
+import (
+	"errors"
+	"testing"
+
+	"code.vikunja.io/api/pkg/modules/keyvalue/memory"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRememberReturnsExisting(t *testing.T) {
+	store = memory.NewStorage()
+	err := Put("foo", "bar")
+	require.NoError(t, err)
+
+	called := false
+	val, err := Remember("foo", func() (interface{}, error) {
+		called = true
+		return "baz", nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "bar", val)
+	assert.False(t, called)
+}
+
+func TestRememberComputesAndStores(t *testing.T) {
+	store = memory.NewStorage()
+
+	called := 0
+	val, err := Remember("foo", func() (interface{}, error) {
+		called++
+		return "bar", nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "bar", val)
+	assert.Equal(t, 1, called)
+
+	v, exists, err := Get("foo")
+	require.NoError(t, err)
+	assert.True(t, exists)
+	assert.Equal(t, "bar", v)
+
+	val, err = Remember("foo", func() (interface{}, error) {
+		called++
+		return "baz", nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "bar", val)
+	assert.Equal(t, 1, called)
+}
+
+func TestRememberErrorDoesNotStore(t *testing.T) {
+	store = memory.NewStorage()
+
+	_, err := Remember("foo", func() (interface{}, error) {
+		return nil, errors.New("fail")
+	})
+
+	require.Error(t, err)
+	_, exists, err2 := Get("foo")
+	require.NoError(t, err2)
+	assert.False(t, exists)
+}

--- a/pkg/routes/api/v1/task_attachment.go
+++ b/pkg/routes/api/v1/task_attachment.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 
 	"code.vikunja.io/api/pkg/db"
-	"code.vikunja.io/api/pkg/log"
 	"code.vikunja.io/api/pkg/models"
 	auth2 "code.vikunja.io/api/pkg/modules/auth"
 	"code.vikunja.io/api/pkg/web/handler"
@@ -160,13 +159,11 @@ func GetTaskAttachment(c echo.Context) error {
 		return handler.HandleHTTPError(err)
 	}
 
-	// If the preview query parameter is set and the preview was already generated and cached, return the cached preview image
+	// If the preview query parameter is set, get the preview (cached or generate)
 	previewSize := models.GetPreviewSizeFromString(c.QueryParam("preview_size"))
 	if previewSize != models.PreviewSizeUnknown && strings.HasPrefix(taskAttachment.File.Mime, "image") {
-		previewFileBytes := taskAttachment.GetPreviewFromCache(previewSize)
+		previewFileBytes := taskAttachment.GetPreview(previewSize)
 		if previewFileBytes != nil {
-			log.Debugf("Cached attachment image preview found for task attachment %v", taskAttachment.ID)
-
 			return c.Blob(http.StatusOK, "image/png", previewFileBytes)
 		}
 	}
@@ -181,14 +178,6 @@ func GetTaskAttachment(c echo.Context) error {
 	if err := s.Commit(); err != nil {
 		_ = s.Rollback()
 		return handler.HandleHTTPError(err)
-	}
-
-	// If a preview is requested and the preview was not cached, we create the preview and cache it
-	if previewSize != models.PreviewSizeUnknown {
-		previewFileBytes := taskAttachment.GenerateAndSavePreviewToCache(previewSize)
-		if previewFileBytes != nil {
-			return c.Blob(http.StatusOK, "image/png", previewFileBytes)
-		}
 	}
 
 	http.ServeContent(c.Response(), c.Request(), taskAttachment.File.Name, taskAttachment.File.Created, taskAttachment.File.File)


### PR DESCRIPTION
## Summary
- implement `keyvalue.Remember` helper
- add unit tests for `Remember`

## Testing
- `mage lint:fix`
- `pnpm lint:fix`
- `go test ./pkg/modules/keyvalue -run Remember -v`


------
https://chatgpt.com/codex/tasks/task_e_686e185bde788322ba4897472d2cd6fe