### PR TITLE
Fix slash menu appearing behind modals

### DIFF
--- a/frontend/src/components/input/editor/suggestion.ts
+++ b/frontend/src/components/input/editor/suggestion.ts
@@ -190,7 +190,7 @@ export default function suggestionSetup(t) {
 					popupElement.style.position = 'absolute'
 					popupElement.style.top = '0'
 					popupElement.style.left = '0'
-					popupElement.style.zIndex = '1000'
+					popupElement.style.zIndex = '4700'
 					popupElement.appendChild(component.element!)
 					document.body.appendChild(popupElement)
 


### PR DESCRIPTION
The slash menu in the editor was appearing behind task detail modals (z-index 4000) because it had a z-index of only 1000. This made the menu inaccessible when editing task descriptions in Kanban view.

Updated the z-index to 4700 to place it above modals while keeping it below system notifications (z-index 9999).

Fixes #1746