### PR TITLE
feat: use openid provider name instead of generic "OIDC" in synced team names

### DIFF
--- a/pkg/modules/auth/openid/openid.go
+++ b/pkg/modules/auth/openid/openid.go
@@ -169,7 +169,7 @@ func HandleCallback(c *echo.Context) error {
 
 	teamData := getTeamDataFromToken(cl.VikunjaGroups, provider)
 
-	err = models.SyncExternalTeamsForUser(s, u, teamData, idToken.Issuer, "OIDC")
+	err = models.SyncExternalTeamsForUser(s, u, teamData, idToken.Issuer, provider.Name)
 	if err != nil {
 		return err
 	}

--- a/pkg/modules/auth/openid/openid_test.go
+++ b/pkg/modules/auth/openid/openid_test.go
@@ -124,14 +124,14 @@ func TestGetOrCreateUser(t *testing.T) {
 			},
 		}
 
-		provider := &Provider{}
+		provider := &Provider{Name: "Vikunja Login"}
 		idToken := &oidc.IDToken{Issuer: "https://some.service.com", Subject: "12345"}
 
 		u, err := getOrCreateUser(s, cl, provider, idToken)
 		require.NoError(t, err)
 		teamData := getTeamDataFromToken(cl.VikunjaGroups, nil)
 		require.NoError(t, err)
-		err = models.SyncExternalTeamsForUser(s, u, teamData, "https://some.issuer", "OIDC")
+		err = models.SyncExternalTeamsForUser(s, u, teamData, "https://some.issuer", provider.Name)
 		require.NoError(t, err)
 		err = s.Commit()
 		require.NoError(t, err)
@@ -141,7 +141,7 @@ func TestGetOrCreateUser(t *testing.T) {
 			"email": cl.Email,
 		}, false)
 		db.AssertExists(t, "teams", map[string]interface{}{
-			"name":        team + " (OIDC)",
+			"name":        team + " (" + provider.Name + ")",
 			"external_id": oidcID,
 			"is_public":   false,
 		}, false)
@@ -161,19 +161,19 @@ func TestGetOrCreateUser(t *testing.T) {
 			},
 		}
 
-		provider := &Provider{}
+		provider := &Provider{Name: "Vikunja Login"}
 		idToken := &oidc.IDToken{Issuer: "https://some.service.com", Subject: "12345"}
 
 		u, err := getOrCreateUser(s, cl, provider, idToken)
 		require.NoError(t, err)
 		teamData := getTeamDataFromToken(cl.VikunjaGroups, nil)
-		err = models.SyncExternalTeamsForUser(s, u, teamData, "https://some.issuer", "OIDC")
+		err = models.SyncExternalTeamsForUser(s, u, teamData, "https://some.issuer", provider.Name)
 		require.NoError(t, err)
 		err = s.Commit()
 		require.NoError(t, err)
 
 		db.AssertExists(t, "teams", map[string]interface{}{
-			"name":        team + " (OIDC)",
+			"name":        team + " (" + provider.Name + ")",
 			"external_id": oidcID,
 			"is_public":   true,
 		}, false)
@@ -195,7 +195,7 @@ func TestGetOrCreateUser(t *testing.T) {
 
 		u := &user.User{ID: 10}
 		teamData := getTeamDataFromToken(cl.VikunjaGroups, nil)
-		err := models.SyncExternalTeamsForUser(s, u, teamData, "https://some.issuer", "OIDC")
+		err := models.SyncExternalTeamsForUser(s, u, teamData, "https://some.issuer", "Vikunja Login")
 		require.NoError(t, err)
 		err = s.Commit()
 		require.NoError(t, err)
@@ -216,7 +216,7 @@ func TestGetOrCreateUser(t *testing.T) {
 
 		u := &user.User{ID: 10}
 		teamData := getTeamDataFromToken(cl.VikunjaGroups, nil)
-		err := models.SyncExternalTeamsForUser(s, u, teamData, "https://some.issuer", "OIDC")
+		err := models.SyncExternalTeamsForUser(s, u, teamData, "https://some.issuer", "Vikunja Login")
 		require.NoError(t, err)
 		err = s.Commit()
 		require.NoError(t, err)


### PR DESCRIPTION
Teams synced from OpenID Connect providers were always named with "(OIDC)"
suffix (e.g., "DevTeam (OIDC)"). This changes it to use the configured
provider name instead (e.g., "DevTeam (Keycloak)"), making it easier to
identify which provider a team came from when multiple OIDC providers are
configured. Existing team names will be updated automatically on next user
login.

https://claude.ai/code/session_012LXXPvYe6i27WTcha1PL7A