### PR TITLE
fix: remove invalidateAvatarCache call that broke request deduplication

### DIFF
--- a/frontend/src/models/user.ts
+++ b/frontend/src/models/user.ts
@@ -24,9 +24,7 @@ export async function fetchAvatarBlobUrl(user: IUser, size = 50) {
 	if (pendingRequests.has(key)) {
 		return await pendingRequests.get(key) as string
 	}
-	
-	invalidateAvatarCache(user)
-	
+
 	// Create a new request
 	const requestPromise = avatarService.getBlobUrl(`/avatar/${user.username}?size=${size}`)
 		.then(url => {


### PR DESCRIPTION
When multiple avatar components mount with alternating sizes (e.g. 48 and 20), invalidateAvatarCache clears pending requests for ALL sizes of the same user, causing each call to create a new HTTP request instead of reusing the pending one.

I noticed this issue when I open a task with 20 comments, the avatar requests make the service OOM.

<img width="733" height="551" alt="image" src="https://github.com/user-attachments/assets/db45db31-294c-4363-ad27-38d454b5a6a2" />
