### PR TITLE
feat: detect and prevent duplicate OpenID Connect issuers

### DIFF
--- a/pkg/doctor/services.go
+++ b/pkg/doctor/services.go
@@ -18,13 +18,16 @@ package doctor
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"time"
 
 	"code.vikunja.io/api/pkg/config"
 	"code.vikunja.io/api/pkg/modules/auth/ldap"
+	"code.vikunja.io/api/pkg/modules/auth/openid"
 	"code.vikunja.io/api/pkg/red"
 )
 
@@ -243,9 +246,22 @@ func checkOpenID() CheckGroup {
 	}
 
 	var results []CheckResult
+	providerIssuers := make(map[string]string)
 	for key, p := range providerMap {
-		result := checkOpenIDProvider(key, p)
+		result, issuer := checkOpenIDProvider(key, p)
 		results = append(results, result)
+		if issuer != "" {
+			providerIssuers[key] = issuer
+		}
+	}
+
+	// Check for duplicate issuers among successful providers
+	for _, dup := range openid.FindDuplicateIssuers(providerIssuers) {
+		results = append(results, CheckResult{
+			Name:   "Duplicate Issuer",
+			Passed: false,
+			Error:  dup.Error(),
+		})
 	}
 
 	return CheckGroup{
@@ -254,7 +270,7 @@ func checkOpenID() CheckGroup {
 	}
 }
 
-func checkOpenIDProvider(key string, rawProvider interface{}) CheckResult {
+func checkOpenIDProvider(key string, rawProvider interface{}) (CheckResult, string) {
 	// Extract provider config
 	var pi map[string]interface{}
 	switch p := rawProvider.(type) {
@@ -272,7 +288,7 @@ func checkOpenIDProvider(key string, rawProvider interface{}) CheckResult {
 			Name:   fmt.Sprintf("Provider: %s", key),
 			Passed: false,
 			Error:  "invalid configuration format",
-		}
+		}, ""
 	}
 
 	// Get provider name
@@ -288,7 +304,7 @@ func checkOpenIDProvider(key string, rawProvider interface{}) CheckResult {
 			Name:   fmt.Sprintf("Provider: %s", name),
 			Passed: false,
 			Error:  "authurl not configured",
-		}
+		}, ""
 	}
 
 	// Check if the provider's discovery endpoint is reachable
@@ -308,7 +324,7 @@ func checkOpenIDProvider(key string, rawProvider interface{}) CheckResult {
 			Name:   fmt.Sprintf("Provider: %s", name),
 			Passed: false,
 			Error:  err.Error(),
-		}
+		}, ""
 	}
 
 	client := &http.Client{Timeout: 5 * time.Second}
@@ -318,7 +334,7 @@ func checkOpenIDProvider(key string, rawProvider interface{}) CheckResult {
 			Name:   fmt.Sprintf("Provider: %s", name),
 			Passed: false,
 			Error:  err.Error(),
-		}
+		}, ""
 	}
 	defer resp.Body.Close()
 
@@ -327,6 +343,18 @@ func checkOpenIDProvider(key string, rawProvider interface{}) CheckResult {
 			Name:   fmt.Sprintf("Provider: %s", name),
 			Passed: false,
 			Error:  fmt.Sprintf("discovery endpoint returned status %d", resp.StatusCode),
+		}, ""
+	}
+
+	// Parse the issuer from the discovery response for duplicate detection
+	var issuer string
+	body, err := io.ReadAll(resp.Body)
+	if err == nil {
+		var discovery struct {
+			Issuer string `json:"issuer"`
+		}
+		if json.Unmarshal(body, &discovery) == nil {
+			issuer = discovery.Issuer
 		}
 	}
 
@@ -334,5 +362,5 @@ func checkOpenIDProvider(key string, rawProvider interface{}) CheckResult {
 		Name:   fmt.Sprintf("Provider: %s", name),
 		Passed: true,
 		Value:  "OK",
-	}
+	}, issuer
 }

