### PR TITLE
feat: Better support for deploying the frontend at a subpath

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -349,7 +349,9 @@ jobs:
           echo "{\"VERSION\": \"${{ steps.ghd.outputs.describe }}\"}" > src/version.json
       - name: Build frontend
         working-directory: frontend
-        run: VIKUNJA_BUILD_STANDALONE=true pnpm build
+        env:
+          VIKUNJA_BUILD_STANDALONE: true
+        run: pnpm build
       - name: Store Frontend
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -349,7 +349,7 @@ jobs:
           echo "{\"VERSION\": \"${{ steps.ghd.outputs.describe }}\"}" > src/version.json
       - name: Build frontend
         working-directory: frontend
-        run: pnpm build
+        run: VIKUNJA_BUILD_STANDALONE=true pnpm build
       - name: Store Frontend
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:

--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -10,6 +10,6 @@
 # SENTRY_ORG=vikunja
 # SENTRY_PROJECT=frontend-oss
 # VIKUNJA_FRONTEND_BASE=/custom-subpath
-# BUILD_STANDALONE=false
+# VIKUNJA_BUILD_STANDALONE=false
 
 # DEV_PROXY=http://vikunja-backend.domain.tld

--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -10,5 +10,6 @@
 # SENTRY_ORG=vikunja
 # SENTRY_PROJECT=frontend-oss
 # VIKUNJA_FRONTEND_BASE=/custom-subpath
+# BUILD_STANDALONE=false
 
 # DEV_PROXY=http://vikunja-backend.domain.tld

--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -10,6 +10,7 @@
 # SENTRY_ORG=vikunja
 # SENTRY_PROJECT=frontend-oss
 # VIKUNJA_FRONTEND_BASE=/custom-subpath
+# VIKUNJA_API_URL=https://api.example.com/api/v1
 # VIKUNJA_BUILD_STANDALONE=false
 
 # DEV_PROXY=http://vikunja-backend.domain.tld

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -22,9 +22,9 @@
 	// This variable points the frontend to the api.
 	// It has to be the full url, including the last /api/v1 part and port.
 	//
-	// At build time, Vite replaces __VIKUNJA_API_URL__ with
+	// At build time, Vite replaces VIKUNJA_API_URL with
 	// the configured API URL or base path (e.g. "/vikunja").
-	// At serve time, the Go backend replaces the __VIKUNJA_API_URL__ marker
+	// At serve time, the Go backend replaces the VIKUNJA_API_URL marker
 	// with service.publicurl + "/api/v1".
 	window.API_URL = '__VIKUNJA_API_URL__'
 	window.ALLOW_ICON_CHANGES = true

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -22,7 +22,8 @@
 	// This variable points the frontend to the api.
 	// It has to be the full url, including the last /api/v1 part and port.
 	//
-	// At build time, Vite replaces __VIKUNJA_API_URL__ with the configured base path (e.g. "/vikunja").
+	// At build time, Vite replaces __VIKUNJA_API_URL__ with
+	// the configured API URL or base path (e.g. "/vikunja").
 	// At serve time, the Go backend replaces the __VIKUNJA_API_URL__ marker
 	// with service.publicurl + "/api/v1".
 	window.API_URL = '__VIKUNJA_API_URL__'

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -21,8 +21,11 @@
 	//
 	// This variable points the frontend to the api.
 	// It has to be the full url, including the last /api/v1 part and port.
-	// You can change this if your api is not reachable on the same port as the frontend.
-	window.API_URL = '/api/v1'
+	//
+	// At build time, Vite replaces __VIKUNJA_API_URL__ with the configured base path (e.g. "/vikunja").
+	// At serve time, the Go backend replaces the __VIKUNJA_API_URL__ marker
+	// with service.publicurl + "/api/v1".
+	window.API_URL = '__VIKUNJA_API_URL__'
 	window.ALLOW_ICON_CHANGES = true
 </script>
 </body>

