### PR TITLE
fix(build): add osusergo tag to prevent SIGFPE crash under systemd

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -211,7 +211,11 @@ func init() {
 
 // Some variables have external dependencies (like git) which may not always be available.
 func initVars() {
-	Tags = os.Getenv("TAGS")
+	// Always include osusergo to use pure Go os/user implementation instead of CGO.
+	// This prevents SIGFPE crashes when running under systemd without HOME set,
+	// caused by glibc's getpwuid_r() failing in certain environments.
+	// See: https://github.com/go-vikunja/vikunja/issues/2170
+	Tags = "osusergo " + os.Getenv("TAGS")
 	setVersion()
 	setBinLocation()
 	setPkgVersion()


### PR DESCRIPTION
When running Vikunja as a systemd service without HOME set, the AWS SDK's init() function calls os/user.Current() which uses CGO's getpwuid_r(). This can cause a SIGFPE crash in certain restricted environments.

Adding the osusergo build tag forces Go to use its pure implementation that parses /etc/passwd directly, avoiding the problematic CGO call.

Fixes #2170