### PR TITLE
fix: show error when user list filter is empty

### DIFF
--- a/pkg/cmd/user.go
+++ b/pkg/cmd/user.go
@@ -143,13 +143,14 @@ var userListCmd = &cobra.Command{
 
 		if userFlagEmail != "" {
 			u, err := user.GetUserWithEmail(s, &user.User{Email: userFlagEmail})
-			if err != nil && !user.IsErrUserDoesNotExist(err) {
+			if err != nil {
+				if user.IsErrUserDoesNotExist(err) {
+					log.Fatalf("No user found with email %s", userFlagEmail)
+				}
 				log.Fatalf("Error getting user: %s", err)
 			}
 
-			if u != nil {
-				users = []*user.User{u}
-			}
+			users = []*user.User{u}
 		} else {
 			var err error
 			users, err = user.ListAllUsers(s)


### PR DESCRIPTION
## Summary
- return an error when `user list` with an email filter finds no matching users

## Testing
- `mage fmt`
- `mage lint:fix` *(fails: go1.24 build of golangci-lint lower than targeted Go version 1.25)*
- `mage test:filter cmd`


------
https://chatgpt.com/codex/tasks/task_e_68b56a12358083229d2ac04ed76b4e95