### PR TITLE
feat(task): autosave description on route leave

### DIFF
--- a/frontend/cypress/e2e/task/task.spec.ts
+++ b/frontend/cypress/e2e/task/task.spec.ts
@@ -298,11 +298,9 @@ describe('Task', () => {
 				description: 'Old Description',
 			})
 
-			cy.intercept('POST', `${Cypress.env('API_URL')}/tasks/1`).as('updateTask')
-
 			cy.visit('/tasks/1')
 			
-			cy.get('.task-view .details.content.description .tiptap button.done-edit')
+			cy.get('.task-view .details.content.description .tiptap button.done-edit', {timeout: 30_000})
 				.click()
 			cy.get('.task-view .details.content.description .tiptap__editor .tiptap.ProseMirror')
 				.type('{selectall}New Description')
@@ -310,8 +308,6 @@ describe('Task', () => {
 			cy.get('.task-view h6.subtitle a')
 				.first()
 				.click()
-			
-			cy.wait('@updateTask')
 			
 			cy.visit('/tasks/1')
 			cy.get('.task-view .details.content.description')

--- a/frontend/cypress/e2e/task/task.spec.ts
+++ b/frontend/cypress/e2e/task/task.spec.ts
@@ -271,12 +271,12 @@ describe('Task', () => {
 				.should('contain', `${projects[0].identifier}-${tasks[0].index}`)
 		})
 
-		it('Can edit the description', () => {
-			const tasks = TaskFactory.create(1, {
-				id: 1,
-				description: 'Lorem ipsum dolor sit amet.',
-			})
-			cy.visit(`/tasks/${tasks[0].id}`)
+                it('Can edit the description', () => {
+                        const tasks = TaskFactory.create(1, {
+                                id: 1,
+                                description: 'Lorem ipsum dolor sit amet.',
+                        })
+                        cy.visit(`/tasks/${tasks[0].id}`)
 
 			cy.get('.task-view .details.content.description .tiptap button.done-edit')
 				.click()
@@ -286,10 +286,37 @@ describe('Task', () => {
 				.contains('Save')
 				.click()
 
-			cy.get('.task-view .details.content.description h3 span.is-small.has-text-success')
-				.contains('Saved!')
-				.should('exist')
-		})
+                        cy.get('.task-view .details.content.description h3 span.is-small.has-text-success')
+                                .contains('Saved!')
+                                .should('exist')
+                })
+
+                it('autosaves the description when leaving the task view', () => {
+                        TaskFactory.create(1, {
+                                id: 1,
+                                project_id: projects[0].id,
+                                description: 'Old Description',
+                        })
+
+                        cy.intercept('POST', `${Cypress.env('API_URL')}/tasks/1`).as('updateTask')
+
+                        cy.visit('/tasks/1')
+
+                        cy.get('.task-view .details.content.description .tiptap button.done-edit')
+                                .click()
+                        cy.get('.task-view .details.content.description .tiptap__editor .tiptap.ProseMirror')
+                                .type('{selectall}New Description')
+
+                        cy.get('.task-view h6.subtitle a')
+                                .first()
+                                .click()
+
+                        cy.wait('@updateTask')
+
+                        cy.visit('/tasks/1')
+                        cy.get('.task-view .details.content.description')
+                                .should('contain.text', 'New Description')
+                })
 
 		it('Shows an empty editor when the description of a task is empty', () => {
 			const tasks = TaskFactory.create(1, {

--- a/frontend/cypress/e2e/task/task.spec.ts
+++ b/frontend/cypress/e2e/task/task.spec.ts
@@ -316,7 +316,7 @@ describe('Task', () => {
 			cy.visit('/tasks/1')
 			cy.get('.task-view .details.content.description')
 				.should('contain.text', 'New Description')
-})
+		})
 
 		it('Shows an empty editor when the description of a task is empty', () => {
 			const tasks = TaskFactory.create(1, {

--- a/frontend/cypress/e2e/task/task.spec.ts
+++ b/frontend/cypress/e2e/task/task.spec.ts
@@ -271,12 +271,12 @@ describe('Task', () => {
 				.should('contain', `${projects[0].identifier}-${tasks[0].index}`)
 		})
 
-                it('Can edit the description', () => {
-                        const tasks = TaskFactory.create(1, {
-                                id: 1,
-                                description: 'Lorem ipsum dolor sit amet.',
-                        })
-                        cy.visit(`/tasks/${tasks[0].id}`)
+		it('Can edit the description', () => {
+			const tasks = TaskFactory.create(1, {
+				id: 1,
+				description: 'Lorem ipsum dolor sit amet.',
+			})
+			cy.visit(`/tasks/${tasks[0].id}`)
 
 			cy.get('.task-view .details.content.description .tiptap button.done-edit')
 				.click()
@@ -286,37 +286,37 @@ describe('Task', () => {
 				.contains('Save')
 				.click()
 
-                        cy.get('.task-view .details.content.description h3 span.is-small.has-text-success')
-                                .contains('Saved!')
-                                .should('exist')
-                })
+			cy.get('.task-view .details.content.description h3 span.is-small.has-text-success')
+				.contains('Saved!')
+				.should('exist')
+		})
 
-                it('autosaves the description when leaving the task view', () => {
-                        TaskFactory.create(1, {
-                                id: 1,
-                                project_id: projects[0].id,
-                                description: 'Old Description',
-                        })
+		it('autosaves the description when leaving the task view', () => {
+			TaskFactory.create(1, {
+				id: 1,
+				project_id: projects[0].id,
+				description: 'Old Description',
+			})
 
-                        cy.intercept('POST', `${Cypress.env('API_URL')}/tasks/1`).as('updateTask')
+			cy.intercept('POST', `${Cypress.env('API_URL')}/tasks/1`).as('updateTask')
 
-                        cy.visit('/tasks/1')
-
-                        cy.get('.task-view .details.content.description .tiptap button.done-edit')
-                                .click()
-                        cy.get('.task-view .details.content.description .tiptap__editor .tiptap.ProseMirror')
-                                .type('{selectall}New Description')
-
-                        cy.get('.task-view h6.subtitle a')
-                                .first()
-                                .click()
-
-                        cy.wait('@updateTask')
-
-                        cy.visit('/tasks/1')
-                        cy.get('.task-view .details.content.description')
-                                .should('contain.text', 'New Description')
-                })
+			cy.visit('/tasks/1')
+			
+			cy.get('.task-view .details.content.description .tiptap button.done-edit')
+				.click()
+			cy.get('.task-view .details.content.description .tiptap__editor .tiptap.ProseMirror')
+				.type('{selectall}New Description')
+			
+			cy.get('.task-view h6.subtitle a')
+				.first()
+				.click()
+			
+			cy.wait('@updateTask')
+			
+			cy.visit('/tasks/1')
+			cy.get('.task-view .details.content.description')
+				.should('contain.text', 'New Description')
+})
 
 		it('Shows an empty editor when the description of a task is empty', () => {
 			const tasks = TaskFactory.create(1, {

--- a/frontend/src/components/tasks/partials/Description.vue
+++ b/frontend/src/components/tasks/partials/Description.vue
@@ -95,10 +95,7 @@ onBeforeUnmount(() => {
 	window.removeEventListener('beforeunload', save)
 })
 
-onBeforeRouteLeave(() => {
-	// Save the latest changes before leaving the route
-	void save()
-})
+onBeforeRouteLeave(() => save())
 
 async function save() {
 	if (changeTimeout.value !== null) {

--- a/frontend/src/components/tasks/partials/Description.vue
+++ b/frontend/src/components/tasks/partials/Description.vue
@@ -38,7 +38,8 @@
 </template>
 
 <script setup lang="ts">
-import {ref, computed, watchEffect, onBeforeUnmount} from 'vue'
+import {ref, computed, watchEffect, onMounted, onBeforeUnmount} from 'vue'
+import {onBeforeRouteLeave} from 'vue-router'
 
 import CustomTransition from '@/components/misc/CustomTransition.vue'
 import Editor from '@/components/input/AsyncEditor'
@@ -73,6 +74,10 @@ const loading = computed(() => taskStore.isLoading)
 
 const changeTimeout = ref<ReturnType<typeof setTimeout> | null>(null)
 
+onMounted(() => {
+	window.addEventListener('beforeunload', save)
+})
+
 async function saveWithDelay() {
 	if (changeTimeout.value !== null) {
 		clearTimeout(changeTimeout.value)
@@ -87,6 +92,12 @@ onBeforeUnmount(() => {
 	if (changeTimeout.value !== null) {
 		clearTimeout(changeTimeout.value)
 	}
+	window.removeEventListener('beforeunload', save)
+})
+
+onBeforeRouteLeave(() => {
+	// Save the latest changes before leaving the route
+	void save()
 })
 
 async function save() {

--- a/frontend/src/components/tasks/partials/Description.vue
+++ b/frontend/src/components/tasks/partials/Description.vue
@@ -115,6 +115,13 @@ async function save() {
 		setTimeout(() => {
 			saved.value = false
 		}, 2000)
+	} catch (error) {
+		// If the task was deleted (404), silently skip saving
+		if (error?.response?.status === 404) {
+			return
+		}
+		// Re-throw other errors
+		throw error
 	} finally {
 		saving.value = false
 	}


### PR DESCRIPTION
Resolves https://community.vikunja.io/t/autosave-issue-fields/3899/2

## Summary
- autosave the description when leaving the task view or closing the tab
- test autosaving the description by navigating away

## Testing
- `mage lint:fix`
- `pnpm lint:fix`
- `pnpm test:e2e` *(fails: Browser chrome was not found)*

------
https://chatgpt.com/codex/tasks/task_e_687629cc967083229d21315dc276e226