### PR TITLE
fix: collapse view buttons into dropdown when overflowing

### DIFF
--- a/frontend/src/components/project/ProjectWrapper.vue
+++ b/frontend/src/components/project/ProjectWrapper.vue
@@ -238,6 +238,7 @@ function getViewRoute(view: IProjectView) {
 .switch-view-button {
 	padding: .25rem .5rem;
 	display: block;
+	white-space: nowrap;
 	border-radius: $radius;
 	transition: all 100ms;
 


### PR DESCRIPTION
**Problem**

When a project has many views, the view switcher buttons overflow the screen horizontally, making some views inaccessible.

**Solution**

  Automatically detect when the view buttons would overflow the container and collapse them into a dropdown menu.

   - When buttons fit within the container → show inline buttons as before (no change in UX)
   - When buttons overflow → show a dropdown displaying the current view name with a chevron, clicking it reveals all views in a dropdown menu

![Recording 2026-02-26 at 15 47 39](https://github.com/user-attachments/assets/4a6b74d8-6133-4f85-9bde-3ffc4f3e8756)
