### PR TITLE
fix(frontend): hide drag handle for fixed project lists

### DIFF
--- a/frontend/src/components/home/ProjectsNavigation.vue
+++ b/frontend/src/components/home/ProjectsNavigation.vue
@@ -26,6 +26,7 @@
 				:project="project"
 				:is-loading="projectUpdating[project.id]"
 				:can-collapse="canCollapse"
+				:can-edit-order="canEditOrder"
 				:data-project-id="project.id"
 			/>
 		</template>

--- a/frontend/src/components/home/ProjectsNavigationItem.vue
+++ b/frontend/src/components/home/ProjectsNavigationItem.vue
@@ -15,7 +15,7 @@
 				/>
 			</BaseButton>
 			<span
-				v-if="project.id > 0 && project.maxPermission > PERMISSIONS.READ"
+				v-if="canEditOrder && project.id > 0 && project.maxPermission > PERMISSIONS.READ"
 				class="icon menu-item-icon handle drag-handle-standalone"
 				@mousedown.stop
 				@click.stop.prevent
@@ -100,9 +100,10 @@ import ProjectsNavigation from '@/components/home/ProjectsNavigation.vue'
 import {PERMISSIONS} from '@/constants/permissions'
 
 const props = defineProps<{
-	project: IProject,
-	isLoading?: boolean,
-	canCollapse?: boolean,
+        project: IProject,
+        isLoading?: boolean,
+        canCollapse?: boolean,
+        canEditOrder?: boolean,
 }>()
 
 const projectStore = useProjectStore()

--- a/frontend/src/components/home/ProjectsNavigationItem.vue
+++ b/frontend/src/components/home/ProjectsNavigationItem.vue
@@ -100,10 +100,10 @@ import ProjectsNavigation from '@/components/home/ProjectsNavigation.vue'
 import {PERMISSIONS} from '@/constants/permissions'
 
 const props = defineProps<{
-        project: IProject,
-        isLoading?: boolean,
-        canCollapse?: boolean,
-        canEditOrder?: boolean,
+	project: IProject,
+	isLoading?: boolean,
+	canCollapse?: boolean,
+	canEditOrder?: boolean,
 }>()
 
 const projectStore = useProjectStore()


### PR DESCRIPTION
## Summary
- hide drag handle for non-reorderable project lists like favorites

## Testing
- `pnpm lint:fix`
- `pnpm lint:styles:fix`


------
https://chatgpt.com/codex/tasks/task_e_68b9c088d2f48322b2f4935c70d21000