### PR TITLE
refactor: use gap spacing in Kanban card footer

### DIFF
--- a/frontend/src/components/tasks/partials/KanbanCard.vue
+++ b/frontend/src/components/tasks/partials/KanbanCard.vue
@@ -74,7 +74,6 @@
 					v-if="task.assignees.length > 0"
 					:assignees="task.assignees"
 					:avatar-size="24"
-					class="mie-1"
 				/>
 				<ChecklistSummary
 					:task="task"
@@ -285,15 +284,8 @@ $task-background: var(--white);
 		display: flex;
 		flex-wrap: wrap;
 		align-items: center;
+		gap: .25rem;
 		margin-block-start: .25rem;
-
-		:deep(.tag),
-		:deep(.checklist-summary),
-		.assignees,
-		.icon,
-		.priority-label {
-			margin-inline-end: .25rem;
-		}
 
 		:deep(.checklist-summary) {
 			padding-inline-start: 0;
@@ -310,11 +302,6 @@ $task-background: var(--white);
 					margin: 0;
 				}
 			}
-		}
-
-		// FIXME: should be in Labels.vue
-		:deep(.tag) {
-			margin-inline-start: 0;
 		}
 
 		.priority-label {
@@ -393,7 +380,7 @@ $task-background: var(--white);
 }
 
 .kanban-card__done {
-	margin-inline-end: .25rem;
+	// Spacing handled by parent flex gap
 }
 
 .task-progress {
@@ -406,6 +393,5 @@ $task-background: var(--white);
 	background: var(--grey-100);
 	border-radius: $radius;
 	padding: 0.25rem;
-	margin-inline-end: .25rem;
 }
 </style>


### PR DESCRIPTION
## Summary
Replace individual `margin` properties with CSS `gap` for consistent spacing between footer elements in Kanban cards.

## Changes
- Added `gap: .25rem` to the `.footer` flex container
- Removed all individual `margin-inline-end` rules from footer child elements
- Removed `mie-1` utility class from `AssigneeList` component
- Removed obsolete margin rules from `.kanban-card__done` and `:deep(.comment-count)`

## Benefits
- Cleaner, more maintainable code with a single spacing property
- Consistent spacing in all directions
- Better flex behavior with wrapped content
- Easier to adjust spacing globally

## Test plan
- [ ] Verify Kanban card footer elements have correct spacing
- [ ] Test with different card content (labels, assignees, icons, etc.)
- [ ] Verify spacing remains consistent when elements wrap to new lines
- [ ] Test in both light and dark modes
- [ ] Check cards with custom background colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)