### PR TITLE
feat: add 'only my tasks' filter on homepage

### DIFF
--- a/frontend/src/i18n/lang/en.json
+++ b/frontend/src/i18n/lang/en.json
@@ -833,7 +833,8 @@
       "select": "Select a date range",
       "noTasks": "Nothing to do — Have a nice day!",
       "filterByLabel": "Filtering by label {label}",
-      "clearLabelFilter": "Clear label filter"
+      "clearLabelFilter": "Clear label filter",
+      "onlyMyTasks": "Only show tasks assigned to me"
     },
     "detail": {
       "chooseDueDate": "Click here to set a due date",

--- a/frontend/src/modelTypes/IUserSettings.ts
+++ b/frontend/src/modelTypes/IUserSettings.ts
@@ -25,6 +25,7 @@ export interface IFrontendSettings {
 	alwaysShowBucketTaskCount: boolean
 	sidebarWidth: number | null
 	commentSortOrder: 'asc' | 'desc'
+	showOnlyMyTasks: boolean
 }
 
 export interface IExtraSettingsLink {

--- a/frontend/src/models/userSettings.ts
+++ b/frontend/src/models/userSettings.ts
@@ -33,6 +33,7 @@ export default class UserSettingsModel extends AbstractModel<IUserSettings> impl
 		alwaysShowBucketTaskCount: false,
 		sidebarWidth: null,
 		commentSortOrder: 'asc',
+		showOnlyMyTasks: false,
 	}
 	extraSettingsLinks = {}
 


### PR DESCRIPTION
## Summary


In multi-user teams, the homepage's Current Tasks section shows all undone tasks across all projects, making it hard for users to find their own assignments.
<img width="1094" height="242" alt="image" src="https://github.com/user-attachments/assets/396998c1-753a-41f5-a407-e388cd196f20" />

This adds a checkbox next to the Current Tasks title: **"Only show tasks assigned to me"**. When enabled, it filters tasks by `assignees = currentUser`.

The setting is persisted in `frontendSettings` so it syncs across devices.

## Changes

- `IUserSettings.ts`: Add `showOnlyMyTasks` to `IFrontendSettings`
- `userSettings.ts`: Default value `false`
- `ShowTasks.vue`: Add checkbox, save to frontendSettings on toggle, add assignee filter to task query
- `en.json`: Add i18n text