### PR TITLE
fix(cli): make user deletion confirmation check Windows compatible

### DIFF
--- a/pkg/cmd/user.go
+++ b/pkg/cmd/user.go
@@ -364,7 +364,7 @@ var userDeleteCmd = &cobra.Command{
 
 			// On Windows <ENTER> a newline is \r\n, while on Linux it is only \n.
 			text = strings.TrimRight(text, "\r\n")
-			
+
 			if text != "YES, I CONFIRM" {
 				log.Fatalf("invalid confirmation message")
 			}


### PR DESCRIPTION
The current implementation of the user confirmation when deleting a user using the CLI seems to favour Linux. On Windows the <ENTER> command adds "\r\n" to the user input while Linux only adds "\n".

I have added an extra check to the confirmation, but GO is a new language for me, so there is probably a much better way to do this.