### PR TITLE
fix: avoid mutating global http.DefaultClient in webhook proxy

### DIFF
--- a/pkg/models/webhooks.go
+++ b/pkg/models/webhooks.go
@@ -245,7 +245,7 @@ func getWebhookHTTPClient() (client *http.Client) {
 		return webhookClient
 	}
 
-	client = http.DefaultClient
+	client = &http.Client{}
 	client.Timeout = time.Duration(config.WebhooksTimeoutSeconds.GetInt()) * time.Second
 
 	if config.WebhooksProxyURL.GetString() == "" || config.WebhooksProxyPassword.GetString() == "" {

--- a/pkg/modules/avatar/gravatar/gravatar.go
+++ b/pkg/modules/avatar/gravatar/gravatar.go
@@ -90,7 +90,7 @@ func (g *Provider) GetAvatar(user *user.User, size int64) ([]byte, string, error
 		if err != nil {
 			return nil, err
 		}
-		resp, err := http.DefaultClient.Do(req)
+		resp, err := (&http.Client{}).Do(req)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/modules/background/unsplash/proxy.go
+++ b/pkg/modules/background/unsplash/proxy.go
@@ -30,7 +30,7 @@ func unsplashImage(url string, c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := (&http.Client{}).Do(req)
 	if err != nil {
 		return err
 	}

--- a/pkg/modules/background/unsplash/unsplash.go
+++ b/pkg/modules/background/unsplash/unsplash.go
@@ -257,7 +257,7 @@ func (p *Provider) Set(s *xorm.Session, image *background.Image, project *models
 	if err != nil {
 		return
 	}
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := (&http.Client{}).Do(req)
 	if err != nil {
 		return err
 	}
@@ -340,7 +340,7 @@ func pingbackByPhotoID(photoID string) {
 	if err != nil {
 		log.Errorf("Unsplash Pingback Failed: %s", err.Error())
 	}
-	_, err = http.DefaultClient.Do(req)
+	_, err = (&http.Client{}).Do(req)
 	if err != nil {
 		log.Errorf("Unsplash Pingback Failed: %s", err.Error())
 	}

--- a/pkg/modules/migration/microsoft-todo/microsoft_todo.go
+++ b/pkg/modules/migration/microsoft-todo/microsoft_todo.go
@@ -187,7 +187,7 @@ func makeAuthenticatedGetRequest(token, urlPart string, v interface{}) error {
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := (&http.Client{}).Do(req)
 	if err != nil {
 		return err
 	}

--- a/pkg/utils/avatar.go
+++ b/pkg/utils/avatar.go
@@ -101,7 +101,7 @@ func DownloadImage(url string) ([]byte, error) {
 		return nil, fmt.Errorf("failed to create HTTP request: %w", err)
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := (&http.Client{}).Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to download image: %w", err)
 	}


### PR DESCRIPTION
## Summary

- Fixes a bug where the webhook HTTP client was mutating `http.DefaultClient` (the global singleton), causing ALL HTTP requests in the application to use the webhook proxy
- This broke OIDC authentication and other external HTTP calls when webhook proxy was configured
- Creates new `http.Client{}` instances instead of mutating the global across all affected files

## Root Cause

In `pkg/models/webhooks.go:248`, the code was doing:

```go
client = http.DefaultClient  // Assigns pointer to global singleton
client.Transport = &http.Transport{Proxy: ...}  // Mutates global!
```

This meant any code using `http.DefaultClient` (including the go-oidc library for OIDC authentication) would route requests through the webhook proxy.

## Changes

- `pkg/models/webhooks.go` - Create new `http.Client{}` instead of using `http.DefaultClient`
- `pkg/utils/avatar.go` - Use own HTTP client
- `pkg/modules/avatar/gravatar/gravatar.go` - Use own HTTP client
- `pkg/modules/background/unsplash/proxy.go` - Use own HTTP client
- `pkg/modules/background/unsplash/unsplash.go` - Use own HTTP client (2 locations)
- `pkg/modules/migration/microsoft-todo/microsoft_todo.go` - Use own HTTP client

## Test plan

- [ ] Configure webhook proxy settings
- [ ] Verify webhooks still work through the proxy
- [ ] Verify OIDC authentication works when webhook proxy is configured
- [ ] Verify avatar downloads, Gravatar, Unsplash backgrounds still work

Fixes #2144