### PR TITLE
feat(auth):  Add SAML authentication support

### DIFF
--- a/devenv.lock
+++ b/devenv.lock
@@ -3,10 +3,11 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1773012232,
+        "lastModified": 1774880920,
+        "narHash": "sha256-VPLBe2ES5agAANNZKDNaBQE/socnjBeEr2zloVcJHKk=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "46a4bd0299a26ad948b71d3053174ba7b90522f7",
+        "rev": "f333c713e692b687a9ed7cc38ea5738cac67d38a",
         "type": "github"
       },
       "original": {
@@ -16,71 +17,16 @@
         "type": "github"
       }
     },
-    "flake-compat": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1767039857,
-        "owner": "NixOS",
-        "repo": "flake-compat",
-        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "git-hooks": {
-      "inputs": {
-        "flake-compat": "flake-compat",
-        "gitignore": "gitignore",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1772893680,
-        "owner": "cachix",
-        "repo": "git-hooks.nix",
-        "rev": "8baab586afc9c9b57645a734c820e4ac0a604af9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "repo": "git-hooks.nix",
-        "type": "github"
-      }
-    },
-    "gitignore": {
-      "inputs": {
-        "nixpkgs": [
-          "git-hooks",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1762808025,
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "cb5e3fdca1de58ccbc3ef53de65bd372b48f567c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "inputs": {
         "nixpkgs-src": "nixpkgs-src"
       },
       "locked": {
-        "lastModified": 1772749504,
+        "lastModified": 1774287239,
+        "narHash": "sha256-W3krsWcDwYuA3gPWsFA24YAXxOFUL6iIlT6IknAoNSE=",
         "owner": "cachix",
         "repo": "devenv-nixpkgs",
-        "rev": "08543693199362c1fddb8f52126030d0d374ba2e",
+        "rev": "fa7125ea7f1ae5430010a6e071f68375a39bd24c",
         "type": "github"
       },
       "original": {
@@ -93,11 +39,11 @@
     "nixpkgs-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1769922788,
-        "narHash": "sha256-H3AfG4ObMDTkTJYkd8cz1/RbY9LatN5Mk4UF48VuSXc=",
+        "lastModified": 1773840656,
+        "narHash": "sha256-9tpvMGFteZnd3gRQZFlRCohVpqooygFuy9yjuyRL2C0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "207d15f1a6603226e1e223dc79ac29c7846da32e",
+        "rev": "9cf7092bdd603554bd8b63c216e8943cf9b12512",
         "type": "github"
       },
       "original": {
@@ -109,10 +55,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1772773019,
+        "lastModified": 1774709303,
+        "narHash": "sha256-D3Q07BbIA2KnTcSXIqqu9P586uWxN74zNoCH3h2ESHg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+        "rev": "8110df5ad7abf5d4c0f6fb0f8f978390e77f9685",
         "type": "github"
       },
       "original": {
@@ -125,12 +72,8 @@
     "root": {
       "inputs": {
         "devenv": "devenv",
-        "git-hooks": "git-hooks",
         "nixpkgs": "nixpkgs",
-        "nixpkgs-unstable": "nixpkgs-unstable",
-        "pre-commit-hooks": [
-          "git-hooks"
-        ]
+        "nixpkgs-unstable": "nixpkgs-unstable"
       }
     }
   },

--- a/frontend/src/constants/authRouteNames.ts
+++ b/frontend/src/constants/authRouteNames.ts
@@ -10,4 +10,5 @@ export const AUTH_ROUTE_NAMES = new Set([
 	'user.password-reset.reset',
 	'link-share.auth',
 	'openid.auth',
+	'saml.auth',
 ])

--- a/frontend/src/i18n/lang/en.json
+++ b/frontend/src/i18n/lang/en.json
@@ -54,6 +54,7 @@
       "authenticating": "Authenticating…",
       "openIdStateError": "State does not match, refusing to continue!",
       "openIdGeneralError": "An error occurred while authenticating against the third party.",
+      "samlError": "An error occurred while authenticating via SAML.",
       "oauthMissingParams": "Missing required OAuth parameters: {params}",
       "logout": "Logout",
       "emailInvalid": "Please enter a valid email address.",

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -14,6 +14,7 @@ import Login from '@/views/user/Login.vue'
 import Register from '@/views/user/Register.vue'
 import LinkSharingAuth from '@/views/sharing/LinkSharingAuth.vue'
 import OpenIdAuth from '@/views/user/OpenIdAuth.vue'
+import SAMLAuth from '@/views/user/SAMLAuth.vue'
 import UpcomingTasks from '@/views/tasks/ShowTasks.vue'
 
 import NotFoundComponent from '@/views/404.vue'
@@ -393,6 +394,11 @@ const router = createRouter({
 			path: '/auth/openid/:provider',
 			name: 'openid.auth',
 			component: OpenIdAuth,
+		},
+		{
+			path: '/auth/saml/:provider',
+			name: 'saml.auth',
+			component: SAMLAuth,
 		},
 		{
 			path: '/oauth/authorize',

--- a/frontend/src/stores/config.ts
+++ b/frontend/src/stores/config.ts
@@ -6,6 +6,7 @@ import {HTTPFactory} from '@/helpers/fetcher'
 import {objectToCamelCase} from '@/helpers/case'
 
 import type {IProvider} from '@/types/IProvider'
+import type {ISAMLProvider} from '@/types/ISAMLProvider'
 import type {MIGRATORS} from '@/views/migrate/migrators'
 import {InvalidApiUrlProvidedError} from '@/helpers/checkAndSetApiUrl'
 
@@ -41,6 +42,10 @@ export interface ConfigState {
 			enabled: boolean,
 			redirectUrl: string,
 			providers: IProvider[],
+		},
+		saml: {
+			enabled: boolean,
+			providers: ISAMLProvider[],
 		},
 	},
 	publicTeamsEnabled: boolean,
@@ -79,6 +84,10 @@ export const useConfigStore = defineStore('config', () => {
 			openidConnect: {
 				enabled: false,
 				redirectUrl: '',
+				providers: [],
+			},
+			saml: {
+				enabled: false,
 				providers: [],
 			},
 		},

--- a/frontend/src/types/ISAMLProvider.ts
+++ b/frontend/src/types/ISAMLProvider.ts
@@ -1,0 +1,4 @@
+export interface ISAMLProvider {
+	name: string;
+	key: string;
+}

--- a/frontend/src/views/user/Login.vue
+++ b/frontend/src/views/user/Login.vue
@@ -119,6 +119,21 @@
 				{{ $t('user.auth.loginWith', {provider: p.name}) }}
 			</XButton>
 		</div>
+
+		<div
+			v-if="hasSAMLProviders"
+			class="mbs-4"
+		>
+			<XButton
+				v-for="(p, k) in samlProviders.providers"
+				:key="k"
+				variant="secondary"
+				class="is-fullwidth mbs-2"
+				@click="redirectToSAMLProvider(p)"
+			>
+				{{ $t('user.auth.loginWith', {provider: p.name}) }}
+			</XButton>
+		</div>
 	</div>
 </template>
 
@@ -155,6 +170,13 @@ const ldapAuthEnabled = computed(() => configStore.auth.ldap.enabled)
 
 const openidConnect = computed(() => configStore.auth.openidConnect)
 const hasOpenIdProviders = computed(() => openidConnect.value.enabled && openidConnect.value.providers?.length > 0)
+
+const samlProviders = computed(() => configStore.auth.saml)
+const hasSAMLProviders = computed(() => samlProviders.value.enabled && samlProviders.value.providers?.length > 0)
+
+function redirectToSAMLProvider(provider: {name: string, key: string}) {
+	window.location.href = `${window.API_URL}/auth/saml/${provider.key}/login`
+}
 
 const isLoading = computed(() => authStore.isLoading)
 

--- a/frontend/src/views/user/SAMLAuth.vue
+++ b/frontend/src/views/user/SAMLAuth.vue
@@ -1,0 +1,68 @@
+<template>
+	<div>
+		<Message
+			v-if="errorMessage"
+			variant="danger"
+		>
+			{{ errorMessage }}
+		</Message>
+		<Message v-if="loading">
+			{{ $t('user.auth.authenticating') }}
+		</Message>
+	</div>
+</template>
+
+<script setup lang="ts">
+import {ref, computed, onMounted} from 'vue'
+import {useRoute} from 'vue-router'
+import {useI18n} from 'vue-i18n'
+
+import Message from '@/components/misc/Message.vue'
+import {useRedirectToLastVisited} from '@/composables/useRedirectToLastVisited'
+import {useAuthStore} from '@/stores/auth'
+import {saveToken} from '@/helpers/auth'
+
+defineOptions({name: 'SAMLAuth'})
+
+const {t} = useI18n({useScope: 'global'})
+const route = useRoute()
+const {redirectIfSaved} = useRedirectToLastVisited()
+const authStore = useAuthStore()
+
+const loading = computed(() => authStore.isLoading)
+const errorMessage = ref('')
+
+async function authenticateWithToken() {
+	if (localStorage.getItem('authenticating')) {
+		return
+	}
+	localStorage.setItem('authenticating', 'true')
+
+	errorMessage.value = ''
+
+	if (typeof route.query.error !== 'undefined') {
+		localStorage.removeItem('authenticating')
+		errorMessage.value = t('user.auth.samlError')
+		return
+	}
+
+	const token = route.query.token as string
+	if (!token) {
+		localStorage.removeItem('authenticating')
+		errorMessage.value = t('user.auth.samlError')
+		return
+	}
+
+	try {
+		saveToken(token, true)
+		await authStore.checkAuth()
+		redirectIfSaved()
+	} catch (_e) {
+		errorMessage.value = t('user.auth.samlError')
+	} finally {
+		localStorage.removeItem('authenticating')
+	}
+}
+
+onMounted(() => authenticateWithToken())
+</script>

--- a/go.mod
+++ b/go.mod
@@ -110,7 +110,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.15 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.7 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
-	github.com/beevik/etree v1.1.0 // indirect
+	github.com/beevik/etree v1.5.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/boombuler/barcode v1.0.1 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
@@ -121,6 +121,7 @@ require (
 	github.com/containerd/errdefs v1.0.0 // indirect
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.6 // indirect
+	github.com/crewjam/saml v0.5.1 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/distribution/reference v0.6.0 // indirect
@@ -140,14 +141,17 @@ require (
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/goccy/go-json v0.10.5 // indirect
 	github.com/goccy/go-yaml v1.18.0 // indirect
+	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/gorilla/css v1.0.1 // indirect
 	github.com/huandu/go-clone v1.7.3 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/jonboulle/clockwork v0.2.2 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/laurent22/ical-go v0.1.1-0.20181107184520-7e5d6ade8eef // indirect
 	github.com/lithammer/shortuuid/v3 v3.0.7 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
+	github.com/mattermost/xml-roundtrip-validator v0.1.0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.19 // indirect
@@ -172,6 +176,7 @@ require (
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.17.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
+	github.com/russellhaering/goxmldsig v1.4.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sagikazarmark/locafero v0.11.0 // indirect
 	github.com/sony/gobreaker v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -76,6 +76,8 @@ github.com/bbrks/go-blurhash v1.1.1 h1:uoXOxRPDca9zHYabUTwvS4KnY++KKUbwFo+Yxb8ME
 github.com/bbrks/go-blurhash v1.1.1/go.mod h1:lkAsdyXp+EhARcUo85yS2G1o+Sh43I2ebF5togC4bAY=
 github.com/beevik/etree v1.1.0 h1:T0xke/WvNtMoCqgzPhkX2r4rjY3GDZFi+FjpRZY2Jbs=
 github.com/beevik/etree v1.1.0/go.mod h1:r8Aw8JqVegEf0w2fDnATrX9VpkMcyFeM0FhwO62wh+A=
+github.com/beevik/etree v1.5.0 h1:iaQZFSDS+3kYZiGoc9uKeOkUY3nYMXOKLl6KIJxiJWs=
+github.com/beevik/etree v1.5.0/go.mod h1:gPNJNaBGVZ9AwsidazFZyygnd+0pAU38N4D+WemwKNs=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
@@ -118,6 +120,8 @@ github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7Do
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
+github.com/crewjam/saml v0.5.1 h1:g+mfp0CrLuLRZCK793PgJcZeg5dS/0CDwoeAX2zcwNI=
+github.com/crewjam/saml v0.5.1/go.mod h1:r0fDkmFe5URDgPrmtH0IYokva6fac3AUdstiPhyEolQ=
 github.com/d4l3k/messagediff v1.2.1 h1:ZcAIMYsUg0EAp9X+tt8/enBE/Q8Yd5kzPynLyKptt9U=
 github.com/d4l3k/messagediff v1.2.1/go.mod h1:Oozbb1TVXFac9FtSIxHBMnBCq2qeH/2KkEQxENCrlLo=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -206,6 +210,8 @@ github.com/goccy/go-json v0.10.5/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PU
 github.com/goccy/go-yaml v1.18.0 h1:8W7wMFS12Pcas7KU+VVkaiCng+kG8QiFeFwzFb+rwuw=
 github.com/goccy/go-yaml v1.18.0/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
 github.com/gofrs/uuid v4.0.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
+github.com/golang-jwt/jwt/v4 v4.5.2 h1:YtQM7lnr8iZ+j5q71MGKkNw9Mn7AjHM68uc9g5fXeUI=
+github.com/golang-jwt/jwt/v4 v4.5.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang-jwt/jwt/v5 v5.3.0 h1:pv4AsKCKKZuqlgs5sUmn4x8UlGa0kEVt/puTpKx9vvo=
 github.com/golang-jwt/jwt/v5 v5.3.0/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe/go.mod h1:8vg3r2VgvsThLBIFL93Qb5yWzgyZWhEmBwUJWevAkK0=
@@ -318,6 +324,8 @@ github.com/jinzhu/copier v0.4.0 h1:w3ciUoD19shMCRargcpm0cm91ytaBhDvuRpz1ODO/U8=
 github.com/jinzhu/copier v0.4.0/go.mod h1:DfbEm0FYsaqBcKcFuvmOZb218JkPGtvSHsKg8S8hyyg=
 github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
+github.com/jonboulle/clockwork v0.2.2 h1:UOGuzwb1PwsrDAObMuhUnj0p5ULPj8V/xJ7Kx9qUBdQ=
+github.com/jonboulle/clockwork v0.2.2/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
@@ -333,6 +341,8 @@ github.com/kolaente/caldav-go v3.0.1-0.20260326091743-a55d55891017+incompatible/
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
+github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
@@ -366,6 +376,8 @@ github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/matryer/is v1.2.0 h1:92UTHpy8CDwaJ08GqLDzhhuixiBUUD1p3AU6PHddz4A=
 github.com/matryer/is v1.2.0/go.mod h1:2fLPjFQM9rhQ15aVEtbuwhJinnOqrmgXPNdZsdwlWXA=
+github.com/mattermost/xml-roundtrip-validator v0.1.0 h1:RXbVD2UAl7A7nOTR4u7E3ILa4IbtvKBHw64LDsmu9hU=
+github.com/mattermost/xml-roundtrip-validator v0.1.0/go.mod h1:qccnGMcpgwcNaBnxqpJpWWUiPNr5H3O8eDgGV9gT5To=
 github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcnceauSikq3lYCQ=
 github.com/mattn/go-colorable v0.1.6/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=
@@ -435,6 +447,7 @@ github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8
 github.com/pingcap/errors v0.11.4 h1:lFuQV/oaUMGcD2tqt+01ROSmJs75VG1ToEOkZIZ4nE4=
 github.com/pingcap/errors v0.11.4/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
 github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4/go.mod h1:4OwLy04Bl9Ef3GJJCoec+30X3LQs/0/m4HFRt/2LUSA=
+github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -461,11 +474,15 @@ github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUc
 github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
 github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
+github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6poM+XZ2dLUbcbE=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
 github.com/rs/zerolog v1.13.0/go.mod h1:YbFCdg8HfsridGWAh22vktObvhZbQsZXe4/zB0OKkWU=
 github.com/rs/zerolog v1.15.0/go.mod h1:xYTKnLHcpfU2225ny5qZjxnj9NvkumZYjJHlAThCjNc=
+github.com/russellhaering/goxmldsig v1.4.0 h1:8UcDh/xGyQiyrW+Fq5t8f+l2DLB1+zlhYzkPUJ7Qhys=
+github.com/russellhaering/goxmldsig v1.4.0/go.mod h1:gM4MDENBQf7M+V824SGfyIUVFWydB7n0KkEubVJl+Tw=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -101,6 +101,9 @@ const (
 	AuthLdapAttributeDisplayname Key = `auth.ldap.attribute.displayname`
 	AuthLdapAttributeMemberID    Key = `auth.ldap.attribute.memberid`
 
+	AuthSAMLEnabled   Key = `auth.saml.enabled`
+	AuthSAMLProviders Key = `auth.saml.providers`
+
 	LegalImprintURL Key = `legal.imprinturl`
 	LegalPrivacyURL Key = `legal.privacyurl`
 
@@ -382,6 +385,8 @@ func InitDefaultConfig() {
 	AuthLdapAttributeEmail.setDefault("mail")
 	AuthLdapAttributeDisplayname.setDefault("displayName")
 	AuthLdapAttributeMemberID.setDefault("member")
+
+	AuthSAMLEnabled.setDefault(false)
 
 	// Database
 	DatabaseType.setDefault("sqlite")

--- a/pkg/modules/auth/saml/saml.go
+++ b/pkg/modules/auth/saml/saml.go
@@ -1,0 +1,608 @@
+// Vikunja is a to-do list application to facilitate your life.
+// Copyright 2018-present Vikunja and contributors. All rights reserved.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package saml
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/xml"
+	"fmt"
+	"math/big"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"code.vikunja.io/api/pkg/config"
+	"code.vikunja.io/api/pkg/db"
+	"code.vikunja.io/api/pkg/log"
+	"code.vikunja.io/api/pkg/models"
+	"code.vikunja.io/api/pkg/modules/auth"
+	"code.vikunja.io/api/pkg/modules/keyvalue"
+	"code.vikunja.io/api/pkg/user"
+
+	petname "github.com/dustinkirkland/golang-petname"
+	"github.com/labstack/echo/v5"
+
+	"github.com/crewjam/saml"
+	"github.com/crewjam/saml/samlsp"
+
+	"xorm.io/xorm"
+)
+
+// Provider represents a SAML identity provider configuration
+type Provider struct {
+	Name         string                 `json:"name"`
+	Key          string                 `json:"key"`
+	MetadataURL  string                 `json:"-"`
+	MetadataFile string                 `json:"-"`
+	IDPMetadata  *saml.EntityDescriptor `json:"-"`
+	CertFile     string                 `json:"-"`
+	KeyFile      string                 `json:"-"`
+	RootURL      string                 `json:"-"`
+	Middleware   *samlsp.Middleware     `json:"-"`
+}
+
+func init() {
+	petname.NonDeterministicMode()
+}
+
+// GetAllProviders returns all configured SAML providers
+func GetAllProviders() ([]*Provider, error) {
+	if !config.AuthSAMLEnabled.GetBool() {
+		return nil, nil
+	}
+
+	providers := []*Provider{}
+	exists, err := keyvalue.GetWithValue("saml_providers", &providers)
+	if exists && err == nil {
+		return providers, nil
+	}
+
+	rawProviders := config.AuthSAMLProviders.Get()
+	if rawProviders == nil {
+		return nil, nil
+	}
+
+	rawProvider, is := rawProviders.(map[string]interface{})
+	if !is {
+		if rawProviderInterface, ok := rawProviders.(map[interface{}]interface{}); ok {
+			rawProvider = make(map[string]interface{}, len(rawProviderInterface))
+			for k, v := range rawProviderInterface {
+				if key, keyOK := k.(string); keyOK {
+					rawProvider[key] = v
+				}
+			}
+		} else {
+			log.Criticalf("SAML configuration is in the wrong format. Please check the docs.")
+			return nil, nil
+		}
+	}
+
+	for key, p := range rawProvider {
+		pi, is := p.(map[string]interface{})
+		if !is {
+			if pis, pisOK := p.(map[interface{}]interface{}); pisOK {
+				pi = make(map[string]interface{}, len(pis))
+				for i, s := range pis {
+					if k, keyOK := i.(string); keyOK {
+						pi[k] = s
+					}
+				}
+			} else {
+				log.Errorf("SAML provider %s has invalid configuration format, skipping", key)
+				continue
+			}
+		}
+
+		provider, err := getProviderFromMap(pi, key)
+		if err != nil {
+			log.Errorf("Error while getting SAML provider %s: %s", key, err)
+			continue
+		}
+		if provider == nil {
+			continue
+		}
+
+		providers = append(providers, provider)
+
+		err = keyvalue.Put("saml_provider_"+key, provider)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	err = keyvalue.Put("saml_providers", providers)
+	return providers, err
+}
+
+// GetProvider retrieves a single SAML provider by key
+func GetProvider(key string) (*Provider, error) {
+	provider := &Provider{}
+	exists, err := keyvalue.GetWithValue("saml_provider_"+key, provider)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		_, err = GetAllProviders()
+		if err != nil {
+			return nil, err
+		}
+		_, err = keyvalue.GetWithValue("saml_provider_"+key, provider)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if provider.Middleware == nil {
+		err = provider.initMiddleware()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return provider, nil
+}
+
+func getProviderFromMap(pi map[string]interface{}, key string) (*Provider, error) {
+	optionalKeys := []string{"name", "metadataurl", "metadatafile", "certfile", "keyfile"}
+
+	for _, configKey := range optionalKeys {
+		valueFromFile := config.GetConfigValueFromFile("auth.saml.providers." + key + "." + configKey)
+		if valueFromFile != "" {
+			pi[configKey] = valueFromFile
+		}
+	}
+
+	if _, exists := pi["name"]; !exists {
+		return nil, fmt.Errorf("required key 'name' is missing in the SAML provider configuration")
+	}
+
+	hasMetadataURL := func() bool { _, ok := pi["metadataurl"]; return ok }()
+	hasMetadataFile := func() bool { _, ok := pi["metadatafile"]; return ok }()
+	if !hasMetadataURL && !hasMetadataFile {
+		return nil, fmt.Errorf("either 'metadataurl' or 'metadatafile' is required in the SAML provider configuration")
+	}
+
+	name, is := pi["name"].(string)
+	if !is {
+		return nil, nil
+	}
+
+	var metadataURL, metadataFile string
+	if v, ok := pi["metadataurl"]; ok {
+		metadataURL, _ = v.(string)
+	}
+	if v, ok := pi["metadatafile"]; ok {
+		metadataFile, _ = v.(string)
+	}
+
+	var certFile, keyFile string
+	if v, ok := pi["certfile"]; ok {
+		certFile = v.(string)
+	}
+	if v, ok := pi["keyfile"]; ok {
+		keyFile = v.(string)
+	}
+
+	provider := &Provider{
+		Name:         name,
+		Key:          key,
+		MetadataURL:  metadataURL,
+		MetadataFile: metadataFile,
+		CertFile:     certFile,
+		KeyFile:      keyFile,
+		RootURL:      config.ServicePublicURL.GetString(),
+	}
+
+	err := provider.initMiddleware()
+	if err != nil {
+		log.Errorf("Error initializing SAML provider %s: %s", key, err)
+		return provider, nil
+	}
+
+	return provider, nil
+}
+
+func (p *Provider) initMiddleware() error {
+	rootURL, err := url.Parse(p.RootURL)
+	if err != nil {
+		return fmt.Errorf("invalid root URL: %w", err)
+	}
+
+	var keyPair tls.Certificate
+	if p.CertFile != "" && p.KeyFile != "" {
+		keyPair, err = tls.LoadX509KeyPair(p.CertFile, p.KeyFile)
+		if err != nil {
+			return fmt.Errorf("error loading SAML certificate: %w", err)
+		}
+	} else {
+		// Generate a self-signed cert for SP metadata
+		keyPair, err = generateSelfSignedCert()
+		if err != nil {
+			return fmt.Errorf("error generating self-signed certificate: %w", err)
+		}
+	}
+
+	keyPair.Leaf, err = x509.ParseCertificate(keyPair.Certificate[0])
+	if err != nil {
+		return fmt.Errorf("error parsing certificate: %w", err)
+	}
+
+	var idpMetadata *saml.EntityDescriptor
+	if p.MetadataFile != "" {
+		xmlData, readErr := os.ReadFile(p.MetadataFile)
+		if readErr != nil {
+			return fmt.Errorf("error reading IDP metadata file for %s: %w", p.Name, readErr)
+		}
+		idpMetadata, err = samlsp.ParseMetadata(xmlData)
+		if err != nil {
+			return fmt.Errorf("error parsing IDP metadata file for %s: %w", p.Name, err)
+		}
+	} else {
+		idpMetadataURL, parseErr := url.Parse(p.MetadataURL)
+		if parseErr != nil {
+			return fmt.Errorf("invalid metadata URL: %w", parseErr)
+		}
+		idpMetadata, err = samlsp.FetchMetadata(
+			context.Background(),
+			http.DefaultClient,
+			*idpMetadataURL,
+		)
+		if err != nil {
+			return fmt.Errorf("error fetching IDP metadata for %s: %w", p.Name, err)
+		}
+	}
+
+	p.IDPMetadata = idpMetadata
+
+	rootURLStr := strings.TrimRight(p.RootURL, "/")
+	acsURL := fmt.Sprintf("%s/api/v1/auth/saml/%s/acs", rootURLStr, p.Key)
+	metadataURL := fmt.Sprintf("%s/api/v1/auth/saml/%s/metadata", rootURLStr, p.Key)
+
+	samlSP, err := samlsp.New(samlsp.Options{
+		EntityID:    metadataURL,
+		URL:         *rootURL,
+		Key:         keyPair.PrivateKey.(*rsa.PrivateKey),
+		Certificate: keyPair.Leaf,
+		IDPMetadata: idpMetadata,
+	})
+	if err != nil {
+		return fmt.Errorf("error creating SAML SP for %s: %w", p.Name, err)
+	}
+
+	// Override ACS and Metadata URLs to match our actual API routes
+	parsedACSURL, err := url.Parse(acsURL)
+	if err != nil {
+		return fmt.Errorf("error parsing ACS URL: %w", err)
+	}
+	parsedMetadataURL, err := url.Parse(metadataURL)
+	if err != nil {
+		return fmt.Errorf("error parsing metadata URL: %w", err)
+	}
+	samlSP.ServiceProvider.AcsURL = *parsedACSURL
+	samlSP.ServiceProvider.MetadataURL = *parsedMetadataURL
+
+	// Allow IDP-initiated SSO so that InResponseTo validation is skipped.
+	// This is needed because the SAML ACS endpoint receives a cross-origin POST
+	// from the IDP, and browsers won't send the request-tracking cookie back
+	// (SameSite=None requires Secure/HTTPS).
+	samlSP.ServiceProvider.AllowIDPInitiated = true
+
+	p.Middleware = samlSP
+	return nil
+}
+
+// HandleMetadata returns the SP metadata XML for a given provider
+func HandleMetadata(c *echo.Context) error {
+	providerKey := c.Param("provider")
+	provider, err := GetProvider(providerKey)
+	if err != nil {
+		return err
+	}
+	if provider == nil || provider.Middleware == nil {
+		return echo.NewHTTPError(http.StatusNotFound, "SAML provider not found")
+	}
+
+	buf, err := xml.MarshalIndent(provider.Middleware.ServiceProvider.Metadata(), "", "  ")
+	if err != nil {
+		return err
+	}
+
+	c.Response().Header().Set("Content-Type", "application/samlmetadata+xml")
+	return c.Blob(http.StatusOK, "application/samlmetadata+xml", buf)
+}
+
+// HandleACS processes the SAML Assertion Consumer Service callback
+// @Summary Authenticate a user with SAML
+// @Description After the SAML Identity Provider redirects back with a SAML response, this endpoint processes the assertion and logs the user in.
+// @ID get-token-saml
+// @tags auth
+// @Accept application/x-www-form-urlencoded
+// @Produce json
+// @Param provider path string true "The SAML provider key"
+// @Param SAMLResponse formData string true "The SAML Response"
+// @Success 200 {object} auth.Token
+// @Failure 500 {object} models.Message "Internal error"
+// @Router /auth/saml/{provider}/acs [post]
+func HandleACS(c *echo.Context) error {
+	providerKey := c.Param("provider")
+	provider, err := GetProvider(providerKey)
+	if err != nil {
+		return err
+	}
+	if provider == nil || provider.Middleware == nil {
+		return echo.NewHTTPError(http.StatusNotFound, "SAML provider not found")
+	}
+
+	r := c.Request()
+	err = r.ParseForm()
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "could not parse form")
+	}
+
+	// Retrieve tracked request IDs to validate InResponseTo
+	var possibleRequestIDs []string
+	if provider.Middleware.ServiceProvider.AllowIDPInitiated {
+		possibleRequestIDs = append(possibleRequestIDs, "")
+	}
+	trackedRequests := provider.Middleware.RequestTracker.GetTrackedRequests(r)
+	for _, tr := range trackedRequests {
+		possibleRequestIDs = append(possibleRequestIDs, tr.SAMLRequestID)
+	}
+
+	assertion, err := provider.Middleware.ServiceProvider.ParseResponse(r, possibleRequestIDs)
+	if err != nil {
+		if invalidErr, ok := err.(*saml.InvalidResponseError); ok {
+			log.Errorf("SAML assertion parse error for provider %s: %v (private: %v)", provider.Name, invalidErr.Response, invalidErr.PrivateErr)
+		} else {
+			log.Errorf("SAML assertion parse error for provider %s: %v", provider.Name, err)
+		}
+		// Redirect back to frontend with error
+		frontendURL := strings.TrimRight(config.ServicePublicURL.GetString(), "/")
+		return c.Redirect(http.StatusFound, frontendURL+"/auth/saml/"+providerKey+"?error=saml_assertion_failed")
+	}
+
+	// Stop tracking the request now that it's been validated
+	if relayState := r.FormValue("RelayState"); relayState != "" {
+		_ = provider.Middleware.RequestTracker.StopTrackingRequest(
+			c.Response(), c.Request(), relayState,
+		)
+	}
+
+	// Extract attributes from the assertion
+	email := getAttributeValue(assertion, "email", "urn:oid:0.9.2342.19200300.100.1.3", "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress")
+	name := getAttributeValue(assertion, "displayName", "urn:oid:2.16.840.1.113730.3.1.241", "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name")
+	username := getAttributeValue(assertion, "uid", "urn:oid:0.9.2342.19200300.100.1.1", "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn")
+
+	if email == "" {
+		frontendURL := strings.TrimRight(config.ServicePublicURL.GetString(), "/")
+		return c.Redirect(http.StatusFound, frontendURL+"/auth/saml/"+providerKey+"?error=no_email")
+	}
+
+	// Use the NameID as the subject identifier
+	subject := ""
+	if assertion.Subject != nil && assertion.Subject.NameID != nil {
+		subject = assertion.Subject.NameID.Value
+	}
+	if subject == "" {
+		subject = email
+	}
+
+	issuer := assertion.Issuer.Value
+
+	s := db.NewSession()
+	defer s.Close()
+
+	u, err := getOrCreateUser(s, email, name, username, issuer, subject)
+	if err != nil {
+		_ = s.Rollback()
+		log.Errorf("Error creating user for SAML provider %s: %v", provider.Name, err)
+		return err
+	}
+
+	if u.Status == user.StatusDisabled {
+		_ = s.Rollback()
+		return &user.ErrAccountDisabled{UserID: u.ID}
+	}
+	if u.Status == user.StatusAccountLocked {
+		_ = s.Rollback()
+		return &user.ErrAccountLocked{UserID: u.ID}
+	}
+
+	err = s.Commit()
+	if err != nil {
+		_ = s.Rollback()
+		return err
+	}
+
+	// Generate JWT token
+	session, err := models.CreateSession(s, u.ID, "SAML Login", "", false)
+	if err != nil {
+		_ = s.Rollback()
+		return err
+	}
+
+	token, err := auth.NewUserJWTAuthtoken(u, session.ID)
+	if err != nil {
+		_ = s.Rollback()
+		return err
+	}
+
+	// Redirect to frontend with the token
+	frontendURL := strings.TrimRight(config.ServicePublicURL.GetString(), "/")
+	return c.Redirect(http.StatusFound, frontendURL+"/auth/saml/"+providerKey+"?token="+token)
+}
+
+// HandleLogin initiates SAML authentication by redirecting to the IDP
+func HandleLogin(c *echo.Context) error {
+	providerKey := c.Param("provider")
+	provider, err := GetProvider(providerKey)
+	if err != nil {
+		return err
+	}
+	if provider == nil || provider.Middleware == nil {
+		return echo.NewHTTPError(http.StatusNotFound, "SAML provider not found")
+	}
+
+	binding := saml.HTTPRedirectBinding
+	bindingLocation := provider.Middleware.ServiceProvider.GetSSOBindingLocation(binding)
+	if bindingLocation == "" {
+		binding = saml.HTTPPostBinding
+		bindingLocation = provider.Middleware.ServiceProvider.GetSSOBindingLocation(binding)
+	}
+
+	authReq, err := provider.Middleware.ServiceProvider.MakeAuthenticationRequest(
+		bindingLocation,
+		binding,
+		saml.HTTPPostBinding,
+	)
+	if err != nil {
+		return err
+	}
+
+	// Track the request ID so we can validate InResponseTo in the ACS handler
+	relayState, err := provider.Middleware.RequestTracker.TrackRequest(
+		c.Response(), c.Request(), authReq.ID,
+	)
+	if err != nil {
+		return err
+	}
+
+	redirectURL, err := authReq.Redirect(relayState, &provider.Middleware.ServiceProvider)
+	if err != nil {
+		return err
+	}
+
+	return c.Redirect(http.StatusFound, redirectURL.String())
+}
+
+func getAttributeValue(assertion *saml.Assertion, names ...string) string {
+	for _, stmt := range assertion.AttributeStatements {
+		for _, attr := range stmt.Attributes {
+			for _, name := range names {
+				if attr.Name == name || attr.FriendlyName == name {
+					if len(attr.Values) > 0 {
+						return attr.Values[0].Value
+					}
+				}
+			}
+		}
+	}
+	return ""
+}
+
+func getOrCreateUser(s *xorm.Session, email, name, username, issuer, subject string) (u *user.User, err error) {
+	// Check if user already exists by issuer+subject
+	u, err = user.GetUserWithEmail(s, &user.User{
+		Issuer:  issuer,
+		Subject: subject,
+	})
+	if err == nil {
+		// User exists, update if needed
+		if email != u.Email {
+			u.Email = email
+		}
+		if name != u.Name {
+			u.Name = name
+		}
+		u, err = user.UpdateUser(s, u, false)
+		return u, err
+	}
+	if !user.IsErrUserDoesNotExist(err) && !user.IsErrUserStatusError(err) {
+		return nil, err
+	}
+	if user.IsErrUserStatusError(err) {
+		return u, nil
+	}
+
+	// Try to find by email
+	u, err = user.GetUserWithEmail(s, &user.User{
+		Email:  email,
+		Issuer: user.IssuerLocal,
+	})
+	if err == nil {
+		// Found by email, link to SAML
+		u.Issuer = issuer
+		u.Subject = subject
+		u, err = user.UpdateUser(s, u, false)
+		return u, err
+	}
+	if !user.IsErrUserDoesNotExist(err) && !user.IsErrUserStatusError(err) {
+		return nil, err
+	}
+	if user.IsErrUserStatusError(err) {
+		return u, nil
+	}
+
+	// Create new user
+	if username == "" {
+		username = strings.ReplaceAll(email, "@", "-")
+	}
+	username = strings.ReplaceAll(username, " ", "-")
+
+	uu := &user.User{
+		Username: username,
+		Email:    email,
+		Name:     name,
+		Status:   user.StatusActive,
+		Issuer:   issuer,
+		Subject:  subject,
+	}
+
+	u, err = auth.CreateUserWithRandomUsername(s, uu)
+	return u, err
+}
+
+// CleanupSavedSAMLProviders removes cached SAML providers
+func CleanupSavedSAMLProviders() {
+	_ = keyvalue.Del("saml_providers")
+}
+
+func generateSelfSignedCert() (tls.Certificate, error) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			Organization: []string{"Vikunja SAML SP"},
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(10 * 365 * 24 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, &key.PublicKey, key)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+
+	return tls.Certificate{
+		Certificate: [][]byte{certDER},
+		PrivateKey:  key,
+	}, nil
+}

--- a/pkg/routes/api/v1/info.go
+++ b/pkg/routes/api/v1/info.go
@@ -22,6 +22,7 @@ import (
 	"code.vikunja.io/api/pkg/config"
 	"code.vikunja.io/api/pkg/log"
 	"code.vikunja.io/api/pkg/modules/auth/openid"
+	"code.vikunja.io/api/pkg/modules/auth/saml"
 	microsofttodo "code.vikunja.io/api/pkg/modules/migration/microsoft-todo"
 	"code.vikunja.io/api/pkg/modules/migration/ticktick"
 	"code.vikunja.io/api/pkg/modules/migration/todoist"
@@ -58,6 +59,7 @@ type authInfo struct {
 	Local         localAuthInfo  `json:"local"`
 	Ldap          ldapAuthInfo   `json:"ldap"`
 	OpenIDConnect openIDAuthInfo `json:"openid_connect"`
+	SAML          samlAuthInfo   `json:"saml"`
 }
 
 type localAuthInfo struct {
@@ -72,6 +74,11 @@ type ldapAuthInfo struct {
 type openIDAuthInfo struct {
 	Enabled   bool               `json:"enabled"`
 	Providers []*openid.Provider `json:"providers"`
+}
+
+type samlAuthInfo struct {
+	Enabled   bool             `json:"enabled"`
+	Providers []*saml.Provider `json:"providers"`
 }
 
 type legalInfo struct {
@@ -122,6 +129,9 @@ func Info(c *echo.Context) error {
 			OpenIDConnect: openIDAuthInfo{
 				Enabled: config.AuthOpenIDEnabled.GetBool(),
 			},
+			SAML: samlAuthInfo{
+				Enabled: config.AuthSAMLEnabled.GetBool(),
+			},
 		},
 	}
 
@@ -132,6 +142,14 @@ func Info(c *echo.Context) error {
 	}
 
 	info.AuthInfo.OpenIDConnect.Providers = providers
+
+	samlProviders, err := saml.GetAllProviders()
+	if err != nil {
+		log.Errorf("Error while getting saml providers for /info: %s", err)
+		// No return here to not break /info
+	}
+
+	info.AuthInfo.SAML.Providers = samlProviders
 
 	// Migrators
 	if config.MigrationTodoistEnable.GetBool() {

--- a/pkg/routes/routes.go
+++ b/pkg/routes/routes.go
@@ -63,6 +63,7 @@ import (
 	"code.vikunja.io/api/pkg/models"
 	"code.vikunja.io/api/pkg/modules/auth/oauth2server"
 	"code.vikunja.io/api/pkg/modules/auth/openid"
+	"code.vikunja.io/api/pkg/modules/auth/saml"
 	"code.vikunja.io/api/pkg/modules/background"
 	backgroundHandler "code.vikunja.io/api/pkg/modules/background/handler"
 	"code.vikunja.io/api/pkg/modules/background/unsplash"
@@ -301,6 +302,9 @@ var unauthenticatedAPIPaths = map[string]bool{
 	"/api/v1/login":                          true,
 	"/api/v1/user/token/refresh":             true,
 	"/api/v1/auth/openid/:provider/callback": true,
+	"/api/v1/auth/saml/:provider/login":      true,
+	"/api/v1/auth/saml/:provider/acs":        true,
+	"/api/v1/auth/saml/:provider/metadata":   true,
 	"/api/v1/test/:table":                    true,
 	"/api/v1/info":                           true,
 	"/api/v1/shares/:share/auth":             true,
@@ -381,6 +385,12 @@ func registerAPIRoutes(a *echo.Group) {
 
 	if config.AuthOpenIDEnabled.GetBool() {
 		ur.POST("/auth/openid/:provider/callback", openid.HandleCallback)
+	}
+
+	if config.AuthSAMLEnabled.GetBool() {
+		ur.GET("/auth/saml/:provider/login", saml.HandleLogin)
+		ur.POST("/auth/saml/:provider/acs", saml.HandleACS)
+		ur.GET("/auth/saml/:provider/metadata", saml.HandleMetadata)
 	}
 
 	// OAuth 2.0 token endpoint — unauthenticated because it validates
@@ -686,7 +696,6 @@ func registerAPIRoutes(a *echo.Group) {
 	a.PUT("/teams/:team/members", teamMemberHandler.CreateWeb)
 	a.DELETE("/teams/:team/members/:user", teamMemberHandler.DeleteWeb)
 	a.POST("/teams/:team/members/:user/admin", teamMemberHandler.UpdateWeb)
-
 	// Subscriptions
 	subscriptionHandler := &handler.WebHandler{
 		EmptyStruct: func() handler.CObject {


### PR DESCRIPTION
- Introduced SAML authentication capabilities to the application.
- Added configuration options for SAML providers in `config.go`.
- Implemented SAML login and ACS handling in `saml.go`.
- Created a new Vue component for SAML authentication in `SAMLAuth.vue`.
- Updated API routes to include SAML endpoints.
- Added a new TypeScript interface for SAML providers.
- Enhanced the `/info` endpoint to return SAML provider details.