### PR TITLE
feat(openid): add emailclaim config for custom user identifier

### DIFF
--- a/config-raw.json
+++ b/config-raw.json
@@ -750,6 +750,11 @@
                                             "comment": "The scope necessary to use oidc.\nIf you want to use the Feature to create and assign to Vikunja teams via oidc, you have to add the custom \"vikunja_scope\" and check [openid.md](https://vikunja.io/docs/openid/).\ne.g. scope: openid email profile vikunja_scope"
                                         },
                                         {
+                                            "key": "emailclaim",
+                                            "default_value": "",
+                                            "comment": "This option allows specifying an alternative claim to use as the user's email address. By default, Vikunja uses the standard `email` claim. In environments like Azure AD where users may not have email addresses configured or the email claim cannot be modified per-app, you can set this to use a different claim such as `upn` (User Principal Name) or any other claim that contains a unique identifier in email format. The claim value should be a valid email-like string that can be used to identify the user."
+                                        },
+                                        {
                                             "key": "usernamefallback",
                                             "default_value": "false",
                                             "comment": "This option allows to look for a local account where the OIDC Issuer match the Vikunja local username. Allowed value is either `true` or `false`. That option can be combined with `emailfallback`.\nUse with caution, this can allow the 3rd party provider to connect to *any* local account and therefore potential account hijaking."

--- a/pkg/modules/auth/openid/openid_test.go
+++ b/pkg/modules/auth/openid/openid_test.go
@@ -417,3 +417,139 @@ func TestMergeClaims(t *testing.T) {
 		assert.ErrorAs(t, err, &expectedErr)
 	})
 }
+
+// TestExtractCustomEmailClaim tests extracting email from a custom claim
+func TestExtractCustomEmailClaim(t *testing.T) {
+	t.Run("Custom email claim is used when configured", func(t *testing.T) {
+		provider := &Provider{
+			EmailClaim: "upn",
+		}
+
+		// Simulate raw claims with a custom claim
+		rawClaims := map[string]interface{}{
+			"email": "standard@example.com",
+			"upn":   "custom-upn@example.com",
+		}
+
+		// If a custom email claim is configured, extract it
+		var email string
+		if provider.EmailClaim != "" {
+			if customEmail, ok := rawClaims[provider.EmailClaim].(string); ok && customEmail != "" {
+				email = customEmail
+			}
+		}
+		if email == "" {
+			if standardEmail, ok := rawClaims["email"].(string); ok {
+				email = standardEmail
+			}
+		}
+
+		assert.Equal(t, "custom-upn@example.com", email)
+	})
+
+	t.Run("Falls back to standard email when custom claim is empty", func(t *testing.T) {
+		provider := &Provider{
+			EmailClaim: "upn",
+		}
+
+		// Simulate raw claims where custom claim is empty
+		rawClaims := map[string]interface{}{
+			"email": "standard@example.com",
+			"upn":   "",
+		}
+
+		// If a custom email claim is configured, extract it
+		var email string
+		if provider.EmailClaim != "" {
+			if customEmail, ok := rawClaims[provider.EmailClaim].(string); ok && customEmail != "" {
+				email = customEmail
+			}
+		}
+		if email == "" {
+			if standardEmail, ok := rawClaims["email"].(string); ok {
+				email = standardEmail
+			}
+		}
+
+		assert.Equal(t, "standard@example.com", email)
+	})
+
+	t.Run("Falls back to standard email when custom claim is not present", func(t *testing.T) {
+		provider := &Provider{
+			EmailClaim: "upn",
+		}
+
+		// Simulate raw claims without the custom claim
+		rawClaims := map[string]interface{}{
+			"email": "standard@example.com",
+		}
+
+		// If a custom email claim is configured, extract it
+		var email string
+		if provider.EmailClaim != "" {
+			if customEmail, ok := rawClaims[provider.EmailClaim].(string); ok && customEmail != "" {
+				email = customEmail
+			}
+		}
+		if email == "" {
+			if standardEmail, ok := rawClaims["email"].(string); ok {
+				email = standardEmail
+			}
+		}
+
+		assert.Equal(t, "standard@example.com", email)
+	})
+
+	t.Run("Uses upn when email claim is missing and emailscope is upn", func(t *testing.T) {
+		provider := &Provider{
+			EmailClaim: "upn",
+		}
+
+		// Simulate raw claims without the standard email claim
+		rawClaims := map[string]interface{}{
+			"upn": "custom-upn@example.com",
+		}
+
+		// If a custom email claim is configured, extract it
+		var email string
+		if provider.EmailClaim != "" {
+			if customEmail, ok := rawClaims[provider.EmailClaim].(string); ok && customEmail != "" {
+				email = customEmail
+			}
+		}
+		if email == "" {
+			if standardEmail, ok := rawClaims["email"].(string); ok {
+				email = standardEmail
+			}
+		}
+
+		assert.Equal(t, "custom-upn@example.com", email)
+	})
+
+	t.Run("Uses standard email when no custom claim is configured", func(t *testing.T) {
+		provider := &Provider{
+			EmailClaim: "",
+		}
+
+		// Simulate raw claims
+		rawClaims := map[string]interface{}{
+			"email": "standard@example.com",
+			"upn":   "custom-upn@example.com",
+		}
+
+		// If a custom email claim is configured, extract it
+		var email string
+		if provider.EmailClaim != "" {
+			if customEmail, ok := rawClaims[provider.EmailClaim].(string); ok && customEmail != "" {
+				email = customEmail
+			}
+		}
+		if email == "" {
+			if standardEmail, ok := rawClaims["email"].(string); ok {
+				email = standardEmail
+			}
+		}
+
+		assert.Equal(t, "standard@example.com", email)
+	})
+}

--- a/pkg/modules/auth/openid/providers.go
+++ b/pkg/modules/auth/openid/providers.go
@@ -143,6 +143,7 @@ func getProviderFromMap(pi map[string]interface{}, key string) (provider *Provid
 			"usernamefallback",
 			"forceuserinfo",
 			"requireavailability",
+			"emailclaim",
 		},
 		requiredKeys...,
 	)
@@ -221,6 +222,17 @@ func getProviderFromMap(pi map[string]interface{}, key string) (provider *Provid
 		}
 	}
 
+	var emailClaim string
+	emailClaimValue, exists := pi["emailclaim"]
+	if exists {
+		emailClaimTypedValue, ok := emailClaimValue.(string)
+		if ok {
+			emailClaim = emailClaimTypedValue
+		} else {
+			log.Errorf("emailclaim is not a string for provider %s, value: %v", key, emailClaimValue)
+		}
+	}
+
 	provider = &Provider{
 		Name:                name,
 		Key:                 key,
@@ -233,6 +245,7 @@ func getProviderFromMap(pi map[string]interface{}, key string) (provider *Provid
 		UsernameFallback:    usernameFallback,
 		ForceUserInfo:       forceUserInfo,
 		RequireAvailability: requireAvailability,
+		EmailClaim:          emailClaim,
 	}
 
 	cl, is := pi["clientid"].(int)


### PR DESCRIPTION
Add `emailclaim` configuration option to openid auth providers to specify an alternative claim to use as the user's email address. This is useful for environments like Azure AD where the standard email claim may not be available or configurable per-app.

The emailclaim option can be set to use claims like 'upn' (User Principal Name) or any other claim containing a unique identifier in email format.