### PR TITLE
fix: normalize frontend version string

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN npm install -g corepack && corepack enable && \
     pnpm install --frozen-lockfile
 COPY frontend/ ./
 ARG RELEASE_VERSION=dev
-RUN echo "{\"VERSION\": \"$RELEASE_VERSION\"}" > src/version.json && pnpm run build
+RUN echo "{\"VERSION\": \"${RELEASE_VERSION/-g/-}\"}" > src/version.json && pnpm run build
 
 FROM --platform=$BUILDPLATFORM ghcr.io/techknowlogick/xgo:go-1.23.x@sha256:37bfe9dccce00f473c55369be10018e5c8f653409d5c5e5467b1a3be06318652 AS apibuilder
 


### PR DESCRIPTION
## Summary
- normalize frontend version string in Docker build to match API format

## Testing
- `mage lint:fix`
- `pnpm lint:fix`
- `pnpm lint:styles:fix`


------
https://chatgpt.com/codex/tasks/task_e_689c6c20f75c8322800ed77fe30df70e