### PR TITLE
fix(caldav): Replace href with pathname from parseURL for api base

### DIFF
--- a/frontend/src/stores/config.ts
+++ b/frontend/src/stores/config.ts
@@ -87,12 +87,13 @@ export const useConfigStore = defineStore('config', () => {
 
 	const migratorsEnabled = computed(() => state.availableMigrators?.length > 0)
 	const apiBase = computed(() => {
-		const {host, protocol, href} = parseURL(window.API_URL)
+		const {host, protocol, pathname} = parseURL(window.API_URL)
 
-		const cleanHref = href ? (href.endsWith('/') 
-			? href.slice(0, -1) 
-			: href) : ''
-		return `${protocol}//${host}${cleanHref ? `/${cleanHref}` : ''}`
+		// Strip the /api/v1 suffix (and optional trailing slash) to get the deployment base.
+		const basePath = pathname
+			.replace(/\/api\/v1\/?$/, '')
+			.replace(/\/+$/, '')
+		return `${protocol}//${host}${basePath}`
 	})
 
 	function setConfig(config: ConfigState) {


### PR DESCRIPTION
Looking at the source code of `ufo.parseURL`:

```ts
export function parseURL(input = "", defaultProto?: string): ParsedURL {
  const _specialProtoMatch = input.match(
    /^[\s\0]*(blob:|data:|javascript:|vbscript:)(.*)/i,
  );
  if (_specialProtoMatch) {
    const [, _proto, _pathname = ""] = _specialProtoMatch;
    return {
      protocol: _proto.toLowerCase(),
      pathname: _pathname,
      href: _proto + _pathname,
      auth: "",
      host: "",
      search: "",
      hash: "",
    };
  }
  // ...

  return {
    protocol: protocol.toLowerCase(),
    auth: auth ? auth.slice(0, Math.max(0, auth.length - 1)) : "",
    host,
    pathname,
    search,
    hash,
    [protocolRelative]: !protocol,
  };
}

```

`parseURL` only return `href` for special protocols (blob, data, javascript, vbscript). For API_BASE, `href` will be undefined.

As a consequence, the computed `apiBase` will always be root path. For example: `https://try.vikunja.io/`. This is never a problem for standard deployments though, but when I'm trying to host it on some path prefix (e.g., `/vikunja`), the CalDAV URL would be wrong.

The patch usees `pathname` from `ufo.parseURL` which will not be undefined.