### PR TITLE
ci(pr-docker): add disk cleanup and support fork registries

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -47,7 +47,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
-          images: ghcr.io/go-vikunja/vikunja
+          images: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}
           tags: |
             type=ref,event=pr
             type=sha,format=long


### PR DESCRIPTION
Add disk space cleanup step to prevent runner disk exhaustion during Docker builds. Use dynamic repository owner/name for image tags to allow forks to publish to their own registries.