### PR TITLE
fix: allow browser caching for file downloads

### DIFF
--- a/pkg/modules/background/handler/background.go
+++ b/pkg/modules/background/handler/background.go
@@ -380,9 +380,21 @@ func GetProjectBackground(c *echo.Context) error {
 		return err
 	}
 
+	// Override the global no-store directive so browsers can cache background images.
+	// no-cache allows caching but requires revalidation via If-Modified-Since.
+	c.Response().Header().Set("Cache-Control", "no-cache")
+
 	// Set Last-Modified header if we have the file stat, so clients can decide whether to use cached files
 	if stat != nil {
-		c.Response().Header().Set(echo.HeaderLastModified, stat.ModTime().UTC().Format(http.TimeFormat))
+		modTime := stat.ModTime().UTC()
+		c.Response().Header().Set(echo.HeaderLastModified, modTime.Format(http.TimeFormat))
+
+		// Check If-Modified-Since and return 304 if the file hasn't changed
+		if ifModSince := c.Request().Header.Get("If-Modified-Since"); ifModSince != "" {
+			if t, err := http.ParseTime(ifModSince); err == nil && !modTime.After(t) {
+				return c.NoContent(http.StatusNotModified)
+			}
+		}
 	}
 
 	// Serve the file

--- a/pkg/routes/api/v1/task_attachment.go
+++ b/pkg/routes/api/v1/task_attachment.go
@@ -217,8 +217,19 @@ func GetTaskAttachment(c *echo.Context) error {
 	c.Response().Header().Set("Content-Type", mimeToReturn)
 	c.Response().Header().Set("Content-Length", strconv.FormatUint(taskAttachment.File.Size, 10))
 	c.Response().Header().Set("Last-Modified", taskAttachment.File.Created.UTC().Format(http.TimeFormat))
+	// Override the global no-store directive so browsers can cache attachments.
+	// no-cache allows caching but requires revalidation via If-Modified-Since.
+	c.Response().Header().Set("Cache-Control", "no-cache")
 
 	if config.FilesType.GetString() == "s3" {
+		// Check If-Modified-Since and return 304 if the file hasn't changed.
+		// http.ServeContent handles this automatically for local files.
+		if ifModSince := c.Request().Header.Get("If-Modified-Since"); ifModSince != "" {
+			if t, parseErr := http.ParseTime(ifModSince); parseErr == nil && !taskAttachment.File.Created.UTC().After(t) {
+				return c.NoContent(http.StatusNotModified)
+			}
+		}
+
 		// s3 files cannot use http.ServeContent as it requires a Seekable file
 		// so we stream the file content directly to the response
 		_, err = io.Copy(c.Response(), taskAttachment.File.File)


### PR DESCRIPTION
## Problem

The global API middleware sets `Cache-Control: no-store` on all `/api/v1/` responses to prevent browsers from heuristically caching JSON data. However, this also applies to binary file downloads (project backgrounds, task attachments), causing browsers to re-download these files on every request — even though they have `Last-Modified` headers set.

## Fix

Override `Cache-Control` to `no-cache` in the file download endpoints for:
- **Project backgrounds** (`/api/v1/projects/{id}/background`)
- **Task attachments** (`/api/v1/tasks/{id}/attachments/{id}`)

`no-cache` allows the browser to store the file locally but requires revalidation via `If-Modified-Since` before using the cached copy. Since these files are immutable (updates create a new file with a new ID), the `Last-Modified` header already set by these endpoints is sufficient for correct revalidation.

Export downloads are intentionally left with `no-store` since they are one-time downloads.