### PR TITLE
feat: add unified New Task button with full detail view creation

### DIFF
--- a/frontend/src/components/project/ProjectWrapper.vue
+++ b/frontend/src/components/project/ProjectWrapper.vue
@@ -32,6 +32,7 @@
 				class="is-flex is-align-items-center"
 				style="gap: .5rem"
 			>
+				<slot name="header" />
 				<XButton
 					v-if="canWrite && !currentProject?.isArchived"
 					icon="plus"
@@ -39,7 +40,6 @@
 				>
 					{{ $t('task.newTask') }}
 				</XButton>
-				<slot name="header" />
 			</div>
 		</div>
 		<CustomTransition name="fade">

--- a/frontend/src/components/project/ProjectWrapper.vue
+++ b/frontend/src/components/project/ProjectWrapper.vue
@@ -28,7 +28,19 @@
 					{{ getViewTitle(view) }}
 				</BaseButton>
 			</div>
-			<slot name="header" />
+			<div
+				class="is-flex is-align-items-center"
+				style="gap: .5rem"
+			>
+				<XButton
+					v-if="canWrite && !currentProject?.isArchived"
+					icon="plus"
+					:to="{name: 'task.new', params: {projectId: projectId}}"
+				>
+					{{ $t('task.newTask') }}
+				</XButton>
+				<slot name="header" />
+			</div>
 		</div>
 		<CustomTransition name="fade">
 			<Message
@@ -49,6 +61,7 @@ import {computed} from 'vue'
 import {useI18n} from 'vue-i18n'
 
 import BaseButton from '@/components/base/BaseButton.vue'
+import XButton from '@/components/input/Button.vue'
 import Message from '@/components/misc/Message.vue'
 import CustomTransition from '@/components/misc/CustomTransition.vue'
 
@@ -58,6 +71,8 @@ import {useTitle} from '@/composables/useTitle'
 import {useBaseStore} from '@/stores/base'
 import {useProjectStore} from '@/stores/projects'
 import {useViewFiltersStore} from '@/stores/viewFilters'
+
+import {PERMISSIONS} from '@/constants/permissions'
 
 import type {IProject} from '@/modelTypes/IProject'
 import type {IProjectView} from '@/modelTypes/IProjectView'
@@ -83,6 +98,10 @@ const currentProject = computed<IProject>(() => {
 	}
 })
 useTitle(() => currentProject.value?.id ? getProjectTitle(currentProject.value) : '')
+
+const canWrite = computed(() => {
+	return (currentProject.value?.maxPermission ?? 0) > PERMISSIONS.READ && currentProject.value?.id > 0
+})
 
 const views = computed(() => projectStore.projects[props.projectId]?.views)
 

--- a/frontend/src/components/tasks/partials/Description.vue
+++ b/frontend/src/components/tasks/partials/Description.vue
@@ -96,6 +96,16 @@ async function saveWithDelay() {
 	}
 
 	hasChanges.value = true
+
+	// For new tasks, sync immediately since there's no API call
+	if (isNewTask.value) {
+		emit('update:modelValue', {
+			...props.modelValue,
+			description: description.value,
+		})
+		return
+	}
+
 	if (changeTimeout.value !== null) {
 		clearTimeout(changeTimeout.value)
 	}

--- a/frontend/src/components/tasks/partials/Description.vue
+++ b/frontend/src/components/tasks/partials/Description.vue
@@ -41,7 +41,7 @@
 </template>
 
 <script setup lang="ts">
-import {ref, computed, watchEffect,  onBeforeUnmount} from 'vue'
+import {ref, computed, watchEffect, onBeforeUnmount, inject} from 'vue'
 import {onBeforeRouteLeave} from 'vue-router'
 
 import CustomTransition from '@/components/misc/CustomTransition.vue'
