### PR TITLE
fix: properly quote email sender names containing @ symbols

### DIFF
--- a/pkg/user/user.go
+++ b/pkg/user/user.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/mail"
 	"reflect"
 	"strconv"
 	"time"
@@ -175,7 +176,12 @@ func (u *User) GetName() string {
 
 // GetNameAndFromEmail returns the name and email address for a user. Useful to use in notifications.
 func (u *User) GetNameAndFromEmail() string {
-	return u.GetName() + " via Vikunja <" + config.MailerFromEmail.GetString() + ">"
+	// Use RFC 5322 compliant address formatting to properly handle special characters like @ in names
+	addr := mail.Address{
+		Name:    u.GetName() + " via Vikunja",
+		Address: config.MailerFromEmail.GetString(),
+	}
+	return addr.String()
 }
 
 func (u *User) GetFailedTOTPAttemptsKey() string {


### PR DESCRIPTION
When user names contain @ symbols, the email library fails to parse the sender address format "Name @ Symbol via Vikunja <email@domain.com>". This fix uses Go's net/mail.Address to properly format the sender address according to RFC 5322, which automatically quotes names containing special characters.

Fixes the error: "getting sender address: no FROM address set"