### PR TITLE
fix(frontend): add missing permission translation keys

### DIFF
--- a/frontend/src/i18n/lang/en.json
+++ b/frontend/src/i18n/lang/en.json
@@ -336,12 +336,6 @@
         "addedSuccess": "The {type} was successfully added.",
         "updatedSuccess": "The {type} was successfully added."
       },
-      "right": {
-        "title": "Permission",
-        "read": "Read only",
-        "readWrite": "Read & write",
-        "admin": "Admin"
-      },
       "permission": {
         "title": "Permission",
         "read": "Read only",

--- a/frontend/src/i18n/lang/en.json
+++ b/frontend/src/i18n/lang/en.json
@@ -342,6 +342,12 @@
         "readWrite": "Read & write",
         "admin": "Admin"
       },
+      "permission": {
+        "title": "Permission",
+        "read": "Read only",
+        "readWrite": "Read & write",
+        "admin": "Admin"
+      },
       "attributes": {
         "link": "Link",
         "delete": "Delete"

--- a/frontend/src/i18n/lang/pl-PL.json
+++ b/frontend/src/i18n/lang/pl-PL.json
@@ -289,18 +289,6 @@
 				"addedSuccess": "{type} został pomyślnie dodany.",
 				"updatedSuccess": "{type} został pomyślnie zaktualizowany."
 			},
-			"right": {
-				"title": "Uprawnienia",
-				"read": "Tylko do odczytu",
-				"readWrite": "Odczyt i zapis",
-				"admin": "Administracja"
-			},
-			"permission": {
-				"title": "Uprawnienia",
-				"read": "Tylko do odczytu",
-				"readWrite": "Odczyt i zapis",
-				"admin": "Administracja"
-			},
 			"attributes": {
 				"link": "Link",
 				"delete": "Usuń"

--- a/frontend/src/i18n/lang/pl-PL.json
+++ b/frontend/src/i18n/lang/pl-PL.json
@@ -289,6 +289,12 @@
 				"addedSuccess": "{type} został pomyślnie dodany.",
 				"updatedSuccess": "{type} został pomyślnie zaktualizowany."
 			},
+			"permission": {
+				"title": "Uprawnienie",
+				"read": "Tylko do odczytu",
+				"readWrite": "Odczyt i zapis",
+				"admin": "Administrator"
+			},
 			"attributes": {
 				"link": "Link",
 				"delete": "Usuń"

--- a/frontend/src/i18n/lang/pl-PL.json
+++ b/frontend/src/i18n/lang/pl-PL.json
@@ -290,16 +290,16 @@
 				"updatedSuccess": "{type} został pomyślnie zaktualizowany."
 			},
 			"right": {
-				"title": "Uprawnienie",
+				"title": "Uprawnienia",
 				"read": "Tylko do odczytu",
 				"readWrite": "Odczyt i zapis",
-				"admin": "Administrator"
+				"admin": "Administracja"
 			},
 			"permission": {
-				"title": "Uprawnienie",
+				"title": "Uprawnienia",
 				"read": "Tylko do odczytu",
 				"readWrite": "Odczyt i zapis",
-				"admin": "Administrator"
+				"admin": "Administracja"
 			},
 			"attributes": {
 				"link": "Link",

--- a/frontend/src/i18n/lang/pl-PL.json
+++ b/frontend/src/i18n/lang/pl-PL.json
@@ -295,6 +295,12 @@
 				"readWrite": "Odczyt i zapis",
 				"admin": "Administrator"
 			},
+			"permission": {
+				"title": "Uprawnienie",
+				"read": "Tylko do odczytu",
+				"readWrite": "Odczyt i zapis",
+				"admin": "Administrator"
+			},
 			"attributes": {
 				"link": "Link",
 				"delete": "Usuń"

--- a/frontend/src/i18n/lang/pl-PL.json
+++ b/frontend/src/i18n/lang/pl-PL.json
@@ -289,7 +289,7 @@
 				"addedSuccess": "{type} został pomyślnie dodany.",
 				"updatedSuccess": "{type} został pomyślnie zaktualizowany."
 			},
-			"permission": {
+			"right": {
 				"title": "Uprawnienie",
 				"read": "Tylko do odczytu",
 				"readWrite": "Odczyt i zapis",


### PR DESCRIPTION
Added missing 'permission' section to both English and Polish translation files for project sharing permissions. This resolves the issue where permission labels were showing as raw keys (project.share.permission.readWrite) instead of translated text.

The permission section duplicates the existing 'right' section to maintain compatibility with components that reference either naming convention.

This PR fixes : https://github.com/go-vikunja/vikunja/issues/1319

The issue is resolved after fix :
<img width="796" height="157" alt="obraz" src="https://github.com/user-attachments/assets/606e05d8-73dd-4e1a-89e5-5fc86e9d50d8" />
