### PR TITLE
feat(frontend): preserve Gantt date range when switching views

### DIFF
--- a/frontend/src/components/project/ProjectWrapper.vue
+++ b/frontend/src/components/project/ProjectWrapper.vue
@@ -23,7 +23,7 @@
 					:key="view.id"
 					class="switch-view-button"
 					:class="{'is-active': view.id === viewId}"
-					:to="{ name: 'project.view', params: { projectId, viewId: view.id } }"
+					:to="getViewRoute(view)"
 				>
 					{{ getViewTitle(view) }}
 				</BaseButton>
@@ -57,6 +57,7 @@ import {useTitle} from '@/composables/useTitle'
 
 import {useBaseStore} from '@/stores/base'
 import {useProjectStore} from '@/stores/projects'
+import {useViewFiltersStore} from '@/stores/viewFilters'
 
 import type {IProject} from '@/modelTypes/IProject'
 import type {IProjectView} from '@/modelTypes/IProjectView'
@@ -71,6 +72,7 @@ const {t} = useI18n()
 
 const baseStore = useBaseStore()
 const projectStore = useProjectStore()
+const viewFiltersStore = useViewFiltersStore()
 
 const currentProject = computed<IProject>(() => {
 	return baseStore.currentProject || {
@@ -95,8 +97,17 @@ function getViewTitle(view: IProjectView) {
 		case 'Kanban':
 			return t('project.kanban.title')
 	}
-	
+
 	return view.title
+}
+
+function getViewRoute(view: IProjectView) {
+	const storedQuery = viewFiltersStore.getViewQuery(view.id)
+	return {
+		name: 'project.view',
+		params: {projectId: props.projectId, viewId: view.id},
+		query: storedQuery,
+	}
 }
 </script>
 

--- a/frontend/src/stores/viewFilters.test.ts
+++ b/frontend/src/stores/viewFilters.test.ts
@@ -1,0 +1,41 @@
+import {describe, it, expect, beforeEach} from 'vitest'
+import {setActivePinia, createPinia} from 'pinia'
+import {useViewFiltersStore} from './viewFilters'
+
+describe('viewFilters store', () => {
+	beforeEach(() => {
+		setActivePinia(createPinia())
+	})
+
+	it('should store and retrieve query params for a view', () => {
+		const store = useViewFiltersStore()
+
+		store.setViewQuery(18, {dateFrom: '2026-01-01', dateTo: '2026-01-31'})
+
+		expect(store.getViewQuery(18)).toEqual({dateFrom: '2026-01-01', dateTo: '2026-01-31'})
+	})
+
+	it('should return empty object for views without stored params', () => {
+		const store = useViewFiltersStore()
+
+		expect(store.getViewQuery(999)).toEqual({})
+	})
+
+	it('should clear query params for a view', () => {
+		const store = useViewFiltersStore()
+
+		store.setViewQuery(18, {dateFrom: '2026-01-01', dateTo: '2026-01-31'})
+		store.clearViewQuery(18)
+
+		expect(store.getViewQuery(18)).toEqual({})
+	})
+
+	it('should update existing query params', () => {
+		const store = useViewFiltersStore()
+
+		store.setViewQuery(18, {dateFrom: '2026-01-01', dateTo: '2026-01-31'})
+		store.setViewQuery(18, {dateFrom: '2026-02-01', dateTo: '2026-02-28'})
+
+		expect(store.getViewQuery(18)).toEqual({dateFrom: '2026-02-01', dateTo: '2026-02-28'})
+	})
+})

--- a/frontend/src/stores/viewFilters.ts
+++ b/frontend/src/stores/viewFilters.ts
@@ -1,0 +1,27 @@
+import {defineStore} from 'pinia'
+import {ref} from 'vue'
+import type {LocationQueryRaw} from 'vue-router'
+import type {IProjectView} from '@/modelTypes/IProjectView'
+
+export const useViewFiltersStore = defineStore('viewFilters', () => {
+	const viewQueries = ref<Record<IProjectView['id'], LocationQueryRaw>>({})
+
+	function setViewQuery(viewId: IProjectView['id'], query: LocationQueryRaw) {
+		viewQueries.value[viewId] = query
+	}
+
+	function getViewQuery(viewId: IProjectView['id']): LocationQueryRaw {
+		return viewQueries.value[viewId] ?? {}
+	}
+
+	function clearViewQuery(viewId: IProjectView['id']) {
+		delete viewQueries.value[viewId]
+	}
+
+	return {
+		viewQueries,
+		setViewQuery,
+		getViewQuery,
+		clearViewQuery,
+	}
+})


### PR DESCRIPTION
## Summary
- Adds a `viewFilters` Pinia store that stores query params per view ID
- Syncs Gantt filters to the store whenever they change
- View tab links now include stored query params, so custom date ranges persist when switching views

## Test plan
- [ ] Set a custom date range in Gantt view
- [ ] Switch to List view
- [ ] Switch back to Gantt view
- [ ] Verify the custom date range is preserved
- [ ] Test with Kanban and Table views as well
- [ ] Verify Reset button still clears the custom date range
- [ ] Verify page refresh uses URL as source of truth

Fixes #2124