### PR TITLE
feat: add Swedish for language selection

### DIFF
--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -40,6 +40,7 @@ export const SUPPORTED_LOCALES = {
 	'tr-TR': 'Türkçe',
 	'fi-FI': 'Suomi',
 	'he-IL': 'עִבְרִית',
+	'sv-SE': 'Svenska',
 	// IMPORTANT: Also add new languages to useDayjsLanguageSync
 	// IMPORTANT: Also add new languages to pkg/i18n/i18n.go
 } as const

--- a/frontend/src/i18n/useDayjsLanguageSync.ts
+++ b/frontend/src/i18n/useDayjsLanguageSync.ts
@@ -32,6 +32,7 @@ export const DAYJS_LOCALE_MAPPING = {
 	'tr-tr': 'tr',
 	'fi-fi': 'fi',
 	'he-il': 'he',
+	'sv-se': 'sv',
 } as Record<SupportedLocale, ISOLanguage>
 
 export const DAYJS_LANGUAGE_IMPORTS = {
@@ -63,6 +64,7 @@ export const DAYJS_LANGUAGE_IMPORTS = {
 	'tr-tr': () => import('dayjs/locale/tr'),
 	'fi-fi': () => import('dayjs/locale/fi'),
 	'he-il': () => import('dayjs/locale/he'),
+	'sv-se': () => import('dayjs/locale/sv'),
 } as Record<SupportedLocale, () => Promise<ILocale>>
 
 export async function loadDayJsLocale(language: SupportedLocale) {

--- a/pkg/i18n/i18n.go
+++ b/pkg/i18n/i18n.go
@@ -76,6 +76,7 @@ var availableLanguages = map[string]bool{
 	"tr-TR":    true,
 	"fi-FI":    true,
 	"he-IL":    true,
+	"sv-SE":    true,
 	// IMPORTANT: Also add new languages to the frontend
 }
 


### PR DESCRIPTION
The Swedish translations were finished on crowdin recently but I noticed that the language selection was still missing so I went ahead and added it.