### PR TITLE
chore: rename user_id field to username

### DIFF
--- a/frontend/src/components/sharing/UserTeam.vue
+++ b/frontend/src/components/sharing/UserTeam.vue
@@ -282,7 +282,7 @@ async function load() {
 
 async function deleteSharable() {
 	if (props.shareType === 'user') {
-		stuffModel.userId = sharable.value.username
+		stuffModel.username = sharable.value.username
 	} else if (props.shareType === 'team') {
 		stuffModel.teamId = sharable.value.id
 	}
@@ -291,7 +291,7 @@ async function deleteSharable() {
 	showDeleteModal.value = false
 	for (const i in sharables.value) {
 		if (
-			(sharables.value[i].username === stuffModel.userId && props.shareType === 'user') ||
+			(sharables.value[i].username === stuffModel.username && props.shareType === 'user') ||
 			(sharables.value[i].id === stuffModel.teamId && props.shareType === 'team')
 		) {
 			sharables.value.splice(i, 1)
@@ -315,7 +315,7 @@ async function add(admin) {
 	}
 
 	if (props.shareType === 'user') {
-		stuffModel.userId = sharable.value.username
+		stuffModel.username = sharable.value.username
 	} else if (props.shareType === 'team') {
 		stuffModel.teamId = sharable.value.id
 	}
@@ -336,7 +336,7 @@ async function toggleType(sharable) {
 	stuffModel.right = selectedRight.value[sharable.id]
 
 	if (props.shareType === 'user') {
-		stuffModel.userId = sharable.username
+		stuffModel.username = sharable.username
 	} else if (props.shareType === 'team') {
 		stuffModel.teamId = sharable.id
 	}
@@ -345,7 +345,7 @@ async function toggleType(sharable) {
 	for (const i in sharables.value) {
 		if (
 			(sharables.value[i].username ===
-				stuffModel.userId &&
+				stuffModel.username &&
 				props.shareType === 'user') ||
 			(sharables.value[i].id === stuffModel.teamId &&
 				props.shareType === 'team')

--- a/frontend/src/modelTypes/IUserShareBase.ts
+++ b/frontend/src/modelTypes/IUserShareBase.ts
@@ -3,7 +3,7 @@ import type {IUser} from './IUser'
 import type {Right} from '@/constants/rights'
 
 export interface IUserShareBase extends IAbstract {
-	userId: IUser['id']
+	username: IUser['username']
 	right: Right
 
 	created: Date

--- a/frontend/src/models/userShareBase.ts
+++ b/frontend/src/models/userShareBase.ts
@@ -5,7 +5,7 @@ import type {IUserShareBase} from '@/modelTypes/IUserShareBase'
 import type {IUser} from '@/modelTypes/IUser'
 
 export default class UserShareBaseModel extends AbstractModel<IUserShareBase> implements IUserShareBase {
-	userId: IUser['id'] = ''
+	username: IUser['username'] = ''
 	right: Right = RIGHTS.READ
 
 	created: Date = null

--- a/frontend/src/services/userProject.ts
+++ b/frontend/src/services/userProject.ts
@@ -8,8 +8,8 @@ export default class UserProjectService extends AbstractService<IUserProject> {
 		super({
 			create: '/projects/{projectId}/users',
 			getAll: '/projects/{projectId}/users',
-			update: '/projects/{projectId}/users/{userId}',
-			delete: '/projects/{projectId}/users/{userId}',
+			update: '/projects/{projectId}/users/{username}',
+			delete: '/projects/{projectId}/users/{username}',
 		})
 	}
 

--- a/pkg/models/project_team.go
+++ b/pkg/models/project_team.go
@@ -20,10 +20,9 @@ import (
 	"time"
 
 	"code.vikunja.io/api/pkg/db"
-
 	"code.vikunja.io/api/pkg/events"
-
 	"code.vikunja.io/api/pkg/web"
+
 	"xorm.io/xorm"
 )
 

--- a/pkg/models/project_users.go
+++ b/pkg/models/project_users.go
@@ -20,11 +20,10 @@ import (
 	"time"
 
 	"code.vikunja.io/api/pkg/db"
-
 	"code.vikunja.io/api/pkg/events"
-
 	"code.vikunja.io/api/pkg/user"
 	"code.vikunja.io/api/pkg/web"
+
 	"xorm.io/xorm"
 )
 
@@ -33,7 +32,7 @@ type ProjectUser struct {
 	// The unique, numeric id of this project <-> user relation.
 	ID int64 `xorm:"bigint autoincr not null unique pk" json:"id"`
 	// The username.
-	Username string `xorm:"-" json:"user_id" param:"user"`
+	Username string `xorm:"-" json:"username" param:"user"`
 	// Used internally to reference the user
 	UserID int64 `xorm:"bigint not null INDEX" json:"-"`
 	// The project id.


### PR DESCRIPTION
The field is actually the username, but it was called user_id for some reason. This change makes this more clear