### PR TITLE
feat: merge duplicate notifications

### DIFF
--- a/frontend/src/components/misc/Notification.vue
+++ b/frontend/src/components/misc/Notification.vue
@@ -21,11 +21,16 @@
 					{{ item.title }}
 				</div>
 				<div class="notification-content">
-					<template
-						v-for="(t, k) in item.text"
-						:key="k"
-					>
-						{{ t }}<br>
+					<template v-if="Array.isArray(item.text)">
+						<template
+							v-for="(t, k) in item.text"
+							:key="k"
+						>
+							{{ t }}<br>
+						</template>
+					</template>
+					<template v-else>
+						{{ item.text }}
 					</template>
 					<span
 						v-if="item.duplicates > 0"

--- a/frontend/src/message/index.ts
+++ b/frontend/src/message/index.ts
@@ -36,9 +36,11 @@ export function error(e, actions: Action[] = []) {
 	notify({
 		type: 'error',
 		title: i18n.global.t('error.error'),
-		text: [getErrorText(e)],
+		text: getErrorText(e),
 		ignoreDuplicates: true,
-		actions: actions,
+		data: {
+			actions: actions,
+		},
 	})
 }
 
@@ -46,7 +48,8 @@ export function success(e, actions: Action[] = []) {
 	notify({
 		type: 'success',
 		title: i18n.global.t('error.success'),
-		text: [getErrorText(e)],
+		text: getErrorText(e),
+		ignoreDuplicates: true,
 		data: {
 			actions: actions,
 		},

--- a/frontend/tests/e2e/misc/notifications.spec.ts
+++ b/frontend/tests/e2e/misc/notifications.spec.ts
@@ -1,0 +1,30 @@
+import {test, expect} from '../../support/fixtures'
+
+test.describe('Duplicate Notifications', () => {
+	test('Merges duplicate notifications and shows count', async ({authenticatedPage: page}) => {
+		await page.goto('/')
+		await page.waitForLoadState('networkidle')
+
+		// Trigger the same notification twice via the Vue app using $notify directly
+		await page.evaluate(() => {
+			const app = document.getElementById('app')
+			const vueApp = (app as any).__vue_app__
+			vueApp.config.globalProperties.$notify({
+				type: 'success',
+				title: 'Test',
+				text: 'Duplicate Test',
+			})
+			vueApp.config.globalProperties.$notify({
+				type: 'success',
+				title: 'Test',
+				text: 'Duplicate Test',
+			})
+		})
+
+		// Should only show one notification with a count of ×2
+		const notification = page.locator('.global-notification .vue-notification.success')
+		await expect(notification).toHaveCount(1)
+		await expect(notification.locator('.notification-content')).toContainText('Duplicate Test')
+		await expect(notification.locator('.notification-content')).toContainText('×2')
+	})
+})


### PR DESCRIPTION
closes https://github.com/go-vikunja/vikunja/pull/971

## Summary
Incorporates the changes from https://github.com/go-vikunja/vikunja/pull/971 with improvements:

- Enables duplicate notification merging using the `ignoreDuplicates` prop from vue3-notification
- Shows a count (×N) when notifications are merged
- **Fix**: Uses string text instead of arrays so duplicate detection actually works (vue3-notification uses strict equality)
- **Fix**: Moves `actions` under `data` in error notifications to match template's `item.data?.actions`
- **Fix**: Updates template to handle both string and array text for backwards compatibility
- Replaces Cypress test with Playwright e2e test

## Test plan
- [x] Playwright test verifies duplicate notifications are merged and show correct count