### PR TITLE
config: Expand environment variables in `some.config.value.path.file`

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -514,7 +514,7 @@ func GetConfigValueFromFile(configKey string) string {
 	if !strings.HasSuffix(configKey, ".file") {
 		configKey += ".file"
 	}
-	var valuePath = viper.GetString(configKey)
+	var valuePath = os.ExpandEnv(viper.GetString(configKey))
 	if valuePath == "" {
 		return ""
 	}


### PR DESCRIPTION
This little change adds the possibility to have config values like:

```yaml
mailer:
  password:
    file: $CREDENTIALS_DIRECTORY/smtp.secret
```

Which allows to provide such secrets via systemd's `LoadCredential` directives.
See official docs: https://systemd.io/CREDENTIALS/