### PR TITLE
fix: Backend hard coded api base

### DIFF
--- a/pkg/modules/auth/auth.go
+++ b/pkg/modules/auth/auth.go
@@ -19,6 +19,7 @@ package auth
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -47,8 +48,21 @@ type Token struct {
 	Token string `json:"token" example:"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"`
 }
 
-const RefreshTokenCookieName = "vikunja_refresh_token"      //nolint:gosec // not a credential
-const refreshTokenCookiePath = "/api/v1/user/token/refresh" //nolint:gosec // not a credential
+const RefreshTokenCookieName = "vikunja_refresh_token" //nolint:gosec // not a credential
+
+// getRefreshTokenCookiePath returns the cookie path for the refresh token,
+// derived from service.publicurl.
+func getRefreshTokenCookiePath() string {
+	publicURL := config.ServicePublicURL.GetString()
+	u, err := url.Parse(publicURL)
+	if err != nil || publicURL == "" || publicURL == "/" {
+		return "/api/v1/user/token/refresh"
+	}
+
+	// Extract the path component and append the refresh endpoint
+	basePath := strings.TrimRight(u.Path, "/")
+	return basePath + "/api/v1/user/token/refresh"
+}
 
 // SetRefreshTokenCookie sets an HttpOnly cookie containing the refresh token.
 // The cookie is path-scoped to the refresh endpoint so the browser only sends
@@ -67,7 +81,7 @@ func SetRefreshTokenCookie(c *echo.Context, token string, maxAge int) {
 	c.SetCookie(&http.Cookie{
 		Name:     RefreshTokenCookieName,
 		Value:    token,
-		Path:     refreshTokenCookiePath,
+		Path:     getRefreshTokenCookiePath(),
 		MaxAge:   maxAge,
 		HttpOnly: true,
 		Secure:   secure,

--- a/pkg/modules/auth/auth.go
+++ b/pkg/modules/auth/auth.go
@@ -53,15 +53,17 @@ const RefreshTokenCookieName = "vikunja_refresh_token" //nolint:gosec // not a c
 // getRefreshTokenCookiePath returns the cookie path for the refresh token,
 // derived from service.publicurl.
 func getRefreshTokenCookiePath() string {
+	refreshURL := "/api/v1/user/token/refresh"
+
 	publicURL := config.ServicePublicURL.GetString()
 	u, err := url.Parse(publicURL)
-	if err != nil || publicURL == "" || publicURL == "/" {
-		return "/api/v1/user/token/refresh"
+	if err != nil {
+		return refreshURL
 	}
 
 	// Extract the path component and append the refresh endpoint
 	basePath := strings.TrimRight(u.Path, "/")
-	return basePath + "/api/v1/user/token/refresh"
+	return basePath + refreshURL
 }
 
 // SetRefreshTokenCookie sets an HttpOnly cookie containing the refresh token.

--- a/pkg/routes/api/v1/docs.go
+++ b/pkg/routes/api/v1/docs.go
@@ -17,9 +17,13 @@
 package v1
 
 import (
+	"bytes"
 	_ "embed"
+	"html/template"
 	"net/http"
+	"strings"
 
+	"code.vikunja.io/api/pkg/config"
 	"code.vikunja.io/api/pkg/log"
 	_ "code.vikunja.io/api/pkg/swagger" // To make sure the swag files are properly registered
 
@@ -30,12 +34,13 @@ import (
 //go:embed redoc/redoc.html
 var redocHTML string
 
+var redocUITemplate = template.Must(template.New("redoc").Parse(redocHTML))
+
 //go:embed redoc/redoc.standalone.js
 var redocJS []byte
 
 // DocsJSON serves swagger doc json specs
 func DocsJSON(c *echo.Context) error {
-
 	doc, err := swag.ReadDoc()
 	if err != nil {
 		log.Error(err.Error())
@@ -47,7 +52,17 @@ func DocsJSON(c *echo.Context) error {
 
 // RedocUI serves everything needed to provide the redoc ui
 func RedocUI(c *echo.Context) error {
-	return c.HTML(http.StatusOK, redocHTML)
+	publicURL := config.ServicePublicURL.GetString()
+	docsURL := strings.TrimRight(publicURL, "/") + "/api/v1/docs.json"
+
+	var buf bytes.Buffer
+	data := map[string]string{"Url": docsURL}
+
+	if err := redocUITemplate.Execute(&buf, data); err != nil {
+		return err
+	}
+
+	return c.HTML(http.StatusOK, buf.String())
 }
 
 // RedocJS serves the embedded redoc standalone JavaScript bundle

--- a/pkg/routes/api/v1/docs.go
+++ b/pkg/routes/api/v1/docs.go
@@ -53,10 +53,10 @@ func DocsJSON(c *echo.Context) error {
 // RedocUI serves everything needed to provide the redoc ui
 func RedocUI(c *echo.Context) error {
 	publicURL := config.ServicePublicURL.GetString()
-	docsURL := strings.TrimRight(publicURL, "/") + "/api/v1/docs.json"
+	docsBase := strings.TrimRight(publicURL, "/") + "/"
 
 	var buf bytes.Buffer
-	data := map[string]string{"Url": docsURL}
+	data := map[string]string{"Base": docsBase}
 
 	if err := redocUITemplate.Execute(&buf, data); err != nil {
 		return err

--- a/pkg/routes/api/v1/redoc/redoc.html
+++ b/pkg/routes/api/v1/redoc/redoc.html
@@ -8,7 +8,7 @@
     <style>body{margin:0;padding:0;}</style>
 </head>
 <body>
-<redoc spec-url='{{.Url}}'></redoc>
-<script src="/api/v1/docs/redoc.standalone.js"></script>
+<redoc spec-url='{{.Base}}api/v1/docs.json'></redoc>
+<script src="{{.Base}}api/v1/docs/redoc.standalone.js"></script>
 </body>
 </html>

--- a/pkg/routes/api/v1/redoc/redoc.html
+++ b/pkg/routes/api/v1/redoc/redoc.html
@@ -8,7 +8,7 @@
     <style>body{margin:0;padding:0;}</style>
 </head>
 <body>
-<redoc spec-url='/api/v1/docs.json'></redoc>
+<redoc spec-url='{{.Url}}'></redoc>
 <script src="/api/v1/docs/redoc.standalone.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Porting stale changes from #2436, this mainly focus on the backend.

Resolves https://github.com/go-vikunja/vikunja/issues/2657

## What changed

- `auth/auth.go`: Compute refresh token cookie base path from `service.publicurl` rather than hard coding the base as `/api/v1`.
- `api/v1/docs.go`: Build `redocHTML` as template, and replace with `apiBase + api/v1/docs.json` and `apiBase + api/v1/docs/redoc.standalone.js`.