### PR TITLE
fix(auth): remove unnecessary fields from JWT token payloads

### DIFF
--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -325,7 +325,6 @@ export const useAuthStore = defineStore('auth', () => {
 			const newUser = new UserModel({
 				...response.data,
 				...(info.value?.type && {type: info.value?.type}),
-				...(info.value?.email && {email: info.value?.email}),
 				...(info.value?.exp && {exp: info.value?.exp}),
 			})
 

--- a/pkg/modules/auth/auth.go
+++ b/pkg/modules/auth/auth.go
@@ -70,11 +70,7 @@ func NewUserJWTAuthtoken(u *user.User, long bool) (token string, err error) {
 	claims["type"] = AuthTypeUser
 	claims["id"] = u.ID
 	claims["username"] = u.Username
-	claims["email"] = u.Email
 	claims["exp"] = exp
-	claims["name"] = u.Name
-	claims["emailRemindersEnabled"] = u.EmailRemindersEnabled
-	claims["isLocalUser"] = u.Issuer == user.IssuerLocal
 	claims["long"] = long
 
 	// Generate encoded token and send it as response.
@@ -97,7 +93,6 @@ func NewLinkShareJWTAuthtoken(share *models.LinkSharing) (token string, err erro
 	claims["permission"] = share.Permission
 	claims["sharedByID"] = share.SharedByID
 	claims["exp"] = exp
-	claims["isLocalUser"] = true // Link shares are always local
 
 	// Generate encoded token and send it as response.
 	return t.SignedString([]byte(config.ServiceJWTSecret.GetString()))

--- a/pkg/user/user.go
+++ b/pkg/user/user.go
@@ -461,24 +461,14 @@ func GetUserFromClaims(claims jwt.MapClaims) (user *User, err error) {
 	if err != nil {
 		return nil, err
 	}
-	email, err := getClaimAsString(claims, "email")
-	if err != nil {
-		return nil, err
-	}
 	username, err := getClaimAsString(claims, "username")
-	if err != nil {
-		return nil, err
-	}
-	name, err := getClaimAsString(claims, "name")
 	if err != nil {
 		return nil, err
 	}
 
 	return &User{
 		ID:       userID,
-		Email:    email,
 		Username: username,
-		Name:     name,
 	}, nil
 }
 


### PR DESCRIPTION
## Summary

- Remove `email`, `name`, `emailRemindersEnabled`, and `isLocalUser` claims from user JWT tokens
- Remove `isLocalUser` claim from link share JWT tokens
- Simplify `GetUserFromClaims` to only extract `id` and `username`
- Remove the now-unnecessary email override in the frontend's `refreshUserInfo`

These fields are never used from the token — the backend always fetches the full user from the database by ID, and the frontend fetches user data from the `GET /user` API endpoint immediately after login. Existing tokens with the old claims continue to work since extra fields are simply ignored.

## Test plan

- [x] Backend web tests pass
- [x] `go vet` and `go build` pass on changed packages
- [x] Frontend lint passes
- [ ] Manual login/logout flow works correctly
- [ ] Link share access works correctly