### PR TITLE
fix: mobile device  minimum width

### DIFF
--- a/frontend/src/styles/common-imports.scss
+++ b/frontend/src/styles/common-imports.scss
@@ -15,8 +15,8 @@ $family-sans-serif: 'Open Sans', Helvetica, Arial, sans-serif;
 // the default values get overwritten by the definitions above
 @import "bulma-css-variables/sass/utilities/_all";
 
-// since $tablet is defined by bulma we can just define it after importing the utilities
-$mobile: math.div($tablet, 2);
+// mobile minimum width
+$mobile: 320px;
 
 $vikunja-font: 'Quicksand', sans-serif;
 


### PR DESCRIPTION
## Description of bug
The mobile breakpoint is set to an arbitrary value by dividing the tablet size by two (384.5px).However, many mainstream devices, such as the iPhone SE, have a smaller width. I suggest a minimum width of 320, which will fit 99% of mobile devices.  

## Before fix ( You have to scroll down a whole page to get to your tasks)
<img width="418" height="726" alt="Screenshot 2025-08-24 at 12 11 17" src="https://github.com/user-attachments/assets/ced86fad-5143-40ed-8aed-bd2731b8136f" />

## After fix
<img width="431" height="728" alt="Screenshot 2025-08-24 at 12 02 29" src="https://github.com/user-attachments/assets/735bea85-c7e5-4edd-9f0b-2f35780a453c" />

