### PR TITLE
fix: 403 http error code on failed login

### DIFF
--- a/pkg/user/error.go
+++ b/pkg/user/error.go
@@ -222,7 +222,7 @@ const ErrCodeWrongUsernameOrPassword = 1011
 
 // HTTPError holds the http error description
 func (err ErrWrongUsernameOrPassword) HTTPError() web.HTTPError {
-	return web.HTTPError{HTTPCode: http.StatusPreconditionFailed, Code: ErrCodeWrongUsernameOrPassword, Message: "Wrong username or password."}
+	return web.HTTPError{HTTPCode: http.StatusForbidden, Code: ErrCodeWrongUsernameOrPassword, Message: "Wrong username or password."}
 }
 
 // IsErrWrongUsernameOrPassword checks if an error is a ErrWrongUsernameOrPassword.


### PR DESCRIPTION
Hi,

this PR is doing a minor change to the error code that the API returns back for a failed login, when the wrong username or password is provided.

The swagger docs are reporting to expect a `403` error code, as mentioned here:
https://github.com/go-vikunja/vikunja/blob/59878741659c3f5335acd5bdd96842c69ac0778f/pkg/routes/api/v1/login.go#L45

However it was sending actually sending a `http.StatusPreconditionFailed` (so a `412` code). 

With the change it should now send a `http.StatusForbidden` (so a `403`) as documented (and it makes a bit more sense than `412` as well IMHO).

Reason I noticed it:
Was trying to set up fail2ban with a TOTP enabled account, but manually testing discovered, that even when I put in nonsense values in the first "login stage" (i.e. where you enter user + pass, BEFORE you get the TOTP field displayed), I got a `412` back, instead of a `403`.

The [fail2ban documentation](https://vikunja.io/docs/fail2ban/) also does not need to be updated, it already assumes 400, 403 and 412 as failure codes.

----
And while I was at it, I did a tiny copy/paste error correction on some comments