--- a/pkg/initialize/init.go
+++ b/pkg/initialize/init.go
@@ -101,6 +101,9 @@ func FullInitWithoutAsync() {
 	// Check all OpenID Connect providers at startup
 	_, err = openid.GetAllProviders()
 	if err != nil {
+		if openid.IsErrDuplicateOIDCIssuer(err) {
+			log.Fatalf("OpenID Connect configuration error: %s", err)
+		}
 		log.Errorf("Error initializing OpenID Connect providers: %s", err)
 	}
 

--- a/pkg/modules/auth/openid/providers.go
+++ b/pkg/modules/auth/openid/providers.go
@@ -17,6 +17,7 @@
 package openid
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 
@@ -27,6 +28,44 @@ import (
 	"github.com/coreos/go-oidc/v3/oidc"
 	"golang.org/x/oauth2"
 )
+
+// ErrDuplicateOIDCIssuer is returned when two configured providers resolve to the same issuer URL.
+type ErrDuplicateOIDCIssuer struct {
+	Issuer    string
+	Provider1 string
+	Provider2 string
+}
+
+func (e *ErrDuplicateOIDCIssuer) Error() string {
+	return fmt.Sprintf(
+		"duplicate OpenID Connect issuer %q: providers %q and %q resolve to the same issuer, which will cause team sync conflicts",
+		e.Issuer, e.Provider1, e.Provider2,
+	)
+}
+
+// IsErrDuplicateOIDCIssuer checks if an error is a duplicate issuer error.
+func IsErrDuplicateOIDCIssuer(err error) bool {
+	var target *ErrDuplicateOIDCIssuer
+	return errors.As(err, &target)
+}
+
+// FindDuplicateIssuers checks a map of provider key → issuer URL for duplicates.
+// It returns a list of all duplicate pairs found.
+func FindDuplicateIssuers(providerIssuers map[string]string) []ErrDuplicateOIDCIssuer {
+	issuerToKey := make(map[string]string)
+	var duplicates []ErrDuplicateOIDCIssuer
+	for key, issuer := range providerIssuers {
+		if existingKey, exists := issuerToKey[issuer]; exists {
+			duplicates = append(duplicates, ErrDuplicateOIDCIssuer{
+				Issuer:    issuer,
+				Provider1: existingKey,
+				Provider2: key,
+			})
+		}
+		issuerToKey[issuer] = key
+	}
+	return duplicates
+}
 
 // GetAllProviders returns all configured providers
 func GetAllProviders() (providers []*Provider, err error) {
@@ -97,6 +136,21 @@ func GetAllProviders() (providers []*Provider, err error) {
 				return nil, err
 			}
 		}
+
+		// Check for duplicate issuers across providers
+		providerIssuers := make(map[string]string)
+		for _, p := range providers {
+			issuer, issuerErr := p.Issuer()
+			if issuerErr != nil {
+				log.Errorf("Error getting issuer for openid provider %s: %s", p.Key, issuerErr)
+				continue
+			}
+			providerIssuers[p.Key] = issuer
+		}
+		if duplicates := FindDuplicateIssuers(providerIssuers); len(duplicates) > 0 {
+			return nil, &duplicates[0]
+		}
+
 		err = keyvalue.Put("openid_providers", providers)
 	}
 

--- a/pkg/modules/auth/openid/providers_test.go
+++ b/pkg/modules/auth/openid/providers_test.go
@@ -17,10 +17,16 @@
 package openid
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"code.vikunja.io/api/pkg/config"
 	"code.vikunja.io/api/pkg/modules/keyvalue"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetAllProvidersTypeSafety(t *testing.T) {
@@ -83,4 +89,120 @@ func TestGetAllProvidersTypeSafety(t *testing.T) {
 			t.Errorf("Expected empty providers list, got: %d", len(providers))
 		}
 	})
