### PR TITLE
fix: prevent date parsing from consuming numbers in middle of task titles

### DIFF
--- a/frontend/src/helpers/time/parseDate.ts
+++ b/frontend/src/helpers/time/parseDate.ts
@@ -24,18 +24,18 @@ const monthsRegexGroup = '(january|february|march|april|june|july|august|septemb
  */
 function matchDateAtBoundary(text: string, pattern: string): RegExpExecArray | null {
 	const regex = new RegExp(`(^| )${pattern}($| )`, 'gi')
-	const result = regex.exec(text)
-	if (result === null) return null
+	let result: RegExpExecArray | null
+	while ((result = regex.exec(text)) !== null) {
+		const matchEnd = result.index + result[0].length
+		const isAtStart = result.index === 0
+		const isAtEnd = matchEnd >= text.length
 
-	const matchEnd = result.index + result[0].length
-	const isAtStart = result.index === 0
-	const isAtEnd = matchEnd >= text.length
+		if (isAtStart || isAtEnd) return result
 
-	if (isAtStart || isAtEnd) return result
-
-	// Allow middle-of-text matches when followed by a time expression
-	const afterMatch = text.substring(matchEnd)
-	if (/^(at |@ )/i.test(afterMatch)) return result
+		// Allow middle-of-text matches when followed by a time expression
+		const afterMatch = text.substring(matchEnd)
+		if (/^(at |@ )/i.test(afterMatch)) return result
+	}
 
 	return null
 }

--- a/frontend/src/modules/parseTaskText.test.ts
+++ b/frontend/src/modules/parseTaskText.test.ts
@@ -398,6 +398,7 @@ describe('Parse Task Text', () => {
 				{input: 'Lorem Ipsum 06/26/2021', dateStr: '2021-6-26', text: 'Lorem Ipsum'},
 				{input: '01.02 Lorem Ipsum', dateStr: '2022-2-1', text: 'Lorem Ipsum'},
 				{input: 'Lorem Ipsum 01.02', dateStr: '2022-2-1', text: 'Lorem Ipsum'},
+				{input: 'The 9/11 Report due 10/12', dateStr: '2021-10-12', text: 'The 9/11 Report due'},
 			]
 
 			boundaryTests.forEach(({input, dateStr, text}) => {


### PR DESCRIPTION
## Summary

- Adds a `matchDateAtBoundary()` helper that only matches numeric date patterns (MM/DD, YYYY/MM/DD, YYYY-MM-DD, DD.MM) at the **start** or **end** of the text, preventing false positives like "The 9/11 Report" or "The 01/02 Report"
- Rewires `getDateFromText()` to use the new boundary-aware matching instead of raw unanchored regexes
- Adds negative tests for middle-of-text false positives and positive tests confirming dates at text boundaries still parse correctly

Closes #2195

## Test plan

- [x] Existing 853 frontend unit tests pass
- [x] ESLint clean
- [x] Verify "The 9/11 Report" no longer gets a date extracted
- [x] Verify "9/11 meeting" and "meeting 9/11" still parse September 11
- [x] Verify all existing date formats (slash, dash, dot, month names, ordinals) still work at start/end of text