### PR TITLE
fix(frontend): prevent saved filters from appearing twice in sidebar

### DIFF
--- a/frontend/src/stores/projects.ts
+++ b/frontend/src/stores/projects.ts
@@ -35,7 +35,7 @@ export const useProjectStore = defineStore('project', () => {
 	const notArchivedRootProjects = computed(() => projectsArray.value
 		.filter(p => p.parentProjectId === 0 && !p.isArchived && p.id > 0))
 	const favoriteProjects = computed(() => projectsArray.value
-		.filter(p => !p.isArchived && p.isFavorite))
+		.filter(p => !p.isArchived && p.isFavorite && p.id > 0))
 	const savedFilterProjects = computed(() => projectsArray.value
 		.filter(p => !p.isArchived && p.id < -1))
 	const hasProjects = computed(() => projectsArray.value.length > 0)


### PR DESCRIPTION
## Summary
- Saved filters were appearing in both the Favorites section and the Filters section when marked as favorite
- This occurred because `favoriteProjects` included all items with `isFavorite: true`, regardless of whether they were actual projects or saved filters (which have negative IDs)
- Added a check for positive IDs (`p.id > 0`) to exclude saved filters from the favorites list

## Test plan
- [x] Mark a saved filter as favorite
- [x] Verify the filter appears only once in the sidebar (in the Filters section)
- [x] Verify regular projects still appear correctly in Favorites when marked as favorite

Fixes #1989

🤖 Generated with [Claude Code](https://claude.com/claude-code)