--- a/frontend/src/components/tasks/partials/Comments.vue
+++ b/frontend/src/components/tasks/partials/Comments.vue
@@ -505,7 +505,9 @@ async function deleteComment(commentToDelete: ITaskComment) {
 
 function getCommentUrl(commentId: string) {
 	const baseUrl = frontendUrl.value.endsWith('/') ? frontendUrl.value.slice(0, -1) : frontendUrl.value
-	return `${baseUrl}${location.pathname}${location.search}#comment-${commentId}`
+	const url = new URL(location.pathname + location.search, baseUrl)
+	url.hash = `comment-${commentId}`
+	return url.toString()
 }
 </script>
 

--- a/frontend/src/helpers/checkAndSetApiUrl.ts
+++ b/frontend/src/helpers/checkAndSetApiUrl.ts
@@ -1,7 +1,7 @@
 import {useConfigStore} from '@/stores/config'
 
 const API_DEFAULT_PORT = '3456'
-const API_DEFAULT_PATH = '/api/v1'
+const API_PATH_SUFFIX = '/api/v1'
 
 export const ERROR_NO_API_URL = 'noApiUrlProvided'
 
@@ -35,7 +35,7 @@ function joinPath(base: string, suffix: string): string {
  */
 function hasApiPath(pathname: string): boolean {
 	const clean = pathname.endsWith('/') ? pathname.slice(0, -1) : pathname
-	return clean.endsWith(API_DEFAULT_PATH)
+	return clean.endsWith(API_PATH_SUFFIX)
 }
 
 export const checkAndSetApiUrl = (pUrl: string | undefined | null): Promise<string> => {
@@ -77,7 +77,7 @@ export const checkAndSetApiUrl = (pUrl: string | undefined | null): Promise<stri
 			console.warn(`Could not fetch 'info' from the provided endpoint ${pUrl} on ${window.API_URL}/info. Some automatic fallback will be tried.`)
 			// Check if it is reachable at the base path + /api/v1 via http
 			if (!hasApiPath(urlToCheck.pathname)) {
-				urlToCheck.pathname = joinPath(urlToCheck.pathname, API_DEFAULT_PATH)
+				urlToCheck.pathname = joinPath(urlToCheck.pathname, API_PATH_SUFFIX)
 				window.API_URL = urlToCheck.toString()
 				return configStore.update()
 			}
@@ -87,7 +87,7 @@ export const checkAndSetApiUrl = (pUrl: string | undefined | null): Promise<stri
 			// Check if it is reachable at the base path + /api/v1 via https
 			urlToCheck.pathname = origPathname
 			if (!hasApiPath(urlToCheck.pathname)) {
-				urlToCheck.pathname = joinPath(urlToCheck.pathname, API_DEFAULT_PATH)
+				urlToCheck.pathname = joinPath(urlToCheck.pathname, API_PATH_SUFFIX)
 				window.API_URL = urlToCheck.toString()
 				return configStore.update()
 			}
@@ -106,7 +106,7 @@ export const checkAndSetApiUrl = (pUrl: string | undefined | null): Promise<stri
 			// Check if it is reachable at :API_DEFAULT_PORT with base path + /api/v1
 			urlToCheck.pathname = origPathname
 			if (!hasApiPath(urlToCheck.pathname)) {
-				urlToCheck.pathname = joinPath(urlToCheck.pathname, API_DEFAULT_PATH)
+				urlToCheck.pathname = joinPath(urlToCheck.pathname, API_PATH_SUFFIX)
 				window.API_URL = urlToCheck.toString()
 				return configStore.update()
 			}

--- a/frontend/src/helpers/checkAndSetApiUrl.ts
+++ b/frontend/src/helpers/checkAndSetApiUrl.ts
@@ -1,6 +1,7 @@
 import {useConfigStore} from '@/stores/config'
 
 const API_DEFAULT_PORT = '3456'
+const API_DEFAULT_PATH = '/api/v1'
 
 export const ERROR_NO_API_URL = 'noApiUrlProvided'
 
@@ -18,6 +19,23 @@ export class InvalidApiUrlProvidedError extends Error {
 		this.message = 'The provided API URL is invalid.'
 		this.name = 'InvalidApiUrlProvidedError'
 	}
+}
+
+/**
+ * Join a base pathname with the API_DEFAULT_PATH, normalizing slashes between them.
+ */
+function joinPath(base: string, suffix: string): string {
+	const normalizedBase = base.endsWith('/') ? base.slice(0, -1) : base
+	return normalizedBase + suffix
+}
+
+/**
+ * Check whether a pathname already ends with the API default path,
+ * with or without a trailing slash.
+ */
+function hasApiPath(pathname: string): boolean {
+	const clean = pathname.endsWith('/') ? pathname.slice(0, -1) : pathname
+	return clean.endsWith(API_DEFAULT_PATH)
 }
 
 export const checkAndSetApiUrl = (pUrl: string | undefined | null): Promise<string> => {
@@ -57,25 +75,19 @@ export const checkAndSetApiUrl = (pUrl: string | undefined | null): Promise<stri
 	return configStore.update()
 		.catch(e => {
 			console.warn(`Could not fetch 'info' from the provided endpoint ${pUrl} on ${window.API_URL}/info. Some automatic fallback will be tried.`)
-			// Check if it is reachable at /api/v1 and http
-			if (
-				!urlToCheck.pathname.endsWith('/api/v1') &&
-				!urlToCheck.pathname.endsWith('/api/v1/')
-			) {
-				urlToCheck.pathname = `${urlToCheck.pathname}api/v1`
+			// Check if it is reachable at the base path + /api/v1 via http
+			if (!hasApiPath(urlToCheck.pathname)) {
+				urlToCheck.pathname = joinPath(urlToCheck.pathname, API_DEFAULT_PATH)
 				window.API_URL = urlToCheck.toString()
 				return configStore.update()
 			}
 			throw e
 		})
 		.catch(e => {
-			// Check if it is reachable at /api/v1 and https
+			// Check if it is reachable at the base path + /api/v1 via https
 			urlToCheck.pathname = origPathname
-			if (
-				!urlToCheck.pathname.endsWith('/api/v1') &&
-				!urlToCheck.pathname.endsWith('/api/v1/')
-			) {
-				urlToCheck.pathname = `${urlToCheck.pathname}api/v1`
+			if (!hasApiPath(urlToCheck.pathname)) {
+				urlToCheck.pathname = joinPath(urlToCheck.pathname, API_DEFAULT_PATH)
 				window.API_URL = urlToCheck.toString()
 				return configStore.update()
 			}
@@ -91,13 +103,10 @@ export const checkAndSetApiUrl = (pUrl: string | undefined | null): Promise<stri
 			throw e
 		})
 		.catch(e => {
-			// Check if it is reachable at :API_DEFAULT_PORT and /api/v1
+			// Check if it is reachable at :API_DEFAULT_PORT with base path + /api/v1
 			urlToCheck.pathname = origPathname
-			if (
-				!urlToCheck.pathname.endsWith('/api/v1') &&
-				!urlToCheck.pathname.endsWith('/api/v1/')
-			) {
-				urlToCheck.pathname = `${urlToCheck.pathname}api/v1`
+			if (!hasApiPath(urlToCheck.pathname)) {
+				urlToCheck.pathname = joinPath(urlToCheck.pathname, API_DEFAULT_PATH)
 				window.API_URL = urlToCheck.toString()
 				return configStore.update()
 			}

--- a/frontend/src/helpers/redirectToProvider.ts
+++ b/frontend/src/helpers/redirectToProvider.ts
@@ -1,3 +1,4 @@
+import {getFullBaseUrl} from '@/helpers/getFullBaseUrl'
 import {createRandomID} from '@/helpers/randomId'
 import type {IProvider} from '@/types/IProvider'
 import {parseURL} from 'ufo'
@@ -6,7 +7,8 @@ export function getRedirectUrlFromCurrentFrontendPath(provider: IProvider): stri
 	// We're not using the redirect url provided by the server to allow redirects when using the electron app.
 	// The implications are not quite clear yet hence the logic to pass in another redirect url still exists.
 	const url = parseURL(window.location.href)
-	return `${url.protocol}//${url.host}/auth/openid/${provider.key}`
+	const base = getFullBaseUrl()
+	return `${url.protocol}//${url.host}${base}auth/openid/${provider.key}`
 }
 
 export const redirectToProvider = (provider: IProvider) => {

--- a/frontend/src/sw.ts
+++ b/frontend/src/sw.ts
@@ -20,9 +20,11 @@ workbox.routing.registerRoute(
 	new workbox.strategies.StaleWhileRevalidate(),
 )
 
+// Construct pattern with full base URL
+const apiRoutePattern = new RegExp(`${fullBaseUrl.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}api\\/v1\\/.*$`)
 // Always send api requests through the network and bypass the browser's HTTP cache
 workbox.routing.registerRoute(
-	new RegExp('api\\/v1\\/.*$'),
+	apiRoutePattern,
 	new workbox.strategies.NetworkOnly({
 		fetchOptions: {
 			cache: 'no-store',

--- a/frontend/tests/support/authenticateUser.ts
+++ b/frontend/tests/support/authenticateUser.ts
@@ -1,14 +1,13 @@
 import type {Page, APIRequestContext} from '@playwright/test'
 import {UserFactory} from '../factories/user'
-import {TEST_PASSWORD} from './constants'
+import {TEST_PASSWORD, TEST_API_URL} from './constants'
 
 /**
  * Sets up the API URL in the page's localStorage and window so the frontend
  * knows where to send requests. Call this before navigating to any page.
  */
 export async function setupApiUrl(page: Page) {
-	// Use 127.0.0.1 instead of localhost to match the frontend's origin for CORS
-	const apiUrl = process.env.API_URL || 'http://127.0.0.1:3456/api/v1'
+	const apiUrl = TEST_API_URL
 	await page.addInitScript(({apiUrl}) => {
 		window.localStorage.setItem('API_URL', apiUrl)
 		window.API_URL = apiUrl

--- a/frontend/tests/support/constants.ts
+++ b/frontend/tests/support/constants.ts
@@ -13,3 +13,8 @@ export const TEST_PASSWORD = '1234'
  */
 export const TEST_PASSWORD_HASH = '$2a$14$dcadBoMBL9jQoOcZK8Fju.cy0Ptx2oZECkKLnaa8ekRoTFe1w7To.'
 
+/**
+ * Default API URL used in test environments.
+ * Override with the API_URL environment variable when running against a different host or base path.
+ */
+export const TEST_API_URL = process.env.API_URL || 'http://127.0.0.1:3456/api/v1'

--- a/frontend/tests/support/fixtures.ts
+++ b/frontend/tests/support/fixtures.ts
@@ -1,6 +1,7 @@
 import {test as base, type APIRequestContext, type Page} from '@playwright/test'
 import {Factory} from './factory'
 import {login, createFakeUser} from './authenticateUser'
+import {TEST_API_URL} from './constants'
 
 export const test = base.extend<{
 	apiContext: APIRequestContext;
@@ -9,7 +10,7 @@ export const test = base.extend<{
 	userToken: string;
 }>({
 	apiContext: async ({playwright}, use) => {
-		const baseURL = process.env.API_URL || 'http://localhost:3456/api/v1/'
+		const baseURL = TEST_API_URL.endsWith('/') ? TEST_API_URL : TEST_API_URL + '/'
 		const apiContext = await playwright.request.newContext({
 			baseURL,
 		})

--- a/frontend/tests/support/seed.ts
+++ b/frontend/tests/support/seed.ts
@@ -1,4 +1,5 @@
 import type {APIRequestContext} from '@playwright/test'
+import {TEST_API_URL} from './constants'
 
 /**
  * Seeds a db table with data. If a data object is provided as the second argument, it will load the fixtures
@@ -15,7 +16,7 @@ export async function seed(apiContext: APIRequestContext, table: string, data: a
 		data = []
 	}
 
-	const apiUrl = process.env.API_URL || 'http://localhost:3456/api/v1'
+	const apiUrl = TEST_API_URL
 	const testSecret = process.env.TEST_SECRET || 'averyLongSecretToSe33dtheDB'
 
 	await apiContext.patch(`${apiUrl}/test/${table}?truncate=${truncate ? 'true' : 'false'}`, {

--- a/frontend/tests/support/updateUserSettings.ts
+++ b/frontend/tests/support/updateUserSettings.ts
@@ -1,8 +1,9 @@
 import type {APIRequestContext} from '@playwright/test'
 import {objectToSnakeCase} from '../../src/helpers/case'
+import {TEST_API_URL} from './constants'
 
 export async function updateUserSettings(apiContext: APIRequestContext, token: string, settings: any) {
-	const apiUrl = process.env.API_URL || 'http://localhost:3456/api/v1'
+	const apiUrl = TEST_API_URL
 
 	const userResponse = await apiContext.get(`${apiUrl}/user`, {
 		headers: {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -157,7 +157,7 @@ function getBuildConfig(env: Record<string, string>) {
 					}
 					const apiUrl = env.VIKUNJA_API_URL
 						|| (base.replace(/\/+$/, '') + '/api/v1')
-					return html.replace('__VIKUNJA_API_URL__', apiUrl)
+					return html.replaceAll('__VIKUNJA_API_URL__', apiUrl)
 				},
 			},
 			VueI18nPlugin({

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -103,8 +103,9 @@ export default defineConfig(({command, mode}) => {
 })
 
 function getBuildConfig(env: Record<string, string>) {
+	const base = env.VIKUNJA_FRONTEND_BASE || '/'
 	return {
-		base: env.VIKUNJA_FRONTEND_BASE,
+		base,
 		// https://vitest.dev/config/
 		test: {
 			environment: 'happy-dom',
@@ -142,17 +143,20 @@ function getBuildConfig(env: Record<string, string>) {
 				svgo: false,
 			}),
 			// if VIKUNJA_BUILD_STANDALONE=true, replace __VIKUNJA_API_URL__ in index.html
-			// at build time with the configured base path + /api/v1.
-			// This only matters for standalone frontend deployments (via HTTP servers).
-			// Otherwise the Go backend will replace this at serve time with service.publicurl.
+			// at build time. For standalone frontend deployments (e.g. nginx).
+			// - If VIKUNJA_API_URL is set, use it as API_BASE. This supports deployments
+			//   where the backend is at a different origin/path than the frontend.
+			// - Otherwise, derive the API URL from VIKUNJA_FRONTEND_BASE + /api/v1.
+			// When VIKUNJA_BUILD_STANDALONE is not set, the marker stays in the HTML
+			// so the Go backend can replace it at serve time with service.publicurl.
 			{
 				name: 'vikunja-api-url',
 				transformIndexHtml(html: string) {
 					if (env.VIKUNJA_BUILD_STANDALONE !== 'true') {
-						return html;
+						return html
 					}
-					const base = (env.VIKUNJA_FRONTEND_BASE || '/').replace(/\/+$/, '')
-					const apiUrl = base + '/api/v1'
+					const apiUrl = env.VIKUNJA_API_URL
+						|| (base.replace(/\/+$/, '') + '/api/v1')
 					return html.replace('__VIKUNJA_API_URL__', apiUrl)
 				},
 			},

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -141,6 +141,21 @@ function getBuildConfig(env: Record<string, string>) {
 				// we don't need to optimize them again.
 				svgo: false,
 			}),
+			// if BUILD_STANDALONE=true, replace __VIKUNJA_API_URL__ in index.html at build time
+			// with the configured base path + /api/v1.
+			// This only matters for standalone frontend deployments (via HTTP servers).
+			// Otherwise the Go backend will replace this at serve time with service.publicurl.
+			{
+				name: 'vikunja-api-url',
+				transformIndexHtml(html: string) {
+					if (env.BUILD_STANDALONE !== 'true') {
+						return html;
+					}
+					const base = (env.VIKUNJA_FRONTEND_BASE || '/').replace(/\/+$/, '')
+					const apiUrl = base + '/api/v1'
+					return html.replace('__VIKUNJA_API_URL__', apiUrl)
+				},
+			},
 			VueI18nPlugin({
 				// TODO: only install needed stuff
 				// Whether to install the full set of APIs, components, etc. provided by Vue I18n.

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -141,14 +141,14 @@ function getBuildConfig(env: Record<string, string>) {
 				// we don't need to optimize them again.
 				svgo: false,
 			}),
-			// if BUILD_STANDALONE=true, replace __VIKUNJA_API_URL__ in index.html at build time
-			// with the configured base path + /api/v1.
+			// if VIKUNJA_BUILD_STANDALONE=true, replace __VIKUNJA_API_URL__ in index.html
+			// at build time with the configured base path + /api/v1.
 			// This only matters for standalone frontend deployments (via HTTP servers).
 			// Otherwise the Go backend will replace this at serve time with service.publicurl.
 			{
 				name: 'vikunja-api-url',
 				transformIndexHtml(html: string) {
-					if (env.BUILD_STANDALONE !== 'true') {
+					if (env.VIKUNJA_BUILD_STANDALONE !== 'true') {
 						return html;
 					}
 					const base = (env.VIKUNJA_FRONTEND_BASE || '/').replace(/\/+$/, '')

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -277,18 +277,29 @@ function getBuildConfig(env: Record<string, string>) {
 function getServeConfig(env: Record<string, string>) {
 	// get some default settings from prod mod
 	const buildConfig = getBuildConfig(env)
+
+	// Build the proxy pattern from VIKUNJA_FRONTEND_BASE so that custom base
+	// paths like /vikunja proxy /vikunja/api/* correctly.
+	// Falls back to /api.
+	const base = (env.VIKUNJA_FRONTEND_BASE || '/').replace(/\/+$/, '')
+	const proxyPath = `${base}/api`
+
 	// override prod settings with dev settings
 	return {
 		...buildConfig,
 		server: {
 			...buildConfig.server,
-			...(env.DEV_PROXY && { proxy: {
-				'/api': {
-					target: env.DEV_PROXY,
-					changeOrigin: true,
-					secure: false,
-				},
-			}}),
+			...(env.DEV_PROXY && {
+				proxy: {
+					[proxyPath]: {
+						target: env.DEV_PROXY,
+						changeOrigin: true,
+						secure: false,
+						// Strips prefix for the backend
+						rewrite: (path: string) => path.replace(new RegExp(`^${base}`), ''),
+					},
+				}
+			}),
 		},
 	}
 }

--- a/magefile.go
+++ b/magefile.go
@@ -564,6 +564,10 @@ func (Test) E2E(ctx context.Context, args string) error {
 	fmt.Println("\n--- Building frontend ---")
 	buildFrontendCmd := exec.CommandContext(ctx, "pnpm", "build:dev")
 	buildFrontendCmd.Dir = "frontend"
+	buildFrontendCmd.Env = append(os.Environ(),
+		"VIKUNJA_BUILD_STANDALONE=true",
+		fmt.Sprintf("VIKUNJA_API_URL=%s", apiBase),
+	)
 	buildFrontendCmd.Stdout = os.Stdout
 	buildFrontendCmd.Stderr = os.Stderr
 	if err := buildFrontendCmd.Run(); err != nil {

--- a/pkg/modules/auth/auth.go
+++ b/pkg/modules/auth/auth.go
@@ -19,6 +19,7 @@ package auth
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -47,8 +48,21 @@ type Token struct {
 	Token string `json:"token" example:"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"`
 }
 
-const RefreshTokenCookieName = "vikunja_refresh_token"      //nolint:gosec // not a credential
-const refreshTokenCookiePath = "/api/v1/user/token/refresh" //nolint:gosec // not a credential
+const RefreshTokenCookieName = "vikunja_refresh_token" //nolint:gosec // not a credential
+
+// getRefreshTokenCookiePath returns the cookie path for the refresh token,
+// derived from service.publicurl.
+func getRefreshTokenCookiePath() string {
+	publicURL := config.ServicePublicURL.GetString()
+	u, err := url.Parse(publicURL)
+	if err != nil || publicURL == "" || publicURL == "/" {
+		return "/api/v1/user/token/refresh"
+	}
+
+	// Extract the path component and append the refresh endpoint
+	basePath := strings.TrimRight(u.Path, "/")
+	return basePath + "/api/v1/user/token/refresh"
+}
 
 // SetRefreshTokenCookie sets an HttpOnly cookie containing the refresh token.
 // The cookie is path-scoped to the refresh endpoint so the browser only sends
@@ -67,7 +81,7 @@ func SetRefreshTokenCookie(c *echo.Context, token string, maxAge int) {
 	c.SetCookie(&http.Cookie{
 		Name:     RefreshTokenCookieName,
 		Value:    token,
-		Path:     refreshTokenCookiePath,
+		Path:     getRefreshTokenCookiePath(),
 		MaxAge:   maxAge,
 		HttpOnly: true,
 		Secure:   secure,

--- a/pkg/modules/auth/auth.go
+++ b/pkg/modules/auth/auth.go
@@ -53,15 +53,17 @@ const RefreshTokenCookieName = "vikunja_refresh_token" //nolint:gosec // not a c
 // getRefreshTokenCookiePath returns the cookie path for the refresh token,
 // derived from service.publicurl.
 func getRefreshTokenCookiePath() string {
+	refreshURL := "/api/v1/user/token/refresh"
+
 	publicURL := config.ServicePublicURL.GetString()
 	u, err := url.Parse(publicURL)
-	if err != nil || publicURL == "" || publicURL == "/" {
-		return "/api/v1/user/token/refresh"
+	if err != nil {
+		return refreshURL
 	}
 
 	// Extract the path component and append the refresh endpoint
 	basePath := strings.TrimRight(u.Path, "/")
-	return basePath + "/api/v1/user/token/refresh"
+	return basePath + refreshURL
 }
 
 // SetRefreshTokenCookie sets an HttpOnly cookie containing the refresh token.

--- a/pkg/routes/api/v1/docs.go
+++ b/pkg/routes/api/v1/docs.go
@@ -17,9 +17,13 @@
 package v1
 
 import (
+	"bytes"
 	_ "embed"
+	"html/template"
 	"net/http"
+	"strings"
 
+	"code.vikunja.io/api/pkg/config"
 	"code.vikunja.io/api/pkg/log"
 	_ "code.vikunja.io/api/pkg/swagger" // To make sure the swag files are properly registered
 
@@ -30,12 +34,13 @@ import (
 //go:embed redoc/redoc.html
 var redocHTML string
 
+var redocUITemplate = template.Must(template.New("redoc").Parse(redocHTML))
+
 //go:embed redoc/redoc.standalone.js
 var redocJS []byte
 
 // DocsJSON serves swagger doc json specs
 func DocsJSON(c *echo.Context) error {
-
 	doc, err := swag.ReadDoc()
 	if err != nil {
 		log.Error(err.Error())
@@ -47,7 +52,17 @@ func DocsJSON(c *echo.Context) error {
 
 // RedocUI serves everything needed to provide the redoc ui
 func RedocUI(c *echo.Context) error {
-	return c.HTML(http.StatusOK, redocHTML)
+	publicURL := config.ServicePublicURL.GetString()
+	docsURL := strings.TrimRight(publicURL, "/") + "/api/v1/docs.json"
+
+	var buf bytes.Buffer
+	data := map[string]string{"Url": docsURL}
+
+	if err := redocUITemplate.Execute(&buf, data); err != nil {
+		return err
+	}
+
+	return c.HTML(http.StatusOK, buf.String())
 }
 
 // RedocJS serves the embedded redoc standalone JavaScript bundle

--- a/pkg/routes/api/v1/redoc/redoc.html
+++ b/pkg/routes/api/v1/redoc/redoc.html
@@ -8,7 +8,7 @@
     <style>body{margin:0;padding:0;}</style>
 </head>
 <body>
-<redoc spec-url='/api/v1/docs.json'></redoc>
+<redoc spec-url='{{.Url}}'></redoc>
 <script src="/api/v1/docs/redoc.standalone.js"></script>
 </body>
 </html>

--- a/pkg/routes/static.go
+++ b/pkg/routes/static.go
@@ -118,7 +118,10 @@ func serveIndexFile(c *echo.Context, assetFs http.FileSystem) (err error) {
 			publicURL = "/"
 		}
 
-		scriptConfigString = strings.ReplaceAll(scriptConfigString, "'http://localhost:3456/api/v1'", "'"+publicURL+"api/v1'")
+		// Replace the __VIKUNJA_API_URL__ placeholder in the built index.html
+		// with the configured public URL + /api/v1.
+		apiURL := strings.TrimRight(publicURL, "/") + "/api/v1"
+		scriptConfigString = strings.ReplaceAll(scriptConfigString, "__VIKUNJA_API_URL__", apiURL)
 	}
 
 	reader := strings.NewReader(scriptConfigString)


### PR DESCRIPTION
Make the frontend work correctly when served at a subpath (e.g. `/vikunja/` instead of `/`). Previously, API URLs, OIDC redirects, CalDAV URLs, and the service worker all had paths hardcoded relative to the domain root, which broke any deployment behind a reverse proxy with a path prefix.

This PR is based on the fix in #2440 .

## What changed

- **`index.html` / `static.go`**: Replaced the hardcoded `window.API_URL` value with a `__VIKUNJA_API_URL__` marker. Vite replaces it at build time (for standalone nginx deploys) if `VIKUNJA_BUILD_STANDALONE=true` is set in `.env.local`. Otherwise the Go backend replaces it at serve time using `service.publicurl`.

  - I'm unsure about this change. The original `static.go` targets `'http://localhost:3456/api/v1'` to replace, but in actual `index.html` it is `'/api/v1'`, so this is already broken?

  - Current implementation would work for this case: Serving frontend and backend on the same server under a subpath (e.g., `example.com/vikunja`), in which it does not matter whether Vite does the `API_BASE` replacement or the go backend.

  - ~~However, it is not feasible to serve frontend at subpath but backend at subdomain (e.g., `example.com/vikunja` served by nginx, and backend at `api.example.com`). Might need some refactoring.~~ Fixed in 2e134cec1. See [this comment](#issuecomment-4105788703).

- **`checkAndSetApiUrl.ts`**: Extracted `API_DEFAULT_PATH` constant and `joinPath`/`hasApiPath` helpers.

- **`config.ts` (`apiBase` computed)**: See !2435. Uses `pathname` and strips `/api/v1` to derive the deployment base. This fixes CalDAV URL construction in `Caldav.vue`.

- **`redirectToProvider.ts`**: OIDC redirect URL now includes the base path via `getFullBaseUrl()`, so the callback lands on a route the Vue router handles.

- **`sw.ts`**: Service worker API route regex is anchored to the configured base path instead of matching `api/v1/` anywhere in the URL.

- **`auth/auth.go`**: Compute refresh token cookie base path from `service.publicurl` rather than hard coding the base as `/api/v1`.

- **`api/v1/docs.go`**: Build `RedocUITemplate` as template, and replace with `apiBase + api/v1/docs.json`.

- **Test files**: Centralized `TEST_API_URL` constant so the API base URL for tests is defined in one place.

- **`vite.config.ts`**: Added a `transformIndexHtml` plugin for the marker replacement. Made the dev proxy path and rewrite dynamic based on `VIKUNJA_FRONTEND_BASE` so local development works with a subpath.

## How to deploy at a subpath

1. Set `VIKUNJA_FRONTEND_BASE` to the desired path (e.g. `/vikunja/`) before building the frontend. This sets Vite's `base` and bakes the correct API URL into the built HTML.

2. Configure the reverse proxy to forward requests from the subpath to Vikunja. The Go backend still expects `/api/v1` at its root — the proxy should strip the prefix before forwarding.

   Example Caddyfile:

   ```Caddyfile
   example.com:80 {
    handle_path /vikunja* {
     reverse_proxy 127.0.0.1:3456
    }
   }
   ```

3. Set `service.publicurl` in `config.yml` to the full public URL including the subpath (e.g. `https://example.com/vikunja`). When the Go backend serves the frontend, it will replace the `window.API_BASE` placeholder.

4. For OIDC: no extra configuration needed — the redirect URL is now built dynamically from the frontend's base path.

5. For migration services (Trello, Todoist, Microsoft To Do): the redirect URLs in `config.yml` are absolute URLs set by the admin, so include the subpath there if applicable.

## Docs changes needed

The following should be mentioned in the deployment documentation:

- **`VIKUNJA_FRONTEND_BASE`**: (Already there).

- **`VIKUNJA_API_URL`**: The full URL to the Vikunja API. Only required when building the standalone frontend (see below `VIKUNJA_BUILD_STANDALONE`). If unset when building a standalone frontend, it would be automatically derived as `VIKUNJA_FRONTEND_BASE + /api/v1`. Only set this when the backend is at a different origin or path than the frontend.

- **`VIKUNJA_BUILD_STANDALONE`**: If building a frontend that is intended to be served at a subpath by a reverse proxy, set this to `true` so that Vite replaces `__VIKUNJA_API_URL__` with `VIKUNJA_API_URL` at build time.
  Otherwise go backend will handle the replacement using `service.publicurl`.

- **Reverse proxy subpath configuration**: Document that when deploying at a subpath, the reverse proxy should strip the prefix before forwarding to the backend.
  Include example configs for common web servers.

- **Include the subpath in `service.publicurl`**: If the Go backend serves the frontend and the deployment uses a subpath, `service.publicurl` must reflect that (e.g. `https://example.com/vikunja`).

- **Migration redirect URLs**: Admins must include the subpath in `migration.*.redirecturl` values in `config.yml` if deploying at a subpath. These are not auto-detected.
