### PR TITLE
chore(i18n): add Traditional Chinese locale and translations

### DIFF
--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -1,11 +1,11 @@
-import {createI18n} from 'vue-i18n'
-import type {PluralizationRule} from 'vue-i18n'
+import type { PluralizationRule } from 'vue-i18n'
+import { createI18n } from 'vue-i18n'
 import langEN from './lang/en.json'
 
+import { loadDayJsLocale } from '@/i18n/useDayjsLanguageSync.ts'
+import dayjs from 'dayjs'
 import localizedFormat from 'dayjs/plugin/localizedFormat'
 import relativeTime from 'dayjs/plugin/relativeTime'
-import dayjs from 'dayjs'
-import {loadDayJsLocale} from '@/i18n/useDayjsLanguageSync.ts'
 
 dayjs.extend(localizedFormat)
 dayjs.extend(relativeTime)
@@ -22,7 +22,8 @@ export const SUPPORTED_LOCALES = {
 	'pl-PL': 'Polski',
 	'nl-NL': 'Nederlands',
 	'pt-PT': 'Português',
-	'zh-CN': '中文',
+	'zh-CN': '简体中文',
+	'zh-TW': '繁體中文',
 	'no-NO': 'Norsk Bokmål',
 	'es-ES': 'Español',
 	'da-DK': 'Dansk',

--- a/frontend/src/i18n/useDayjsLanguageSync.ts
+++ b/frontend/src/i18n/useDayjsLanguageSync.ts
@@ -1,7 +1,7 @@
-import {computed, ref, watch} from 'vue'
 import type dayjs from 'dayjs'
+import { computed, ref, watch } from 'vue'
 
-import {i18n, type ISOLanguage, type SupportedLocale} from '@/i18n'
+import { i18n, type ISOLanguage, type SupportedLocale } from '@/i18n'
 
 export const DAYJS_LOCALE_MAPPING = {
 	'de-de': 'de',
@@ -15,6 +15,7 @@ export const DAYJS_LOCALE_MAPPING = {
 	'nl-nl': 'nl',
 	'pt-pt': 'pt',
 	'zh-cn': 'zh-cn',
+	'zh-tw': 'zh-tw',
 	'no-no': 'nb',
 	'es-es': 'es',
 	'da-dk': 'da',
@@ -45,6 +46,7 @@ export const DAYJS_LANGUAGE_IMPORTS = {
 	'nl-nl': () => import('dayjs/locale/nl'),
 	'pt-pt': () => import('dayjs/locale/pt'),
 	'zh-cn': () => import('dayjs/locale/zh-cn'),
+	'zh-tw': () => import('dayjs/locale/zh-tw'),
 	'no-no': () => import('dayjs/locale/nb'),
 	'es-es': () => import('dayjs/locale/es'),
 	'da-dk': () => import('dayjs/locale/da'),

--- a/pkg/i18n/i18n.go
+++ b/pkg/i18n/i18n.go
@@ -59,6 +59,7 @@ var availableLanguages = map[string]bool{
 	"nl-NL":    true,
 	"pt-PT":    true,
 	"zh-CN":    true,
+	"zh-TW":    true,
 	"no-NO":    true,
 	"es-ES":    true,
 	"da-DK":    true,


### PR DESCRIPTION
## Summary

  Add Traditional Chinese (zh-TW) locale support to Vikunja with complete translation strings. This enables users to access the application in Traditional Chinese alongside the existing Simplified Chinese (zh-CN) option.

  ## Changes

  - **New Locale**: Added `zh-TW` (Traditional Chinese) with 1270+ translation strings covering all UI elements
  - **Locale Names**: Updated display names for clarity - `zh-CN` now shows as "简体中文" (Simplified Chinese) and `zh-TW` as "繁體中文" (Traditional Chinese)

  ## Files Modified

  - `frontend/src/i18n/index.ts` - Added zh-TW support and reorganized imports
  - `frontend/src/i18n/lang/zh-TW.json` - Complete Traditional Chinese translations
  - `frontend/src/i18n/useDayjsLanguageSync.ts` - Import reorganization
  - `pkg/i18n/i18n.go` - Backend i18n support

  ## Test Plan

  - [ ] Verify application loads correctly with zh-TW locale selected
  - [ ] Check that all UI elements display proper Traditional Chinese translations
  - [ ] Test locale switcher can toggle between zh-CN and zh-TW
  - [ ] Verify date/time formatting works correctly in Traditional Chinese
  - [ ] Confirm no console errors or warnings related to locale loading