### PR TITLE
fix(frontend): require 1s press-and-hold to drag tasks on mobile

### DIFF
--- a/frontend/src/components/project/views/ProjectKanban.vue
+++ b/frontend/src/components/project/views/ProjectKanban.vue
@@ -338,7 +338,7 @@ const DRAG_OPTIONS = {
 	ghostClass: 'ghost',
 	dragClass: 'task-dragging',
 	delayOnTouchOnly: true,
-	delay: 150,
+	delay: 1000,
 } as const
 
 const MIN_SCROLL_HEIGHT_PERCENT = 0.25

--- a/frontend/src/components/project/views/ProjectList.vue
+++ b/frontend/src/components/project/views/ProjectList.vue
@@ -60,6 +60,8 @@
 							type: 'transition-group'
 						}"
 						:animation="100"
+						:delay-on-touch-only="true"
+						:delay="1000"
 						ghost-class="task-ghost"
 						@start="handleDragStart"
 						@end="saveTaskPosition"


### PR DESCRIPTION
## Summary
- Adds a 1-second press-and-hold delay before drag mode activates on touch devices
- Allows users to tap tasks to open them on mobile without accidentally triggering drag mode
- Only affects touch devices (desktop behavior unchanged via `delayOnTouchOnly`)

Fixes #1986

## Test plan
- [ ] On mobile/touch device: tap a task → should open the task detail view
- [ ] On mobile/touch device: press and hold a task for 1 second → should enter drag mode
- [ ] On desktop: drag behavior should remain unchanged (no delay)
- [ ] Test on both List view and Kanban view