### PR TITLE
fix: use MinPositionSpacing threshold in calculateNewPositionForTask

### DIFF
--- a/pkg/models/task_position.go
+++ b/pkg/models/task_position.go
@@ -303,7 +303,8 @@ func recalculateTaskPositionsForRepair(s *xorm.Session, view *ProjectView) error
 }
 
 func calculateNewPositionForTask(s *xorm.Session, a web.Auth, t *Task, view *ProjectView) (*TaskPosition, error) {
-	if t.Position == 0 {
+	position := t.Position
+	if position == 0 {
 		lowestPosition := &TaskPosition{}
 		exists, err := s.Where("project_view_id = ?", view.ID).
 			OrderBy("position asc").
@@ -327,14 +328,14 @@ func calculateNewPositionForTask(s *xorm.Session, a web.Auth, t *Task, view *Pro
 				}
 			}
 
-			t.Position = lowestPosition.Position / 2
+			position = lowestPosition.Position / 2
 		}
 	}
 
 	return &TaskPosition{
 		TaskID:        t.ID,
 		ProjectViewID: view.ID,
-		Position:      calculateDefaultPosition(t.Index, t.Position),
+		Position:      calculateDefaultPosition(t.Index, position),
 	}, nil
 }
 


### PR DESCRIPTION
calculateNewPositionForTask only checked for lowestPosition == 0 before triggering a full position recalculation. Extremely small position values (e.g. 3.16e-285) passed this check, causing new tasks to get meaningless positions via the index * 2^16 fallback, breaking sort order.

Use the same < MinPositionSpacing threshold that createPositionsForTasksInView and the position update handler already use.