### PR TITLE
fix(attachments): only show dropzone overlay for file drags, not text drags

### DIFF
--- a/frontend/src/components/tasks/partials/Attachments.vue
+++ b/frontend/src/components/tasks/partials/Attachments.vue
@@ -259,10 +259,6 @@ function resetDragState() {
 }
 
 function handleDragEnter(event: DragEvent) {
-	if (!props.editEnabled) {
-		return
-	}
-
 	// Only handle file drags - let text drags work natively
 	if (!isFileDrag(event)) {
 		return
@@ -277,10 +273,6 @@ function handleDragEnter(event: DragEvent) {
 }
 
 function handleDragOver(event: DragEvent) {
-	if (!props.editEnabled) {
-		return
-	}
-
 	// Only prevent default for file drags - this is the key fix!
 	// Not preventing default allows native text dragging to work
 	if (!isFileDrag(event)) {
@@ -292,10 +284,6 @@ function handleDragOver(event: DragEvent) {
 }
 
 function handleDragLeave(event: DragEvent) {
-	if (!props.editEnabled) {
-		return
-	}
-
 	if (!isFileDrag(event)) {
 		return
 	}
@@ -310,10 +298,6 @@ function handleDragLeave(event: DragEvent) {
 }
 
 function handleDrop(event: DragEvent) {
-	if (!props.editEnabled) {
-		return
-	}
-
 	// Only handle file drops - let text drops work natively
 	if (!isFileDrag(event)) {
 		return
@@ -334,29 +318,42 @@ function handleDrop(event: DragEvent) {
 	uploadFilesToTask(files)
 }
 
-onMounted(() => {
+function addDragListeners() {
 	document.addEventListener('dragenter', handleDragEnter)
 	document.addEventListener('dragover', handleDragOver)
 	document.addEventListener('dragleave', handleDragLeave)
 	document.addEventListener('drop', handleDrop)
-})
+}
 
-onUnmounted(() => {
+function removeDragListeners() {
 	document.removeEventListener('dragenter', handleDragEnter)
 	document.removeEventListener('dragover', handleDragOver)
 	document.removeEventListener('dragleave', handleDragLeave)
 	document.removeEventListener('drop', handleDrop)
+}
+
+onMounted(() => {
+	if (props.editEnabled) {
+		addDragListeners()
+	}
+})
+
+onUnmounted(() => {
+	removeDragListeners()
+})
+
+watch(() => props.editEnabled, (enabled) => {
+	if (enabled) {
+		addDragListeners()
+	} else {
+		removeDragListeners()
+		resetDragState()
+	}
 })
 
 const showDropzone = computed(() =>
 	props.editEnabled && isDraggingFiles.value && !isDragOverEditor.value,
 )
-
-watch(() => props.editEnabled, enabled => {
-	if (!enabled) {
-		resetDragState()
-	}
-})
 
 function downloadAttachment(attachment: IAttachment) {
 	attachmentService.download(attachment)


### PR DESCRIPTION
## Summary
- Fixes #1663 - The file upload dropzone overlay was appearing for ALL drag operations, including text drags, blocking normal text manipulation in editors
- Replaced `useDropZone` from VueUse with custom drag event handlers
- Key fix: Only call `event.preventDefault()` for actual file drags (checked via `dataTransfer.types.includes('Files')`)
- This allows native text dragging to work in Firefox (Chrome/Safari have known ProseMirror limitations)

## Changes
- Added `isFileDrag()` helper function to detect file drags vs text drags
- Replaced VueUse's `useDropZone` with custom `handleDragEnter`, `handleDragOver`, `handleDragLeave`, `handleDrop` handlers
- Used `dragDepth` counter to properly handle nested element drag events

## Note on Chrome/Safari text dragging
Text dragging within the TipTap editor doesn't work in Chrome/Safari - this is a [known ProseMirror limitation](https://discuss.prosemirror.net/t/safari-draggable-paragraph-issue/2347), not a Vikunja bug. The maintainer has stated this is "not supported" across browsers. Workaround: use cut/paste instead.

## Test plan
- [ ] Drag a file from desktop over the page (not over editor) → dropzone overlay appears
- [ ] Drag selected text anywhere on page → dropzone does NOT appear
- [ ] Drop file outside editor area → file uploads as attachment
- [ ] Drop file over editor → TipTap handles it (no dropzone interference)
- [ ] Text operations in editor work normally (select, copy, paste)

🤖 Generated with [Claude Code](https://claude.ai/code)