### PR TITLE
fix(editor): prevent image insertion from triggering save

### DIFF
--- a/frontend/src/components/input/editor/TipTap.vue
+++ b/frontend/src/components/input/editor/TipTap.vue
@@ -632,7 +632,7 @@ function uploadAndInsertFiles(files: File[] | FileList) {
 		
 		editor.value?.commands.setContent(html, false)
 		
-		bubbleSave()
+		bubbleNow()
 	})
 }
 
@@ -663,7 +663,7 @@ async function addImage(event) {
 
 	if (url) {
 		editor.value?.chain().focus().setImage({src: url}).run()
-		bubbleSave()
+		bubbleNow()
 	}
 }
 


### PR DESCRIPTION
Ensure inserting an image only updates editor content without firing implicit save or switching out of edit mode. This keeps user in edit flow and avoids unintended save events.
