### PR TITLE
fix: stop event propagation for clicks inside the DeferTask popup

### DIFF
--- a/frontend/src/components/tasks/partials/DeferTask.vue
+++ b/frontend/src/components/tasks/partials/DeferTask.vue
@@ -2,6 +2,10 @@
 	<div
 		:class="{ 'is-loading': taskService.loading }"
 		class="defer-task loading-container"
+		@click.stop
+		@mousedown.stop
+		@pointerdown.stop
+		@touchstart.stop
 	>
 		<label class="label">{{ $t('task.deferDueDate.title') }}</label>
 		<div class="defer-days">


### PR DESCRIPTION
## Description of bug
When using the DeferTask pop-up component, you are often redirected to the task because clicks propagate outside the components (see video below)

## Before fix
https://github.com/user-attachments/assets/47e2e3db-2ccc-4b04-8a72-e33bd0fa0432

## After fix
https://github.com/user-attachments/assets/7cb2e0ab-1d3b-4af4-bb7e-384de3783be0

