### PR TITLE
feat: implement executor features for read users via config

### DIFF
--- a/config-raw.json
+++ b/config-raw.json
@@ -134,6 +134,16 @@
                     "comment": "Enables the public team feature. If enabled, it is possible to configure teams to be public, which makes them\ndiscoverable when sharing a project, therefore not only showing teams the user is member of."
                 },
                 {
+                    "key": "enablereadercomments",
+                    "default_value": "true",
+                    "comment": "Whether to enable comments for users with read access."
+                },
+                {
+                    "key": "enableassigneeedit",
+                    "default_value": "true",
+                    "comment": "Whether to enable task editing for users with read access who are assigned to the task."
+                },
+                {
                     "key": "bcryptrounds",
                     "default_value": "11",
                     "comment": "The number of bcrypt rounds to use during registration. Each increment of this number doubles the computational cost. You probably don't need to change this value."

--- a/frontend/src/components/project/views/ProjectKanban.vue
+++ b/frontend/src/components/project/views/ProjectKanban.vue
@@ -434,7 +434,9 @@ const bucketDraggableComponentData = computed(() => ({
 }))
 const project = computed(() => projectId.value ? projectStore.projects[projectId.value] : null)
 const view = computed(() => project.value?.views.find(v => v.id === props.viewId) as IProjectView || null)
-const canWrite = computed(() => baseStore.currentProject?.maxPermission > Permissions.READ && view.value.bucketConfigurationMode === 'manual')
+const canWrite = computed(() => {
+	return baseStore.currentProject?.maxPermission > Permissions.READ && view.value.bucketConfigurationMode === 'manual'
+})
 const canCreateTasks = computed(() => canWrite.value && projectId.value > 0)
 const buckets = computed(() => kanbanStore.buckets)
 const loading = computed(() => kanbanStore.isLoading)

--- a/frontend/src/stores/config.ts
+++ b/frontend/src/stores/config.ts
@@ -43,6 +43,8 @@ export interface ConfigState {
 		},
 	},
 	publicTeamsEnabled: boolean,