+}
+
+// newMockOIDCServer creates a test HTTP server that serves a valid OIDC discovery document.
+// The issuer in the discovery document matches the server's URL.
+func newMockOIDCServer() *httptest.Server {
+	var server *httptest.Server
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, _ *http.Request) {
+		discovery := map[string]interface{}{
+			"issuer":                 server.URL,
+			"authorization_endpoint": server.URL + "/auth",
+			"token_endpoint":         server.URL + "/token",
+			"jwks_uri":               server.URL + "/jwks",
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(discovery)
+	})
+	server = httptest.NewServer(mux)
+	return server
+}
+
+func TestDuplicateIssuersDetected(t *testing.T) {
+	defer CleanupSavedOpenIDProviders()
+
+	// Create a single mock server — both providers will use the same issuer
+	server := newMockOIDCServer()
+	defer server.Close()
+
+	config.AuthOpenIDEnabled.Set(true)
+	config.AuthOpenIDProviders.Set(map[string]interface{}{
+		"provider1": map[string]interface{}{
+			"name":         "Provider One",
+			"authurl":      server.URL,
+			"clientid":     "client1",
+			"clientsecret": "secret1",
+		},
+		"provider2": map[string]interface{}{
+			"name":         "Provider Two",
+			"authurl":      server.URL,
+			"clientid":     "client2",
+			"clientsecret": "secret2",
+		},
+	})
+	_ = keyvalue.Del("openid_providers")
+
+	providers, err := GetAllProviders()
+	require.Error(t, err)
+	assert.Nil(t, providers)
+	assert.True(t, IsErrDuplicateOIDCIssuer(err))
+
+	var dupErr *ErrDuplicateOIDCIssuer
+	require.ErrorAs(t, err, &dupErr)
+	assert.Equal(t, server.URL, dupErr.Issuer)
+}
+
+func TestUniqueIssuersAllowed(t *testing.T) {
+	defer CleanupSavedOpenIDProviders()
+
+	// Create two separate mock servers — different issuers
+	server1 := newMockOIDCServer()
+	defer server1.Close()
+	server2 := newMockOIDCServer()
+	defer server2.Close()
+
+	config.AuthOpenIDEnabled.Set(true)
+	config.AuthOpenIDProviders.Set(map[string]interface{}{
+		"provider1": map[string]interface{}{
+			"name":         "Provider One",
+			"authurl":      server1.URL,
+			"clientid":     "client1",
+			"clientsecret": "secret1",
+		},
+		"provider2": map[string]interface{}{
+			"name":         "Provider Two",
+			"authurl":      server2.URL,
+			"clientid":     "client2",
+			"clientsecret": "secret2",
+		},
+	})
+	_ = keyvalue.Del("openid_providers")
+
+	providers, err := GetAllProviders()
+	require.NoError(t, err)
+	assert.Len(t, providers, 2)
+}
+
+func TestFailedDiscoverySkippedInIssuerCheck(t *testing.T) {
+	defer CleanupSavedOpenIDProviders()
+
+	// One valid server, one unreachable
+	server := newMockOIDCServer()
+	defer server.Close()
+
+	config.AuthOpenIDEnabled.Set(true)
+	config.AuthOpenIDProviders.Set(map[string]interface{}{
+		"valid": map[string]interface{}{
+			"name":         "Valid Provider",
+			"authurl":      server.URL,
+			"clientid":     "client1",
+			"clientsecret": "secret1",
+		},
+		"broken": map[string]interface{}{
+			"name":         "Broken Provider",
+			"authurl":      "http://127.0.0.1:1",
+			"clientid":     "client2",
+			"clientsecret": "secret2",
+		},
+	})
+	_ = keyvalue.Del("openid_providers")
+
+	// The broken provider will fail discovery and be skipped.
+	// The valid provider should load successfully.
+	providers, err := GetAllProviders()
+	require.NoError(t, err)
+	assert.Len(t, providers, 1)
+	assert.Equal(t, "Valid Provider", providers[0].Name)
 }


### PR DESCRIPTION
## Summary
This PR adds validation to detect and prevent multiple OpenID Connect providers from being configured with the same issuer URL, which would cause team sync conflicts.

## Key Changes
- **New error type** (`ErrDuplicateOIDCIssuer`): Added a custom error type in `pkg/modules/auth/openid/providers.go` to represent duplicate issuer configuration errors, with a helper function `IsErrDuplicateOIDCIssuer()` for type checking.

- **Duplicate issuer detection in provider initialization**: Modified `GetAllProviders()` to check for duplicate issuers across all configured providers after they are loaded. If duplicates are found, initialization fails with the new error type.

- **Startup validation**: Updated `pkg/initialize/init.go` to treat duplicate issuer errors as fatal configuration errors, preventing the application from starting with conflicting provider configurations.

- **Doctor command enhancement**: Enhanced the OpenID diagnostic check in `pkg/doctor/services.go` to:
  - Extract issuer URLs from provider discovery responses
  - Detect and report duplicate issuers among successfully configured providers
  - Provide clear error messages identifying which providers share the same issuer

- **Comprehensive test coverage**: Added three new test cases in `pkg/modules/auth/openid/providers_test.go`:
  - `TestDuplicateIssuersDetected`: Verifies that duplicate issuers are properly detected and rejected
  - `TestUniqueIssuersAllowed`: Confirms that providers with different issuers load successfully
  - `TestFailedDiscoverySkippedInIssuerCheck`: Ensures that providers with failed discovery don't block other providers

## Implementation Details
- The duplicate detection works by collecting issuer URLs from successful provider discovery and checking for collisions
- Providers that fail OIDC discovery are skipped during issuer validation to avoid false positives
- A mock OIDC server helper (`newMockOIDCServer()`) was added to support testing with realistic discovery documents

https://claude.ai/code/session_01H2W7YWuhtbq8GhUD7QM7T3