### PR TITLE
chore: add .pnpm-store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@ mage-static
 /plugins/*
 /plugins-dev/*
 
+# pnpm
+.pnpm-store/
+
 # Devenv
 .devenv*
 devenv.local.nix


### PR DESCRIPTION
Added .pnpm-store to .gitignore so new devs have easier start - this is a cache folder (similar to node_modules) and should not be tracked.