### PR TITLE
fix: set Content-Length on JSON API responses to fix macOS curl piping

### DIFF
--- a/pkg/routes/content_length_middleware.go
+++ b/pkg/routes/content_length_middleware.go
@@ -1,0 +1,64 @@
+// Vikunja is a to-do list application to facilitate your life.
+// Copyright 2018-present Vikunja and contributors. All rights reserved.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package routes
+
+import (
+	"encoding/json"
+	"strconv"
+
+	"github.com/labstack/echo/v5"
+)
+
+// ContentLengthJSONSerializer wraps Echo's default JSON serializer to always
+// set the Content-Length header on JSON responses. This is a server-side
+// mitigation for a known macOS curl bug: when piping curl output to another
+// program (e.g. curl | jq), the receiving program can get empty stdin if the
+// response uses chunked transfer encoding without a Content-Length header.
+//
+// The default serializer uses json.NewEncoder which streams directly to the
+// response writer, so Go's HTTP server cannot pre-calculate Content-Length
+// and falls back to chunked encoding. This serializer marshals to a byte
+// slice first, sets Content-Length, then writes the bytes.
+type ContentLengthJSONSerializer struct{}
+
+// Serialize marshals the target to JSON bytes, sets Content-Length, then writes
+// the response. This ensures the Content-Length header is always present.
+func (s ContentLengthJSONSerializer) Serialize(c *echo.Context, target any, indent string) error {
+	var data []byte
+	var err error
+
+	if indent != "" {
+		data, err = json.MarshalIndent(target, "", indent)
+	} else {
+		data, err = json.Marshal(target)
+	}
+	if err != nil {
+		return err
+	}
+
+	// Append newline for consistency with encoding/json.Encoder behavior
+	data = append(data, '\n')
+
+	c.Response().Header().Set("Content-Length", strconv.Itoa(len(data)))
+	_, err = c.Response().Write(data)
+	return err
+}
+
+// Deserialize decodes JSON from the request body into the target.
+func (s ContentLengthJSONSerializer) Deserialize(c *echo.Context, target any) error {
+	return json.NewDecoder(c.Request().Body).Decode(target)
+}

--- a/pkg/routes/routes.go
+++ b/pkg/routes/routes.go
@@ -195,6 +195,12 @@ func NewEcho() *echo.Echo {
 	// #nosec G115 - maxFileSize is a configuration value that won't exceed int64 max in practice
 	e.Use(middleware.BodyLimit((int64(maxFileSize) + 2) * 1024 * 1024))
 
+	// Use a custom JSON serializer that always sets Content-Length.
+	// This mitigates a macOS curl bug where piping curl output to another
+	// program (e.g. curl | jq) can produce empty stdin when responses use
+	// chunked transfer encoding without Content-Length.
+	e.JSONSerializer = ContentLengthJSONSerializer{}
+
 	// Set up centralized error handler
 	e.HTTPErrorHandler = CreateHTTPErrorHandler(e, config.SentryEnabled.GetBool())
 

--- a/pkg/webtests/content_length_test.go
+++ b/pkg/webtests/content_length_test.go
@@ -17,7 +17,6 @@
 package webtests
 
 import (
-	"fmt"
 	"strconv"
 	"testing"
 
@@ -53,7 +52,6 @@ func TestContentLengthOnListEndpoints(t *testing.T) {
 
 		clInt, err := strconv.Atoi(cl)
 		require.NoError(t, err)
-		assert.Equal(t, rec.Body.Len(), clInt,
-			fmt.Sprintf("Content-Length (%d) must match actual body size (%d)", clInt, rec.Body.Len()))
+		assert.Equal(t, rec.Body.Len(), clInt, "Content-Length must match actual body size")
 	})
 }


### PR DESCRIPTION
## Summary
- Added `ContentLengthJSONSerializer` middleware that marshals JSON to bytes first, sets `Content-Length` header, then writes the response
- This prevents Go's default chunked transfer encoding which macOS curl mishandles when piping to another program (e.g. `curl | jq` produces empty stdin)
- Added web test verifying Content-Length header is present on list endpoints

## Red-Green Evidence

**RED (without fix, middleware not registered in routes.go):**
```
=== RUN   TestContentLengthOnListEndpoints
=== RUN   TestContentLengthOnListEndpoints/ReadAll_response_has_Content-Length
    content_length_test.go:52:
        Error Trace: content_length_test.go:52
        Error:       Should NOT be empty, but was
        Messages:    Content-Length header must be set on list responses to prevent macOS curl piping issues
    content_length_test.go:55:
        Error Trace: content_length_test.go:55
        Error:       Received unexpected error:
                     strconv.Atoi: parsing "": invalid syntax
--- FAIL: TestContentLengthOnListEndpoints (0.04s)
    --- FAIL: TestContentLengthOnListEndpoints/ReadAll_response_has_Content-Length (0.04s)
FAIL
```

**GREEN (with fix applied):**
```
=== RUN   TestContentLengthOnListEndpoints
=== RUN   TestContentLengthOnListEndpoints/ReadAll_response_has_Content-Length
--- PASS: TestContentLengthOnListEndpoints (0.04s)
    --- PASS: TestContentLengthOnListEndpoints/ReadAll_response_has_Content-Length (0.04s)
PASS
ok  	code.vikunja.io/api/pkg/webtests	0.756s
```

## Full test and lint output

**Web tests (mage test:web):**
```
ok  	code.vikunja.io/api/pkg/webtests	15.490s
```

**Lint (mage lint):**
```
0 issues.
```