### PR TITLE
fix: Frontend hard coded api base

### DIFF
--- a/frontend/src/components/tasks/partials/Comments.vue
+++ b/frontend/src/components/tasks/partials/Comments.vue
@@ -506,7 +506,9 @@ async function deleteComment(commentToDelete: ITaskComment) {
 
 function getCommentUrl(commentId: string) {
 	const baseUrl = frontendUrl.value.endsWith('/') ? frontendUrl.value.slice(0, -1) : frontendUrl.value
-	return `${baseUrl}${location.pathname}${location.search}#comment-${commentId}`
+	const url = new URL(location.pathname + location.search, baseUrl)
+	url.hash = `comment-${commentId}`
+	return url.toString()
 }
 </script>
 

--- a/frontend/src/helpers/checkAndSetApiUrl.ts
+++ b/frontend/src/helpers/checkAndSetApiUrl.ts
@@ -1,6 +1,7 @@
 import {useConfigStore} from '@/stores/config'
 
 const API_DEFAULT_PORT = '3456'
+const API_PATH_SUFFIX = '/api/v1'
 
 export const ERROR_NO_API_URL = 'noApiUrlProvided'
 
@@ -18,6 +19,23 @@ export class InvalidApiUrlProvidedError extends Error {
 		this.message = 'The provided API URL is invalid.'
 		this.name = 'InvalidApiUrlProvidedError'
 	}
+}
+
+/**
+ * Join a base pathname with the API_DEFAULT_PATH, normalizing slashes between them.
+ */
+function joinPath(base: string, suffix: string): string {
+	const normalizedBase = base.endsWith('/') ? base.slice(0, -1) : base
+	return normalizedBase + suffix
+}
+
+/**
+ * Check whether a pathname already ends with the API default path,
+ * with or without a trailing slash.
+ */
+function hasApiPath(pathname: string): boolean {
+	const clean = pathname.endsWith('/') ? pathname.slice(0, -1) : pathname
+	return clean.endsWith(API_PATH_SUFFIX)
 }
 
 export const checkAndSetApiUrl = (pUrl: string | undefined | null): Promise<string> => {
@@ -57,25 +75,19 @@ export const checkAndSetApiUrl = (pUrl: string | undefined | null): Promise<stri
 	return configStore.update()
 		.catch(e => {
 			console.warn(`Could not fetch 'info' from the provided endpoint ${pUrl} on ${window.API_URL}/info. Some automatic fallback will be tried.`)
-			// Check if it is reachable at /api/v1 and http
-			if (
-				!urlToCheck.pathname.endsWith('/api/v1') &&
-				!urlToCheck.pathname.endsWith('/api/v1/')
-			) {
-				urlToCheck.pathname = `${urlToCheck.pathname}api/v1`
+			// Check if it is reachable at the base path + /api/v1 via http
+			if (!hasApiPath(urlToCheck.pathname)) {
+				urlToCheck.pathname = joinPath(urlToCheck.pathname, API_PATH_SUFFIX)
 				window.API_URL = urlToCheck.toString()
 				return configStore.update()
 			}
 			throw e
 		})
 		.catch(e => {
-			// Check if it is reachable at /api/v1 and https
+			// Check if it is reachable at the base path + /api/v1 via https
 			urlToCheck.pathname = origPathname
-			if (
-				!urlToCheck.pathname.endsWith('/api/v1') &&
-				!urlToCheck.pathname.endsWith('/api/v1/')
-			) {
-				urlToCheck.pathname = `${urlToCheck.pathname}api/v1`
+			if (!hasApiPath(urlToCheck.pathname)) {
+				urlToCheck.pathname = joinPath(urlToCheck.pathname, API_PATH_SUFFIX)
 				window.API_URL = urlToCheck.toString()
 				return configStore.update()
 			}
@@ -91,13 +103,10 @@ export const checkAndSetApiUrl = (pUrl: string | undefined | null): Promise<stri
 			throw e
 		})
 		.catch(e => {
-			// Check if it is reachable at :API_DEFAULT_PORT and /api/v1
+			// Check if it is reachable at :API_DEFAULT_PORT with base path + /api/v1
 			urlToCheck.pathname = origPathname
-			if (
-				!urlToCheck.pathname.endsWith('/api/v1') &&
-				!urlToCheck.pathname.endsWith('/api/v1/')
-			) {
-				urlToCheck.pathname = `${urlToCheck.pathname}api/v1`
+			if (!hasApiPath(urlToCheck.pathname)) {
+				urlToCheck.pathname = joinPath(urlToCheck.pathname, API_PATH_SUFFIX)
 				window.API_URL = urlToCheck.toString()
 				return configStore.update()
 			}

--- a/frontend/src/helpers/redirectToProvider.ts
+++ b/frontend/src/helpers/redirectToProvider.ts
@@ -1,3 +1,4 @@
+import {getFullBaseUrl} from '@/helpers/getFullBaseUrl'
 import {createRandomID} from '@/helpers/randomId'
 import type {IProvider} from '@/types/IProvider'
 import {parseURL} from 'ufo'
@@ -6,7 +7,8 @@ export function getRedirectUrlFromCurrentFrontendPath(provider: IProvider): stri
 	// We're not using the redirect url provided by the server to allow redirects when using the electron app.
 	// The implications are not quite clear yet hence the logic to pass in another redirect url still exists.
 	const url = parseURL(window.location.href)
-	return `${url.protocol}//${url.host}/auth/openid/${provider.key}`
+	const base = getFullBaseUrl()
+	return `${url.protocol}//${url.host}${base}auth/openid/${provider.key}`
 }
 
 export const redirectToProvider = (provider: IProvider) => {

--- a/frontend/src/sw.ts
+++ b/frontend/src/sw.ts
@@ -21,9 +21,11 @@ workbox.routing.registerRoute(
 	new workbox.strategies.StaleWhileRevalidate(),
 )
 
+// Construct pattern with full base URL
+const apiRoutePattern = new RegExp(`${fullBaseUrl.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}api\\/v1\\/.*$`)
 // Always send api requests through the network and bypass the browser's HTTP cache
 workbox.routing.registerRoute(
-	new RegExp('api\\/v1\\/.*$'),
+	apiRoutePattern,
 	new workbox.strategies.NetworkOnly({
 		fetchOptions: {
 			cache: 'no-store',

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -269,16 +269,25 @@ function getBuildConfig(env: Record<string, string>) {
 function getServeConfig(env: Record<string, string>) {
 	// get some default settings from prod mod
 	const buildConfig = getBuildConfig(env)
+
+	// Build the proxy pattern from VIKUNJA_FRONTEND_BASE so that custom base
+	// paths like /vikunja proxy /vikunja/api/* correctly.
+	// Falls back to /api.
+	const base = (env.VIKUNJA_FRONTEND_BASE || '/').replace(/\/+$/, '')
+	const proxyPath = `${base}/api`
+
 	// override prod settings with dev settings
 	return {
 		...buildConfig,
 		server: {
 			...buildConfig.server,
 			...(env.DEV_PROXY && { proxy: {
-				'/api': {
+				[proxyPath]: {
 					target: env.DEV_PROXY,
 					changeOrigin: true,
 					secure: false,
+					// Strips prefix for the backend
+					rewrite: (path: string) => path.replace(new RegExp(`^${base.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`), ''),
 				},
 			}}),
 		},


### PR DESCRIPTION
Porting stale changes from #2436, this mainly focus on the frontend.

## What changed

- `checkAndSetApiUrl.ts`: Extracted `API_DEFAULT_PATH` constant and `joinPath`/`hasApiPath` helpers.
- `redirectToProvider.ts`: OIDC redirect URL now includes the base path via `getFullBaseUrl()`, so the callback lands on a route the Vue router handles.
- `sw.ts`: Service worker API route regex is anchored to the configured base path instead of matching `api/v1/` anywhere in the URL.
- `vite.config.ts`: Made the dev proxy path and rewrite dynamic based on `VIKUNJA_FRONTEND_BASE` so local development works with a subpath.
- `Comments.vue`: Let getCommentUrl handle frontendUrl including sub-path.