### PR TITLE
fix(api): preserve IsFavorite for saved filters in ReadOne

### DIFF
--- a/pkg/models/project.go
+++ b/pkg/models/project.go
@@ -295,6 +295,7 @@ func (p *Project) ReadOne(s *xorm.Session, a web.Auth) (err error) {
 		}
 		p.Title = sf.Title
 		p.Description = sf.Description
+		p.IsFavorite = sf.IsFavorite
 		p.Created = sf.Created
 		p.Updated = sf.Updated
 		p.OwnerID = sf.OwnerID
@@ -334,9 +335,13 @@ func (p *Project) ReadOne(s *xorm.Session, a web.Auth) (err error) {
 		}
 	}
 
-	p.IsFavorite, err = isFavorite(s, p.ID, a, FavoriteKindProject)
-	if err != nil {
-		return
+	// For saved filters, IsFavorite was already set from the SavedFilter struct.
+	// Don't overwrite it with the project favorites lookup.
+	if !isFilter {
+		p.IsFavorite, err = isFavorite(s, p.ID, a, FavoriteKindProject)
+		if err != nil {
+			return
+		}
 	}
 
 	subs, err := GetSubscriptionForUser(s, SubscriptionEntityProject, p.ID, a)


### PR DESCRIPTION
## Summary
- Saved filters' `IsFavorite` field was not being properly returned when fetched as pseudo-projects via `/projects/{id}`
- This caused favorited filters to appear in both the Favorites and Filters sections initially, but then disappear from Favorites after clicking on them (navigating to the filter)

## Root Cause
Two issues in `pkg/models/project.go` `ReadOne()`:
1. `IsFavorite` wasn't being copied from the `SavedFilter` struct to the `Project` struct
2. The `isFavorite()` lookup was then overwriting the value with `false` (since saved filters don't use the regular project favorites table)

## Fix
- Copy `sf.IsFavorite` to `p.IsFavorite` when loading a saved filter as a project
- Skip the `isFavorite()` lookup for saved filters since they manage their favorite status independently via the `saved_filters` table

## Test plan
- [x] Create/mark a saved filter as favorite (via API since no UI exists)
- [x] Refresh page - filter appears in both Favorites and Filters sections (intended)
- [x] Click on the filter to navigate to it
- [x] Verify filter still appears in Favorites section (before fix: it disappeared)
- [x] Verify `/api/v1/projects/-{id}` returns `is_favorite: true` matching `/api/v1/filters/{id}`

Fixes #1989

🤖 Generated with [Claude Code](https://claude.com/claude-code)