### PR TITLE
fix(migration): make migration from Microsoft Todo work for those with previously migrated wunderlist accounts

### DIFF
--- a/pkg/modules/migration/microsoft-todo/microsoft_todo.go
+++ b/pkg/modules/migration/microsoft-todo/microsoft_todo.go
@@ -218,7 +218,7 @@ func getMicrosoftTodoData(token string) (microsoftTodoData []*project, err error
 	microsoftTodoData = []*project{}
 
 	projects := &projectsResponse{}
-	err = makeAuthenticatedGetRequest(token, "lists", projects)
+	err = makeAuthenticatedGetRequest(token, "lists/delta", projects)
 	if err != nil {
 		log.Errorf("[Microsoft Todo Migration] Could not get projects: %s", err)
 		return


### PR DESCRIPTION
Fixed issue where the list query for Microsoft Todo import would query a paginated endpoint without using the nextLink. 
This endpoint also does not work for migrated accounts, such as those migrated over from Wunderlist. The delta endpoint handles this and returns all lists.

- The Microsoft Graph API's /me/todo/lists endpoint only gets all lists that were originally created using the microsoft todo storage api. If the list was created as a result of migration (such as the Wunderlist migrations), then only newly created lists in the Microsoft Todo app will appear in the query.
- In addition, this graph endpoint can reach a predefined limit and then resorts to pagination. If the "nextLink" is not handled in the code, then not all lists will be fetched.
- The "/delta" endpoint is not paginated and will always get all lists, regardless of source. This will fix my issue and likely make it migrate easier for people with large numbers of lists.