+	readerCommentsEnabled: boolean,
+	assigneeEditEnabled: boolean,
 }
 
 export const useConfigStore = defineStore('config', () => {
@@ -81,6 +83,8 @@ export const useConfigStore = defineStore('config', () => {
 			},
 		},
 		publicTeamsEnabled: false,
+		readerCommentsEnabled: false,
+		assigneeEditEnabled: false,
 	})
 
 	const migratorsEnabled = computed(() => state.availableMigrators?.length > 0)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -69,6 +69,8 @@ const (
 	ServiceEnablePublicTeams              Key = `service.enablepublicteams`
 	ServiceBcryptRounds                   Key = `service.bcryptrounds`
 	ServiceEnableOpenIDTeamUserOnlySearch Key = `service.enableopenidteamusersearch`
+	ServiceEnableReaderComments           Key = `service.enablereadercomments`
+	ServiceEnableAssigneeEdit             Key = `service.enableassigneeedit`
 
 	SentryEnabled         Key = `sentry.enabled`
 	SentryDsn             Key = `sentry.dsn`
@@ -356,6 +358,8 @@ func InitDefaultConfig() {
 	ServiceEnablePublicTeams.setDefault(false)
 	ServiceBcryptRounds.setDefault(11)
 	ServiceEnableOpenIDTeamUserOnlySearch.setDefault(false)
+	ServiceEnableReaderComments.setDefault(false)
+	ServiceEnableAssigneeEdit.setDefault(false)
 
 	// Sentry
 	SentryDsn.setDefault("https://440eedc957d545a795c17bbaf477497c@o1047380.ingest.sentry.io/4504254983634944")

--- a/pkg/models/task_comment_permissions.go
+++ b/pkg/models/task_comment_permissions.go
@@ -17,6 +17,7 @@
 package models
 
 import (
+	"code.vikunja.io/api/pkg/config"
 	"code.vikunja.io/api/pkg/web"
 	"xorm.io/xorm"
 )
@@ -67,5 +68,15 @@ func (tc *TaskComment) CanUpdate(s *xorm.Session, a web.Auth) (bool, error) {
 // CanCreate checks if a user can create a new comment
 func (tc *TaskComment) CanCreate(s *xorm.Session, a web.Auth) (bool, error) {
 	t := Task{ID: tc.TaskID}
+	if config.ServiceEnableReaderComments.GetBool() {
+		canRead, _, err := t.CanRead(s, a)
+		if err != nil {
+			return false, err
+		}
+		if canRead {
+			return true, nil
+		}
+	}
 	return t.CanWrite(s, a)
+
 }

--- a/pkg/routes/api/v1/info.go
+++ b/pkg/routes/api/v1/info.go
@@ -52,6 +52,8 @@ type vikunjaInfos struct {
 	DemoModeEnabled            bool      `json:"demo_mode_enabled"`
 	WebhooksEnabled            bool      `json:"webhooks_enabled"`
 	PublicTeamsEnabled         bool      `json:"public_teams_enabled"`
+	ReaderCommentsEnabled      bool      `json:"reader_comments_enabled"`
+	AssigneeEditEnabled        bool      `json:"assignee_edit_enabled"`
 }
 
 type authInfo struct {
@@ -103,6 +105,8 @@ func Info(c echo.Context) error {
 		DemoModeEnabled:        config.ServiceDemoMode.GetBool(),
 		WebhooksEnabled:        config.WebhooksEnabled.GetBool(),
 		PublicTeamsEnabled:     config.ServiceEnablePublicTeams.GetBool(),
+		ReaderCommentsEnabled:  config.ServiceEnableReaderComments.GetBool(),
+		AssigneeEditEnabled:    config.ServiceEnableAssigneeEdit.GetBool(),
 		AvailableMigrators: []string{
 			(&vikunja_file.FileMigrator{}).Name(),
 			(&ticktick.Migrator{}).Name(),


### PR DESCRIPTION
## Description
This PR refines the "Executor" role permissions by splitting the broad `enableexecutorfeatures` configuration into two granular flags. This provides administrators with finer control over what "Read-only" users can do within the system.

#### 💡 Motivation
Previously, `enableexecutorfeatures` bundled several distinct permissions (commenting, editing assigned tasks, and creating tasks). This led to an "all-or-nothing" approach which was often too permissive.

**This change allows decoupling these capabilities:**
* **Granular Control:** Admins can now allow commenting without allowing task editing, or vice-versa.
* **Security & Logic:** It removes the implicit ability for "Read" users to create tasks, ensuring task creation is strictly reserved for users with **Write** permissions or higher, aligning with standard RBAC (Role-Based Access Control) expectations.

#### 🛠 Changes

**Backend:**
* **Config:** Deprecated `service.enableexecutorfeatures`. Added `service.enablereadercomments` and `service.enableassigneeedit`.
* **API:** Updated `/info` endpoint to expose `ReaderCommentsEnabled` and `AssigneeEditEnabled`.
* **Models/Permissions:**
    * `TaskComment.CanCreate`: Now toggled by `ServiceEnableReaderComments`.
    * `Task.CanUpdate`: Now toggled by `ServiceEnableAssigneeEdit`.
    * `Task.CanCreate`: Removed the legacy logic that allowed "Read" users to create tasks.

**Frontend:**
* **Store:** Updated `config` store to support the new granular flags.
* **Views:**
    * `TaskDetailView.vue`: Updated `canComment` and `canWrite` logic to check the new flags and verify if the user is the assignee/creator.
    * **UI Cleanup:** Reverted broad "write" checks in `ProjectList` and `ProjectKanban` to hide creation UI elements (like "Add Task" buttons) from users with only Read access.

#### ⚙️ Configuration
The following settings are now available in `config.yml`:

```yaml
service:
  # Allows users with Read access to comment on tasks
  enablereadercomments: true 
  # Allows users with Read access to edit tasks IF they are the assignee or creator
  enableassigneeedit: true