@@ -55,7 +55,7 @@ export type AttachmentUploadFunction = (file: File, onSuccess: (attachmentUrl: s
 
 const props = defineProps<{
 	modelValue: ITask,
-	attachmentUpload: AttachmentUploadFunction,
+	attachmentUpload?: AttachmentUploadFunction,
 	canWrite: boolean,
 }>()
 
@@ -63,6 +63,7 @@ const emit = defineEmits<{
 	'update:modelValue': [value: ITask]
 }>()
 
+const isNewTask = inject('isNewTask', ref(false))
 const description = ref<string>('')
 const hasChanges = ref(false)
 watchEffect(() => {
@@ -80,7 +81,10 @@ const loading = computed(() => taskStore.isLoading)
 
 const changeTimeout = ref<ReturnType<typeof setTimeout> | null>(null)
 
-const descriptionStorageKey = computed(() => `task-description-${props.modelValue.id}`)
+const descriptionStorageKey = computed(() => {
+	if (isNewTask.value) return ''
+	return `task-description-${props.modelValue.id}`
+})
 
 async function saveWithDelay() {
 	if (description.value === props.modelValue.description) {
@@ -119,6 +123,16 @@ async function save() {
 	if (changeTimeout.value !== null) {
 		clearTimeout(changeTimeout.value)
 	}
+
+	// For new tasks, just update the local model without calling API
+	if (isNewTask.value) {
+		emit('update:modelValue', {
+			...props.modelValue,
+			description: description.value,
+		})
+		return
+	}
+
 	saved.value = false
 	saving.value = true
 
@@ -150,11 +164,13 @@ async function save() {
 }
 
 async function uploadCallback(files: File[] | FileList): Promise<string[]> {
+	if (!props.attachmentUpload) return []
+
 	const uploadPromises: Promise<string>[] = []
 
 	files.forEach((file: File) => {
 		const promise = new Promise<string>((resolve) => {
-			props.attachmentUpload(file, (uploadedFileUrl: string) => resolve(uploadedFileUrl))
+			props.attachmentUpload!(file, (uploadedFileUrl: string) => resolve(uploadedFileUrl))
 		})
 
 		uploadPromises.push(promise)

--- a/frontend/src/components/tasks/partials/EditAssignees.vue
+++ b/frontend/src/components/tasks/partials/EditAssignees.vue
@@ -32,7 +32,7 @@
 </template>
 
 <script setup lang="ts">
-import {ref, shallowReactive, watch, nextTick} from 'vue'
+import {ref, shallowReactive, watch, nextTick, inject} from 'vue'
 import {useI18n} from 'vue-i18n'
 
 import User from '@/components/misc/User.vue'
@@ -62,6 +62,7 @@ const emit = defineEmits<{
 
 const taskStore = useTaskStore()
 const {t} = useI18n({useScope: 'global'})
+const isNewTask = inject('isNewTask', ref(false))
 
 const projectUserService = shallowReactive(new ProjectUserService())
 const foundUsers = ref<IUser[]>([])
@@ -87,24 +88,30 @@ async function addAssignee(user: IUser) {
 	try {
 		nextTick(() => isAdding = true)
 
-		await taskStore.addAssignee({user: user, taskId: props.taskId})
+		if (!isNewTask.value) {
+			await taskStore.addAssignee({user: user, taskId: props.taskId})
+			success({message: t('task.assignee.assignSuccess')})
+		}
 		emit('update:modelValue', assignees.value)
-		success({message: t('task.assignee.assignSuccess')})
 	} finally {
 		nextTick(() => isAdding = false)
 	}
 }
 
 async function removeAssignee(user: IUser) {
-	await taskStore.removeAssignee({user: user, taskId: props.taskId})
+	if (!isNewTask.value) {
+		await taskStore.removeAssignee({user: user, taskId: props.taskId})
+	}
 
-	// Remove the assignee from the project
+	// Remove the assignee from the list
 	for (const a in assignees.value) {
 		if (assignees.value[a].id === user.id) {
 			assignees.value.splice(a, 1)
 		}
 	}
-	success({message: t('task.assignee.unassignSuccess')})
+	if (!isNewTask.value) {
+		success({message: t('task.assignee.unassignSuccess')})
+	}
 }
 
 async function findUser(query: string) {

--- a/frontend/src/components/tasks/partials/Heading.vue
+++ b/frontend/src/components/tasks/partials/Heading.vue
@@ -67,6 +67,7 @@
 <script setup lang="ts">
 import {ref, computed, onMounted, onBeforeUnmount, watch} from 'vue'
 import {useRouter} from 'vue-router'
+import {useI18n} from 'vue-i18n'
 
 import BaseButton from '@/components/base/BaseButton.vue'
 import CustomTransition from '@/components/misc/CustomTransition.vue'
@@ -83,6 +84,7 @@ const props = defineProps<{
 	task: ITask,
 	canWrite: boolean,
 	hasClose: boolean,
+	isNewTask?: boolean,
 }>()
 
 const emit = defineEmits<{
@@ -91,9 +93,11 @@ const emit = defineEmits<{
 }>()
 
 const router = useRouter()
+const {t} = useI18n({useScope: 'global'})
 const copy = useCopyToClipboard()
 
 async function copyUrl() {
+	if (props.isNewTask) return
 	const route = router.resolve({name: 'task.detail', query: {taskId: props.task.id}})
 	const absoluteURL = new URL(route.href, window.location.href).href
 
@@ -103,7 +107,12 @@ async function copyUrl() {
 const taskStore = useTaskStore()
 const loading = computed(() => taskStore.isLoading)
 
-const textIdentifier = computed(() => getTaskIdentifier(props.task))
+const textIdentifier = computed(() => {
+	if (props.isNewTask) {
+		return t('task.detail.newTaskIdentifier')
+	}
+	return getTaskIdentifier(props.task)
+})
 
 // Since loading is global state, this variable ensures we're only showing the saving icon when saving the description.
 const saving = ref(false)
@@ -144,6 +153,13 @@ async function save(title: string) {
 	// We only want to save if the title was actually changed.
 	// so we only continue if the task title changed.
 	if (title === props.task.title) {
+		return
+	}
+
+	// For new tasks, just emit the title change without saving to API
+	if (props.isNewTask) {
+		emit('update:task', {...props.task, title})
+		titleHasChanges.value = false
 		return
 	}
 

--- a/frontend/src/components/tasks/partials/Heading.vue
+++ b/frontend/src/components/tasks/partials/Heading.vue
@@ -65,7 +65,7 @@
 </template>
 
 <script setup lang="ts">
-import {ref, computed, onMounted, onBeforeUnmount, watch} from 'vue'
+import {ref, computed, onMounted, onBeforeUnmount, watch, inject} from 'vue'
 import {useRouter} from 'vue-router'
 import {useI18n} from 'vue-i18n'
 
@@ -84,7 +84,6 @@ const props = defineProps<{
 	task: ITask,
 	canWrite: boolean,
 	hasClose: boolean,
-	isNewTask?: boolean,
 }>()
 
 const emit = defineEmits<{
@@ -95,9 +94,10 @@ const emit = defineEmits<{
 const router = useRouter()
 const {t} = useI18n({useScope: 'global'})
 const copy = useCopyToClipboard()
+const isNewTask = inject('isNewTask', ref(false))
 
 async function copyUrl() {
-	if (props.isNewTask) return
+	if (isNewTask.value) return
 	const route = router.resolve({name: 'task.detail', query: {taskId: props.task.id}})
 	const absoluteURL = new URL(route.href, window.location.href).href
 
@@ -108,7 +108,7 @@ const taskStore = useTaskStore()
 const loading = computed(() => taskStore.isLoading)
 
 const textIdentifier = computed(() => {
-	if (props.isNewTask) {
+	if (isNewTask.value) {
 		return t('task.detail.newTaskIdentifier')
 	}
 	return getTaskIdentifier(props.task)
@@ -157,7 +157,7 @@ async function save(title: string) {
 	}
 
 	// For new tasks, just emit the title change without saving to API
-	if (props.isNewTask) {
+	if (isNewTask.value) {
 		emit('update:task', {...props.task, title})
 		titleHasChanges.value = false
 		return

--- a/frontend/src/helpers/case.ts
+++ b/frontend/src/helpers/case.ts
@@ -18,7 +18,11 @@ export function objectToCamelCase(object: Record<string, any>) {
 
 		// Recursive processing
 		// Prevent processing for some cases
-		if (object[m] === null) {
+		if (
+			object[m] === null ||
+			(object[m] instanceof Date) ||
+			(typeof object[m]?.getTime === 'function')
+		) {
 			continue
 		}
 

--- a/frontend/src/helpers/case.ts
+++ b/frontend/src/helpers/case.ts
@@ -20,8 +20,7 @@ export function objectToCamelCase(object: Record<string, any>) {
 		// Prevent processing for some cases
 		if (
 			object[m] === null ||
-			(object[m] instanceof Date) ||
-			(typeof object[m]?.getTime === 'function')
+			(object[m] instanceof Date)
 		) {
 			continue
 		}

--- a/frontend/src/i18n/lang/en.json
+++ b/frontend/src/i18n/lang/en.json
@@ -817,6 +817,7 @@
   "task": {
     "task": "Task",
     "new": "Create a task",
+    "newTask": "New Task",
     "delete": "Delete this task",
     "createSuccess": "The task was successfully created.",
     "addReminder": "Add a reminder…",
@@ -849,6 +850,9 @@
       "updated": "Updated {0}",
       "doneAt": "Done {0}",
       "updateSuccess": "The task was saved successfully.",
+      "createSuccess": "The task was created successfully.",
+      "newTaskIdentifier": "New",
+      "save": "Save",
       "deleteSuccess": "The task has been deleted successfully.",
       "belongsToProject": "This task belongs to project '{project}'",
       "back": "Back to project",

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -173,6 +173,12 @@ const router = createRouter({
 			component: LinkSharingAuth,
 		},
 		{
+			path: '/projects/:projectId/tasks/new',
+			name: 'task.new',
+			component: () => import('@/views/tasks/TaskDetailView.vue'),
+			props: route => ({ taskId: 0, newTaskProjectId: Number(route.params.projectId as string) }),
+		},
+		{
 			path: '/tasks/:id',
 			name: 'task.detail',
 			component: () => import('@/views/tasks/TaskDetailView.vue'),

--- a/frontend/src/services/task.ts
+++ b/frontend/src/services/task.ts
@@ -57,8 +57,8 @@ export default class TaskService extends AbstractService<ITask> {
 		model.startDate = parseDate(model.startDate)
 		model.endDate = parseDate(model.endDate)
 		model.doneAt = parseDate(model.doneAt)
-		model.created = new Date(model.created).toISOString()
-		model.updated = new Date(model.updated).toISOString()
+		model.created = parseDate(model.created)
+		model.updated = parseDate(model.updated)
 
 		model.reminderDates = null
 		// remove all nulls, these would create empty reminders

--- a/frontend/src/views/tasks/TaskDetailView.vue
+++ b/frontend/src/views/tasks/TaskDetailView.vue
@@ -1105,12 +1105,6 @@ async function saveTask(
 
 async function createNewTask() {
 	const t_ = task.value
-	const hexColor = taskColor.value
-
-	let endDate = t_.endDate
-	if (endDate === null && t_.startDate !== null && t_.dueDate !== null) {
-		endDate = t_.dueDate
-	}
 
 	const newTask = new TaskModel({
 		title: t_.title || t('task.newTask'),
@@ -1119,8 +1113,8 @@ async function createNewTask() {
 		priority: t_.priority,
 		dueDate: t_.dueDate,
 		startDate: t_.startDate,
-		endDate,
-		hexColor,
+		endDate: t_.endDate,
+		hexColor: taskColor.value,
 		percentDone: t_.percentDone,
 		reminders: t_.reminders,
 		repeatAfter: t_.repeatAfter?.amount ? periodToSeconds(t_.repeatAfter.amount, t_.repeatAfter.type) : 0,

--- a/frontend/src/views/tasks/TaskDetailView.vue
+++ b/frontend/src/views/tasks/TaskDetailView.vue
@@ -25,7 +25,6 @@
 				:task="task"
 				:can-write="canWrite"
 				:has-close="isModal"
-				:is-new-task="isNewTask"
 				@update:task="Object.assign(task, $event)"
 				@close="$emit('close')"
 			/>

--- a/frontend/src/views/tasks/TaskDetailView.vue
+++ b/frontend/src/views/tasks/TaskDetailView.vue
@@ -426,86 +426,16 @@
 					v-if="canWrite || isModal"
 					class="column is-one-third action-buttons d-print-none"
 				>
-					<template v-if="canWrite && isNewTask">
+					<template v-if="canWrite">
 						<XButton
+							v-if="isNewTask"
 							icon="check"
 							@click="createNewTask()"
 						>
 							{{ $t('task.detail.save') }}
 						</XButton>
-						
-						<span class="action-heading">{{ $t('task.detail.organization') }}</span>
-						
 						<XButton
-							variant="secondary"
-							icon="users"
-							@click="setFieldActive('assignees')"
-						>
-							{{ $t('task.detail.actions.assign') }}
-						</XButton>
-						<XButton
-							variant="secondary"
-							icon="exclamation-circle"
-							@click="setFieldActive('priority')"
-						>
-							{{ $t('task.detail.actions.priority') }}
-						</XButton>
-						<XButton
-							variant="secondary"
-							icon="percent"
-							@click="setFieldActive('percentDone')"
-						>
-							{{ $t('task.detail.actions.percentDone') }}
-						</XButton>
-						<XButton
-							variant="secondary"
-							icon="fill-drip"
-							:icon-color="color"
-							@click="setFieldActive('color')"
-						>
-							{{ $t('task.detail.actions.color') }}
-						</XButton>
-						
-						<span class="action-heading">{{ $t('task.detail.dateAndTime') }}</span>
-						
-						<XButton
-							variant="secondary"
-							icon="calendar"
-							@click="setFieldActive('dueDate')"
-						>
-							{{ $t('task.detail.actions.dueDate') }}
-						</XButton>
-						<XButton
-							variant="secondary"
-							icon="play"
-							@click="setFieldActive('startDate')"
-						>
-							{{ $t('task.detail.actions.startDate') }}
-						</XButton>
-						<XButton
-							variant="secondary"
-							icon="stop"
-							@click="setFieldActive('endDate')"
-						>
-							{{ $t('task.detail.actions.endDate') }}
-						</XButton>
-						<XButton
-							variant="secondary"
-							:icon="['far', 'clock']"
-							@click="setFieldActive('reminders')"
-						>
-							{{ $t('task.detail.actions.reminders') }}
-						</XButton>
-						<XButton
-							variant="secondary"
-							icon="history"
-							@click="setFieldActive('repeatAfter')"
-						>
-							{{ $t('task.detail.actions.repeatAfter') }}
-						</XButton>
-					</template>
-					<template v-else-if="canWrite">
-						<XButton
+							v-if="!isNewTask"
 							v-shortcut="'t'"
 							:class="{'is-pending': !task.done}"
 							class="button--mark-done"
@@ -516,12 +446,14 @@
 							{{ task.done ? $t('task.detail.undone') : $t('task.detail.done') }}
 						</XButton>
 						<TaskSubscription
+							v-if="!isNewTask"
 							entity="task"
 							:entity-id="task.id"
 							:model-value="task.subscription"
 							@update:modelValue="sub => task.subscription = sub"
 						/>
 						<XButton
+							v-if="!isNewTask"
 							v-shortcut="'s'"
 							variant="secondary"
 							:icon="task.isFavorite ? 'star' : ['far', 'star']"
@@ -535,6 +467,7 @@
 						<span class="action-heading">{{ $t('task.detail.organization') }}</span>
 						
 						<XButton
+							v-if="!isNewTask"
 							v-shortcut="'l'"
 							variant="secondary"
 							icon="tags"
@@ -567,7 +500,10 @@
 							{{ $t('task.detail.actions.color') }}
 						</XButton>
 						
-						<span class="action-heading">{{ $t('task.detail.management') }}</span>
+						<span
+							v-if="!isNewTask"
+							class="action-heading"
+						>{{ $t('task.detail.management') }}</span>
 
 						<XButton
 							v-shortcut="'a'"
@@ -579,6 +515,7 @@
 							{{ $t('task.detail.actions.assign') }}
 						</XButton>
 						<XButton
+							v-if="!isNewTask"
 							v-shortcut="'f'"
 							variant="secondary"
 							icon="paperclip"
@@ -587,6 +524,7 @@
 							{{ $t('task.detail.actions.attachments') }}
 						</XButton>
 						<XButton
+							v-if="!isNewTask"
 							v-shortcut="'r'"
 							variant="secondary"
 							icon="sitemap"
@@ -595,6 +533,7 @@
 							{{ $t('task.detail.actions.relatedTasks') }}
 						</XButton>
 						<XButton
+							v-if="!isNewTask"
 							v-shortcut="'m'"
 							variant="secondary"
 							icon="list"
@@ -643,6 +582,7 @@
 							{{ $t('task.detail.actions.repeatAfter') }}
 						</XButton>
 						<XButton
+							v-if="!isNewTask"
 							v-shortcut="'Shift+Delete'"
 							icon="trash-alt"
 							:shadow="false"

--- a/frontend/src/views/tasks/TaskDetailView.vue
+++ b/frontend/src/views/tasks/TaskDetailView.vue
@@ -25,6 +25,7 @@
 				:task="task"
 				:can-write="canWrite"
 				:has-close="isModal"
+				:is-new-task="isNewTask"
 				@update:task="Object.assign(task, $event)"
 				@close="$emit('close')"
 			/>
@@ -57,7 +58,10 @@
 				</template>
 			</h6>
 
-			<ChecklistSummary :task="task" />
+			<ChecklistSummary
+				v-if="!isNewTask"
+				:task="task"
+			/>
 
 			<!-- Content and buttons -->
 			<div class="columns mbs-2">
@@ -308,7 +312,7 @@
 
 					<!-- Labels -->
 					<div
-						v-if="activeFields.labels"
+						v-if="activeFields.labels && !isNewTask"
 						class="labels-list details"
 					>
 						<div class="detail-title">
@@ -331,13 +335,14 @@
 						<Description
 							:model-value="task"
 							:can-write="canWrite"
-							:attachment-upload="attachmentUpload"
+							:attachment-upload="isNewTask ? undefined : attachmentUpload"
 							@update:modelValue="Object.assign(task, $event)"
 						/>
 					</div>
 					
 					<!-- Reactions -->
-					<Reactions 
+					<Reactions
+						v-if="!isNewTask"
 						v-model="task.reactions" 
 						entity-kind="tasks"
 						:entity-id="task.id"
@@ -347,7 +352,7 @@
 
 					<!-- Attachments -->
 					<div
-						v-show="activeFields.attachments || hasAttachments"
+						v-show="!isNewTask && (activeFields.attachments || hasAttachments)"
 						class="content attachments"
 					>
 						<Attachments
@@ -360,7 +365,7 @@
 
 					<!-- Related Tasks -->
 					<div
-						v-if="activeFields.relatedTasks"
+						v-if="activeFields.relatedTasks && !isNewTask"
 						class="content details mbe-0"
 					>
 						<h3>
@@ -381,7 +386,7 @@
 
 					<!-- Move Task -->
 					<div
-						v-if="activeFields.moveProject"
+						v-if="activeFields.moveProject && !isNewTask"
 						class="content details"
 					>
 						<h3>
@@ -403,6 +408,7 @@
 
 					<!-- Comments -->
 					<Comments
+						v-if="!isNewTask"
 						:can-write="canWrite"
 						:task-id="taskId"
 						:project-id="task.projectId"
@@ -421,7 +427,85 @@
 					v-if="canWrite || isModal"
 					class="column is-one-third action-buttons d-print-none"
 				>
-					<template v-if="canWrite">
+					<template v-if="canWrite && isNewTask">
+						<XButton
+							icon="check"
+							@click="createNewTask()"
+						>
+							{{ $t('task.detail.save') }}
+						</XButton>
+						
+						<span class="action-heading">{{ $t('task.detail.organization') }}</span>
+						
+						<XButton
+							variant="secondary"
+							icon="users"
+							@click="setFieldActive('assignees')"
+						>
+							{{ $t('task.detail.actions.assign') }}
+						</XButton>
+						<XButton
+							variant="secondary"
+							icon="exclamation-circle"
+							@click="setFieldActive('priority')"
+						>
+							{{ $t('task.detail.actions.priority') }}
+						</XButton>
+						<XButton
+							variant="secondary"
+							icon="percent"
+							@click="setFieldActive('percentDone')"
+						>
+							{{ $t('task.detail.actions.percentDone') }}
+						</XButton>
+						<XButton
+							variant="secondary"
+							icon="fill-drip"
+							:icon-color="color"
+							@click="setFieldActive('color')"
+						>
+							{{ $t('task.detail.actions.color') }}
+						</XButton>
+						
+						<span class="action-heading">{{ $t('task.detail.dateAndTime') }}</span>
+						
+						<XButton
+							variant="secondary"
+							icon="calendar"
+							@click="setFieldActive('dueDate')"
+						>
+							{{ $t('task.detail.actions.dueDate') }}
+						</XButton>
+						<XButton
+							variant="secondary"
+							icon="play"
+							@click="setFieldActive('startDate')"
+						>
+							{{ $t('task.detail.actions.startDate') }}
+						</XButton>
+						<XButton
+							variant="secondary"
+							icon="stop"
+							@click="setFieldActive('endDate')"
+						>
+							{{ $t('task.detail.actions.endDate') }}
+						</XButton>
+						<XButton
+							variant="secondary"
+							:icon="['far', 'clock']"
+							@click="setFieldActive('reminders')"
+						>
+							{{ $t('task.detail.actions.reminders') }}
+						</XButton>
+						<XButton
+							variant="secondary"
+							icon="history"
+							@click="setFieldActive('repeatAfter')"
+						>
+							{{ $t('task.detail.actions.repeatAfter') }}
+						</XButton>
+					</template>
+					<template v-else-if="canWrite">
 						<XButton
 							v-shortcut="'t'"
 							:class="{'is-pending': !task.done}"
@@ -571,7 +655,10 @@
 					</template>
 
 					<!-- Created / Updated [by] -->
-					<CreatedUpdated :task="task" />
+					<CreatedUpdated
+						v-if="!isNewTask"
+						:task="task"
+					/>
 				</div>
 			</div>
 			<!-- Created / Updated [by] -->
@@ -613,7 +700,7 @@
 </template>
 
 <script lang="ts" setup>
-import {ref, reactive, shallowReactive, computed, watch, nextTick, onMounted} from 'vue'
+import {ref, reactive, shallowReactive, computed, watch, nextTick, onMounted, provide} from 'vue'
 import {useRouter, useRoute, type RouteLocation, onBeforeRouteLeave} from 'vue-router'
 import {storeToRefs} from 'pinia'
 import {useI18n} from 'vue-i18n'
@@ -658,6 +745,7 @@ import {getProjectTitle} from '@/helpers/getProjectTitle'
 import {isAppleDevice} from '@/helpers/isAppleDevice'
 import {scrollIntoView} from '@/helpers/scrollIntoView'
 import {TASK_REPEAT_MODES} from '@/types/IRepeatMode'
+import {periodToSeconds} from '@/helpers/time/period'
 import {playPopSound} from '@/helpers/playPop'
 
 import {useAttachmentStore} from '@/stores/attachments'
@@ -676,6 +764,7 @@ import type {Action as MessageAction} from '@/message'
 const props = defineProps<{
 	taskId: ITask['id'],
 	backdropView?: RouteLocation['fullPath'],
+	newTaskProjectId?: IProject['id'],
 }>()
 
 defineEmits<{
@@ -693,6 +782,9 @@ const taskStore = useTaskStore()
 const kanbanStore = useKanbanStore()
 const authStore = useAuthStore()
 const baseStore = useBaseStore()
+
+const isNewTask = computed(() => props.taskId === 0 && (props.newTaskProjectId ?? 0) > 0)
+provide('isNewTask', isNewTask)
 
 const task = ref<ITask>(new TaskModel())
 const taskNotFound = ref(false)
@@ -767,10 +859,14 @@ const projectRoute = computed(() => ({
 	hash: route.hash,
 }))
 
-const canWrite = computed(() => (
-	task.value.maxPermission !== null &&
-	task.value.maxPermission > PERMISSIONS.READ
-))
+const canWrite = computed(() => {
+	if (isNewTask.value) {
+		const p = projectStore.projects[props.newTaskProjectId!]
+		return p?.maxPermission !== null && p?.maxPermission > PERMISSIONS.READ
+	}
+	return task.value.maxPermission !== null &&
+		task.value.maxPermission > PERMISSIONS.READ
+})
 
 const color = computed(() => {
 	const color = task.value.getHexColor
@@ -878,6 +974,20 @@ watch(
 	() => props.taskId,
 	async (id) => {
 		if (id === undefined) {
+			return
+		}
+
+		// New task mode: initialize blank task
+		if (isNewTask.value) {
+			Object.assign(task.value, new TaskModel({
+				projectId: props.newTaskProjectId,
+			}))
+			taskColor.value = ''
+			await nextTick()
+			scrollToHeading()
+			resolveScrollContainer()
+			updateScrollable()
+			visible.value = true
 			return
 		}
 
@@ -1034,6 +1144,12 @@ async function saveTask(
 		currentTask.endDate = currentTask.dueDate
 	}
 
+	// In new task mode, saveTask is a no-op — field changes just update local state.
+	// Vue v-model already keeps task ref in sync, so nothing to do here.
+	if (isNewTask.value) {
+		return
+	}
+
 	const updatedTask = await taskStore.update(currentTask) // TODO: markraw ?
 	Object.assign(task.value, updatedTask)
 	setActiveFields()
@@ -1046,6 +1162,42 @@ async function saveTask(
 		}]
 	}
 	success({message: t('task.detail.updateSuccess')}, actions)
+}
+
+async function createNewTask() {
+	const t_ = task.value
+	const hexColor = taskColor.value
+
+	let endDate = t_.endDate
+	if (endDate === null && t_.startDate !== null && t_.dueDate !== null) {
+		endDate = t_.dueDate
+	}
+
+	const newTask = new TaskModel({
+		title: t_.title || t('task.newTask'),
+		description: t_.description,
+		projectId: t_.projectId,
+		priority: t_.priority,
+		dueDate: t_.dueDate,
+		startDate: t_.startDate,
+		endDate,
+		hexColor,
+		percentDone: t_.percentDone,
+		reminders: t_.reminders,
+		repeatAfter: t_.repeatAfter?.amount ? periodToSeconds(t_.repeatAfter.amount, t_.repeatAfter.type) : 0,
+		repeatMode: t_.repeatMode,
+	})
+	const createdTask = await taskService.create(newTask)
+
+	// Assign users after creation (assignees API requires a real task ID)
+	if (t_.assignees?.length > 0) {
+		for (const user of t_.assignees) {
+			await taskStore.addAssignee({user, taskId: createdTask.id})
+		}
+	}
+
+	success({message: t('task.detail.createSuccess')})
+	router.replace({name: 'task.detail', params: {id: createdTask.id}})
 }
 
 useTaskDetailShortcuts({

--- a/frontend/tests/e2e/task/new-task.spec.ts
+++ b/frontend/tests/e2e/task/new-task.spec.ts
@@ -1,0 +1,162 @@
+import {test, expect} from '../../support/fixtures'
+import {ProjectFactory} from '../../factories/project'
+import {TaskFactory} from '../../factories/task'
+import {UserFactory} from '../../factories/user'
+import {UserProjectFactory} from '../../factories/users_project'
+import {BucketFactory} from '../../factories/bucket'
+import {createDefaultViews, createProjects} from '../project/prepareProjects'
+
+test.describe('New Task', () => {
+	test.beforeEach(async ({authenticatedPage: page}) => {
+		await createProjects(1)
+		await BucketFactory.create(1, {
+			project_view_id: 4,
+		})
+	})
+
+	test.describe('New Task Button', () => {
+		test('Should show the New Task button on the list view', async ({authenticatedPage: page}) => {
+			await page.goto('/projects/1/1')
+			await expect(page.locator('.switch-view-container .button').filter({hasText: 'New Task'})).toBeVisible()
+		})
+
+		test('Should show the New Task button on the table view', async ({authenticatedPage: page}) => {
+			await page.goto('/projects/1/3')
+			await expect(page.locator('.switch-view-container .button').filter({hasText: 'New Task'})).toBeVisible()
+		})
+
+		test('Should show the New Task button on the kanban view', async ({authenticatedPage: page}) => {
+			await page.goto('/projects/1/4')
+			await expect(page.locator('.switch-view-container .button').filter({hasText: 'New Task'})).toBeVisible()
+		})
+
+		test('Should not show the New Task button for read-only projects', async ({authenticatedPage: page}) => {
+			await UserFactory.create(2)
+			await UserProjectFactory.create(1, {
+				project_id: 2,
+				user_id: 1,
+				permission: 0,
+			})
+			const projects = await ProjectFactory.create(2, {
+				owner_id: '{increment}',
+			})
+			await page.goto(`/projects/${projects[1].id}/`)
+
+			await expect(page.locator('.switch-view-container .button').filter({hasText: 'New Task'})).not.toBeVisible()
+		})
+
+		test('Should navigate to new task page when clicked', async ({authenticatedPage: page}) => {
+			await page.goto('/projects/1/1')
+			await page.locator('.switch-view-container .button').filter({hasText: 'New Task'}).click()
+			await expect(page).toHaveURL(/\/projects\/1\/tasks\/new/)
+		})
+	})
+
+	test.describe('New Task Detail View', () => {
+		test('Should show the new task identifier', async ({authenticatedPage: page}) => {
+			await page.goto('/projects/1/tasks/new')
+
+			await expect(page.locator('.task-view h1.title.task-id')).toContainText('New')
+		})
+
+		test('Should show the project name', async ({authenticatedPage: page}) => {
+			await page.goto('/projects/1/tasks/new')
+
+			await expect(page.locator('.task-view h6.subtitle')).toContainText('First Project')
+		})
+
+		test('Should show a Save button', async ({authenticatedPage: page}) => {
+			await page.goto('/projects/1/tasks/new')
+
+			await expect(page.locator('.task-view .action-buttons .button').filter({hasText: 'Save'})).toBeVisible()
+		})
+
+		test('Should not show comments section', async ({authenticatedPage: page}) => {
+			await page.goto('/projects/1/tasks/new')
+
+			await expect(page.locator('.task-view .comments')).not.toBeVisible()
+		})
+
+		test('Should not show the Done button', async ({authenticatedPage: page}) => {
+			await page.goto('/projects/1/tasks/new')
+
+			await expect(page.locator('.task-view .action-buttons .button').filter({hasText: 'Mark task done!'})).not.toBeVisible()
+		})
+
+		test('Should create a task with just a title', async ({authenticatedPage: page}) => {
+			await page.goto('/projects/1/tasks/new')
+
+			// Edit the title
+			const titleInput = page.locator('.task-view h1.title.input')
+			await titleInput.click()
+			await titleInput.fill('My New Task')
+			await titleInput.blur()
+
+			// Click Save
+			const createPromise = page.waitForResponse(response =>
+				response.url().includes('/projects/1/tasks') && response.request().method() === 'PUT',
+			)
+			await page.locator('.task-view .action-buttons .button').filter({hasText: 'Save'}).click()
+			await createPromise
+
+			// Should navigate to the real task detail
+			await expect(page).toHaveURL(/\/tasks\/\d+/)
+			await expect(page.locator('.task-view h1.title.input')).toContainText('My New Task')
+			await expect(page.locator('.global-notification')).toContainText('Success')
+		})
+
+		test('Should create a task with a priority', async ({authenticatedPage: page}) => {
+			await page.goto('/projects/1/tasks/new')
+
+			// Set priority
+			await page.locator('.task-view .action-buttons .button').filter({hasText: 'Set Priority'}).click()
+			await page.locator('.task-view .columns.details .column').filter({hasText: 'Priority'}).locator('.select select').selectOption('Urgent')
+
+			// Click Save
+			const createPromise = page.waitForResponse(response =>
+				response.url().includes('/projects/1/tasks') && response.request().method() === 'PUT',
+			)
+			await page.locator('.task-view .action-buttons .button').filter({hasText: 'Save'}).click()
+			await createPromise
+
+			// Should navigate and retain priority
+			await expect(page).toHaveURL(/\/tasks\/\d+/)
+			await expect(page.locator('.task-view .columns.details .column').filter({hasText: 'Priority'}).locator('.select select')).toHaveValue('4')
+		})
+
+		test('Should create a task with a due date', async ({authenticatedPage: page}) => {
+			await page.goto('/projects/1/tasks/new')
+			await page.waitForLoadState('networkidle')
+
+			// Set due date via the action button
+			const setDueDateButton = page.locator('.task-view .action-buttons .button').filter({hasText: 'Set Due Date'})
+			await expect(setDueDateButton).toBeVisible({timeout: 10000})
+			await setDueDateButton.click()
+
+			// The due date column should appear with a datepicker
+			const dueDateColumn = page.locator('.task-view .columns.details .column').filter({hasText: 'Due Date'})
+			await expect(dueDateColumn).toBeVisible()
+
+			// Click the datepicker show button to open the calendar
+			const datepickerShow = dueDateColumn.locator('.date-input .datepicker .show')
+			await expect(datepickerShow).toBeVisible()
+			await datepickerShow.click()
+
+			// Click today in the flatpickr calendar (this also closes the datepicker via closeOnChange)
+			const todayButton = page.locator('.datepicker-popup .flatpickr-innerContainer .flatpickr-days .flatpickr-day.today')
+			await expect(todayButton).toBeVisible()
+			await todayButton.click()
+
+			// Click Save
+			const createPromise = page.waitForResponse(response =>
+				response.url().includes('/projects/1/tasks') && response.request().method() === 'PUT',
+			)
+			await page.locator('.task-view .action-buttons .button').filter({hasText: 'Save'}).click()
+			await createPromise
+
+			// Should navigate to the real task detail with due date visible
+			await expect(page).toHaveURL(/\/tasks\/\d+/)
+			await expect(page.locator('.task-view .columns.details .column').filter({hasText: 'Due Date'})).toBeVisible()
+		})
+	})
+})

--- a/frontend/tests/e2e/task/new-task.spec.ts
+++ b/frontend/tests/e2e/task/new-task.spec.ts
@@ -105,6 +105,27 @@ test.describe('New Task', () => {
 			await expect(page.locator('.global-notification')).toContainText('Success')
 		})
 
+		test('Should create a task with a description without clicking editor save', async ({authenticatedPage: page}) => {
+			await page.goto('/projects/1/tasks/new')
+			await page.waitForLoadState('networkidle')
+
+			// Editor is already in edit mode for new tasks, type directly
+			const editor = page.locator('.task-view .details.content.description .tiptap__editor .tiptap.ProseMirror')
+			await expect(editor).toBeVisible({timeout: 10000})
+			await editor.fill('My task description')
+
+			// Directly click Save without clicking the editor's save button
+			const createPromise = page.waitForResponse(response =>
+				response.url().includes('/projects/1/tasks') && response.request().method() === 'PUT',
+			)
+			await page.locator('.task-view .action-buttons .button').filter({hasText: 'Save'}).click()
+			await createPromise
+
+			// Should navigate and retain the description
+			await expect(page).toHaveURL(/\/tasks\/\d+/)
+			await expect(page.locator('.task-view .details.content.description')).toContainText('My task description')
+		})
+
 		test('Should create a task with a priority', async ({authenticatedPage: page}) => {
 			await page.goto('/projects/1/tasks/new')
 


### PR DESCRIPTION
## Summary

Following the discussion in #2325, this adds a unified "New Task" button across all project views (List, Table, Kanban, Gantt) with a full task detail creation experience.

Instead of a quick-add text input, clicking "New Task" opens the full task detail view in create mode — similar to Azure DevOps where you fill in all fields before saving.

## Changes

### New Task Button
- Added in `ProjectWrapper.vue` (right side of header, after filter/columns buttons)
- Visible when user has write permission and project is not archived
- Route: `/projects/:projectId/tasks/new`

### Create Mode (`TaskDetailView`)
- Shows **"New"** as the task identifier
- Editable title (inline contenteditable, same as existing tasks)
- Full **TipTap rich text editor** for description
- **Priority, dates, color, percent done, reminders, repeat interval** — all editable locally, no API calls until Save
- **Assignees** — selected locally, assigned via API after creation
- **Save button** creates the task and redirects to the real task detail URL
- Hidden until after creation: labels, attachments, comments, reactions, related tasks, move project, subscriptions, favorites

### Technical Approach
- `provide/inject` for `isNewTask` flag (avoids prop drilling into Description, EditAssignees)
- `saveTask()` is a no-op in create mode — Vue `v-model` keeps local state in sync
- `createNewTask()` reads directly from `task.value` (avoids `klona` Date serialization issues)

### Bug Fixes (independent, first commit)
- **`objectToCamelCase`** was recursing into `Date` objects, destroying them into `{}`. Added the same Date skip guard that `objectToSnakeCase` already has.
- **`TaskService.processModel`** used `new Date(null).toISOString()` for `created`/`updated` which throws. Now uses the null-safe `parseDate` helper like all other date fields.

### E2E Tests
13 Playwright tests covering:
- Button visibility across views and read-only projects
- Navigation to new task page
- UI elements (identifier, project name, Save/Done buttons, comments)
- Task creation with title, priority, and due date

## Known Limitations
- **Attachments** are not available in create mode (API requires a real task ID). This also means **images cannot be inserted in the description** during creation.
- **Labels** require a real task ID for the label-task association API, so they are hidden in create mode.
- These features become available immediately after clicking Save and being redirected to the real task detail view.

Closes #2325