### PR TITLE
fix(frontend): prevent file upload overlay when dragging text from editor

### DIFF
--- a/frontend/src/components/tasks/partials/Attachments.vue
+++ b/frontend/src/components/tasks/partials/Attachments.vue
@@ -245,12 +245,29 @@ function resetDragState() {
 	isDragOverEditor.value = false
 }
 
+/**
+ * Check if a drag event contains actual files (not text being dragged).
+ * This prevents the file upload overlay from appearing when dragging text
+ * from within the editor to outside it.
+ */
+function eventContainsFiles(event: Event | null | undefined): boolean {
+	if (!event || !(event instanceof DragEvent)) {
+		return false
+	}
+	return event.dataTransfer?.types.includes('Files') ?? false
+}
+
 const {isOverDropZone} = useDropZone(document, {
 	onEnter(files, event) {
 		if (!props.editEnabled) {
 			return
 		}
-		
+
+		// Only show dropzone if actual files are being dragged, not text
+		if (!eventContainsFiles(event)) {
+			return
+		}
+
 		isDraggingFiles.value = true
 		isDragOverEditor.value = eventTargetsEditor(event)
 	},


### PR DESCRIPTION
## Summary
- Fixes the file upload overlay incorrectly appearing when dragging text from within the TipTap description editor to outside of it
- Added a check for `event.dataTransfer.types.includes('Files')` to ensure the overlay only appears when actual files are being dragged

## Test plan
- [x] Open a task detail view
- [x] Click "Edit" on the description to enable edit mode
- [x] Select some text in the description editor
- [x] Drag the text outside the editor area
- [x] Verify the "Drop files here to upload" overlay does NOT appear
- [x] Drag an actual file from your desktop into the task detail view
- [x] Verify the "Drop files here to upload" overlay DOES appear

Fixes #1663