### PR TITLE
fix: correct case-sensitivity in duedate time parsing

### DIFF
--- a/frontend/src/helpers/time/parseDate.ts
+++ b/frontend/src/helpers/time/parseDate.ts
@@ -109,7 +109,7 @@ const addTimeToDate = (text: string, date: Date, previousMatch: string | null): 
 		}
 	}
 
-	const timeRegex = ' (at|@) ([0-9][0-9]?(:[0-9][0-9]?)?( ?(a|p)m)?)'
+	const timeRegex = ' (at|@) ([0-9][0-9]?(:[0-9][0-9])?( ?(a|p)m)?)'
 	const matcher = new RegExp(timeRegex, 'ig')
 	const results = matcher.exec(text)
 

--- a/frontend/src/helpers/time/parseDate.ts
+++ b/frontend/src/helpers/time/parseDate.ts
@@ -118,7 +118,7 @@ const addTimeToDate = (text: string, date: Date, previousMatch: string | null): 
 		const parts = time.split(':')
 		let hours = parseInt(parts[0])
 		let minutes = 0
-		if (time.endsWith('pm')) {
+		if (time.toLowerCase().endsWith('pm')) {
 			hours += 12
 		}
 		if (parts.length > 1) {
@@ -128,6 +128,7 @@ const addTimeToDate = (text: string, date: Date, previousMatch: string | null): 
 		date.setHours(hours)
 		date.setMinutes(minutes)
 		date.setSeconds(0)
+		date.setMilliseconds(0)
 	}
 
 	const replace = results !== null ? results[0] : previousMatch


### PR DESCRIPTION
This PR resolves the parsing of `PM` (in capitals) which was previously not handled correctly. Fixes #1590.

Also zeroes out the milliseconds value on due dates, for cleanliness.