### PR TITLE
feat(filters): generate open task saved filter on user creation

### DIFF
--- a/frontend/src/helpers/getProjectTitle.ts
+++ b/frontend/src/helpers/getProjectTitle.ts
@@ -10,5 +10,9 @@ export function getProjectTitle(project: IProject) {
 		return i18n.global.t('project.inboxTitle')
 	}
 
+	if (project.title === 'My Open Tasks') {
+		return i18n.global.t('project.myOpenTasksFilterTitle')
+	}
+
 	return project.title
 }

--- a/frontend/src/i18n/lang/en.json
+++ b/frontend/src/i18n/lang/en.json
@@ -349,6 +349,7 @@
     "shared": "Shared Projects",
     "noDescriptionAvailable": "No project description is available.",
     "inboxTitle": "Inbox",
+    "myOpenTasksFilterTitle": "My Open Tasks",
     "favorite": "Mark this project as favorite",
     "unfavorite": "Remove this project from favorites",
     "openSettingsMenu": "Open project settings menu",

--- a/pkg/models/project.go
+++ b/pkg/models/project.go
@@ -760,6 +760,15 @@ func getRawProjectsForUser(s *xorm.Session, opts *projectOptions) (projects []*P
 	return allProjects, len(allProjects), totalItems, err
 }
 
+func CreateDefaultSavedFiltersForUser(s *xorm.Session, u *user.User) error {
+	sf := &SavedFilter{
+		Title:   "My Open Tasks",
+		Filters: &TaskCollection{Filter: fmt.Sprintf("done = false && assignees = %s", u.Username)},
+	}
+
+	return sf.Create(s, u)
+}
+
 func getSavedFilterProjects(s *xorm.Session, doer *user.User, search string) (savedFiltersProjects []*Project, err error) {
 	savedFilters, err := getSavedFiltersForUser(s, doer, search)
 	if err != nil {
@@ -1105,6 +1114,10 @@ func RegisterUser(s *xorm.Session, u *user.User) (*user.User, error) {
 	}
 
 	if err := CreateNewProjectForUser(s, newUser); err != nil {
+		return nil, err
+	}
+
+	if err := CreateDefaultSavedFiltersForUser(s, newUser); err != nil {
 		return nil, err
 	}
 

--- a/pkg/yaegi_symbols/vikunja_models.go
+++ b/pkg/yaegi_symbols/vikunja_models.go
@@ -16,6 +16,7 @@ func init() {
 		"BucketConfigurationModeNone":                      reflect.ValueOf(models.BucketConfigurationModeNone),
 		"CanDoAPIRoute":                                    reflect.ValueOf(models.CanDoAPIRoute),
 		"CollectRoutesForAPITokenUsage":                    reflect.ValueOf(models.CollectRoutesForAPITokenUsage),
+		"CreateDefaultSavedFiltersForUser":                 reflect.ValueOf(models.CreateDefaultSavedFiltersForUser),
 		"CreateDefaultViewsForProject":                     reflect.ValueOf(models.CreateDefaultViewsForProject),
 		"CreateNewProjectForUser":                          reflect.ValueOf(models.CreateNewProjectForUser),
 		"CreateProject":                                    reflect.ValueOf(models.CreateProject),


### PR DESCRIPTION
During user creation, in addition to creating the "Inbox" project, also create a saved filter for the user that shows the open tasks assigned to them. This provides utility for new users to get a quick view of their tasks with no extra setup, as well as gives them an example of a predefined saved filter so they can quickly get up to speed with the syntax and UI layout.

Quick, band-aid solution for #1483 

Provides a "good enough" solution for https://community.vikunja.io/t/add-default-filter-for-tasks-assigned-to-current-logged-in-user/4417

## Considerations

- could be gated with a config value, something like `defaultsettings.new_user_create_filter`
- this won't create the filter for existing users

