### PR TITLE
fix: fatal with clear message when keyvalue type is redis but redis is not enabled

### DIFF
--- a/pkg/modules/keyvalue/keyvalue.go
+++ b/pkg/modules/keyvalue/keyvalue.go
@@ -18,6 +18,7 @@ package keyvalue
 
 import (
 	"code.vikunja.io/api/pkg/config"
+	"code.vikunja.io/api/pkg/log"
 	"code.vikunja.io/api/pkg/modules/keyvalue/memory"
 	"code.vikunja.io/api/pkg/modules/keyvalue/redis"
 )
@@ -40,6 +41,9 @@ var store Storage
 func InitStorage() {
 	switch config.KeyvalueType.GetString() {
 	case "redis":
+		if !config.RedisEnabled.GetBool() {
+			log.Fatalf("keyvalue.type is set to %q but redis is not enabled. Please set redis.enabled to true in your configuration.", config.KeyvalueType.GetString())
+		}
 		store = redis.NewStorage()
 	case "memory":
 		fallthrough


### PR DESCRIPTION
Instead of panicking with a nil pointer dereference when keyvalue.type
is set to "redis" but redis.enabled is false, log a fatal error with a
clear, actionable message telling the user to enable redis.

Closes go-vikunja/vikunja#2608

https://claude.ai/code/session_01TRuPTGYDQjxqHRFWQaJGvy