### PR TITLE
fix(list): add touch CSS properties to list view for mobile drag-and-drop

### DIFF
--- a/frontend/src/components/project/views/ProjectList.vue
+++ b/frontend/src/components/project/views/ProjectList.vue
@@ -375,6 +375,9 @@ onBeforeUnmount(() => {
 
 :deep(.tasks:not(.dragging-disabled) .single-task) {
 	cursor: grab;
+	-webkit-touch-callout: none;
+	user-select: none;
+	touch-action: manipulation;
 
 	&:active {
 		cursor: grabbing;


### PR DESCRIPTION
Adds user-select, touch-action, and webkit-touch-callout CSS to the list view's draggable task items, matching what KanbanCard.vue already has.

Without these properties, the browser's native long-press text selection fires before SortableJS's 1-second touch delay expires, preventing drag from ever starting on mobile devices.

Ref: https://community.vikunja.io/t/missing-positioning-option-in-list-view/4278