### PR TITLE
fix: prevent saved filter error when viewing Favorites

### DIFF
--- a/frontend/src/components/project/views/ProjectKanban.vue
+++ b/frontend/src/components/project/views/ProjectKanban.vue
@@ -357,7 +357,7 @@ const taskPositionService = ref(new TaskPositionService())
 const taskBucketService = ref(new TaskBucketService())
 
 // Saved filter composable for accessing filter data
-const savedFilter = useSavedFilter(() => projectId.value < 0 ? projectId.value : undefined).filter
+const savedFilter = useSavedFilter(() => isSavedFilter({id: projectId.value}) ? projectId.value : undefined).filter
 
 const taskContainerRefs = ref<{ [id: IBucket['id']]: HTMLElement }>({})
 const bucketLimitInputRef = ref<HTMLInputElement | null>(null)

--- a/frontend/src/components/project/views/ProjectList.vue
+++ b/frontend/src/components/project/views/ProjectList.vue
@@ -153,7 +153,7 @@ const {
 const taskPositionService = ref(new TaskPositionService())
 
 // Saved filter composable for accessing filter data
-const _savedFilter = useSavedFilter(() => projectId.value < 0 ? projectId.value : undefined).filter
+const _savedFilter = useSavedFilter(() => isSavedFilter({id: projectId.value}) ? projectId.value : undefined).filter
 
 const tasks = ref<ITask[]>([])
 watch(


### PR DESCRIPTION
## Summary

- Fixes the "The saved filter does not exist" error when clicking on Favorites in the sidebar
- The issue occurred because the code assumed any negative projectId was a saved filter, but Favorites has ID -1 while saved filters start at ID -2
- Changed the condition from `projectId < 0` to `projectId <= -2` in both ProjectList.vue and ProjectKanban.vue

Fixes #2058

## Test plan

- [ ] Log in to Vikunja
- [ ] Create a task and mark it as favorite
- [ ] Click on "Favorites" in the sidebar
- [ ] Verify no error notification appears
- [ ] Verify tasks are displayed correctly
- [ ] Switch between List, Gantt, and Table views - no errors should appear
- [ ] Navigate to an actual saved filter (if any exist) - should still work correctly