### PR TITLE
Closes #2255: Update go to 1.25.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -183,6 +183,6 @@ require (
 
 replace github.com/samedi/caldav-go => github.com/kolaente/caldav-go v3.0.1-0.20190610114120-2a4eb8b5dcc9+incompatible // Branch: feature/dynamic-supported-components, PR: https://github.com/samedi/caldav-go/pull/6 and https://github.com/samedi/caldav-go/pull/7
 
-go 1.25.0
+go 1.25.7
 
-toolchain go1.25.6
+toolchain go1.25.7


### PR DESCRIPTION
Update go and go toolchain to 1.25.7 in order to get rid of CVE-2025-68121