### PR TITLE
Filter background brightness to 60%

### DIFF
--- a/frontend/src/styles/theme/background.scss
+++ b/frontend/src/styles/theme/background.scss
@@ -55,6 +55,6 @@
 
   &.is-visible {
     opacity: 1;
-    filter: brightness(40%);
+    filter: brightness(60%);
   }
 }


### PR DESCRIPTION
Before:

<img width="4008" height="2170" alt="image" src="https://github.com/user-attachments/assets/4ccced01-ecab-447b-97df-1e6c45f78480" />

I bet it's a little too bright that can't focus on cards.

After:

<img width="4008" height="2170" alt="image" src="https://github.com/user-attachments/assets/9f6d4692-05c9-4851-958e-830918d45793" />

Or simply allow user to edit it.
