### PR TITLE
feat: add task creation to table view

### DIFF
--- a/frontend/src/components/project/views/ProjectTable.vue
+++ b/frontend/src/components/project/views/ProjectTable.vue
@@ -305,6 +305,7 @@
 
 <script setup lang="ts">
 import {computed, type Ref, watch} from 'vue'
+import {useRouter} from 'vue-router'
 
 import {useStorage} from '@vueuse/core'
 
@@ -343,6 +344,7 @@ const props = defineProps<{
 
 const projectStore = useProjectStore()
 const baseStore = useBaseStore()
+const router = useRouter()
 const canWrite = computed(() => {
 	const project = baseStore.currentProject
 	return project?.maxPermission > PERMISSIONS.READ && project?.id > 0
@@ -390,9 +392,8 @@ const {
 } = taskList
 const tasks: Ref<ITask[]> = taskList.tasks
 
-function updateTaskList() {
-	currentPage.value = 1
-	taskList.loadTasks()
+function updateTaskList(task: ITask) {
+	router.push({name: 'task.detail', params: {id: task.id}})
 }
 
 watch(


### PR DESCRIPTION
## Summary

Users who primarily use the table view for task management currently have no way to create new tasks without switching to another view.

This adds the `AddTask` component (with Quick Add Magic support) to the table view, matching the list view's behavior. After creating a task, the user is navigated to the task detail page.

## Changes

- Add `AddTask` component to `ProjectTable.vue`
- Navigate to task detail page after creation so the user can immediately edit the new task
- Only shown when user has write permission