### PR TITLE
fix "null" in project views

### DIFF
--- a/pkg/modules/dump/restore.go
+++ b/pkg/modules/dump/restore.go
@@ -228,7 +228,7 @@ func convertFieldValue(fieldName string, value interface{}, isFloat bool) (inter
 		if v == "null" {
 			return nil, nil
 		}
-		
+				
 		decoded, err := base64.StdEncoding.DecodeString(v)
 		if err != nil {
 			var corruptErr base64.CorruptInputError

--- a/pkg/modules/dump/restore.go
+++ b/pkg/modules/dump/restore.go
@@ -224,6 +224,11 @@ func convertFieldValue(fieldName string, value interface{}, isFloat bool) (inter
 	// Handle JSON fields (non-float)
 	switch v := value.(type) {
 	case string:
+		// Check if the string is "null" and return nil for SQL NULL
+		if v == "null" {
+			return nil, nil
+		}
+		
 		decoded, err := base64.StdEncoding.DecodeString(v)
 		if err != nil {
 			var corruptErr base64.CorruptInputError

--- a/pkg/modules/dump/restore.go
+++ b/pkg/modules/dump/restore.go
@@ -228,7 +228,7 @@ func convertFieldValue(fieldName string, value interface{}, isFloat bool) (inter
 		if v == "null" {
 			return nil, nil
 		}
-				
+
 		decoded, err := base64.StdEncoding.DecodeString(v)
 		if err != nil {
 			var corruptErr base64.CorruptInputError

--- a/pkg/modules/dump/restore.go
+++ b/pkg/modules/dump/restore.go
@@ -224,8 +224,8 @@ func convertFieldValue(fieldName string, value interface{}, isFloat bool) (inter
 	// Handle JSON fields (non-float)
 	switch v := value.(type) {
 	case string:
-		// Check if the string is "null" and return nil for SQL NULL
-		if v == "null" {
+		// Check if the string is "null" (case insensitive) and return nil for SQL NULL
+		if strings.ToLower(v) == "null" {
 			return nil, nil
 		}
 

--- a/pkg/modules/dump/restore_test.go
+++ b/pkg/modules/dump/restore_test.go
@@ -140,7 +140,7 @@ func TestConvertFieldValue(t *testing.T) {
 		t.Run("should handle zero float value", func(t *testing.T) {
 			result, err := convertFieldValue("position", 0.0, true)
 			require.NoError(t, err)
-			assert.Equal(t, 0.0, result)
+			assert.InDelta(t, 0.0, result, 0.0001)
 		})
 
 		t.Run("should handle negative float value", func(t *testing.T) {

--- a/pkg/modules/dump/restore_test.go
+++ b/pkg/modules/dump/restore_test.go
@@ -80,6 +80,24 @@ func TestConvertFieldValue(t *testing.T) {
 			assert.JSONEq(t, jsonData, result.(string))
 		})
 
+		t.Run("should return nil for 'null' string", func(t *testing.T) {
+			result, err := convertFieldValue("bucket_configuration", "null", false)
+			require.NoError(t, err)
+			assert.Nil(t, result)
+		})
+
+		t.Run("should return nil for 'NULL' string", func(t *testing.T) {
+			result, err := convertFieldValue("bucket_configuration", "NULL", false)
+			require.NoError(t, err)
+			assert.Nil(t, result)
+		})
+
+		t.Run("should return nil for 'Null' string", func(t *testing.T) {
+			result, err := convertFieldValue("bucket_configuration", "Null", false)
+			require.NoError(t, err)
+			assert.Nil(t, result)
+		})
+
 		t.Run("should return error for non-string type", func(t *testing.T) {
 			_, err := convertFieldValue("permissions", 123, false)
 			require.Error(t, err)
@@ -103,6 +121,32 @@ func TestConvertFieldValue(t *testing.T) {
 			result, err := convertFieldValue("permissions", invalidBase64, false)
 			require.NoError(t, err)
 			assert.Equal(t, invalidBase64, result)
+		})
+	})
+
+	t.Run("Edge cases", func(t *testing.T) {
+		t.Run("should handle empty string for JSON field", func(t *testing.T) {
+			result, err := convertFieldValue("permissions", "", false)
+			require.NoError(t, err)
+			assert.Empty(t, result)
+		})
+
+		t.Run("should handle empty string for float field", func(t *testing.T) {
+			_, err := convertFieldValue("position", "", true)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "could not parse double value")
+		})
+
+		t.Run("should handle zero float value", func(t *testing.T) {
+			result, err := convertFieldValue("position", 0.0, true)
+			require.NoError(t, err)
+			assert.Equal(t, 0.0, result)
+		})
+
+		t.Run("should handle negative float value", func(t *testing.T) {
+			result, err := convertFieldValue("position", -123.45, true)
+			require.NoError(t, err)
+			assert.InEpsilon(t, -123.45, result, 0.0001)
 		})
 	})
 }


### PR DESCRIPTION
Table project_views contains NULL which was decoded to weird UTF-8 characters and compledtely broke the app. 

<img width="855" height="480" alt="grafik" src="https://github.com/user-attachments/assets/d3768ab6-e824-4392-9a7d-75ffe3b80265" />


This command fixed my DB:
```bash
sqlite3 vikunja.db "UPDATE project_views SET bucket_configuration = NULL;"
```

Adding this null check ensures "null" is treated as actual null.

Please again review thorougly, I'm not a go dev and that `nil` is only based on my research.