### PR TITLE
feat(ci): add multi-architecture support for OS package builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,6 +152,16 @@ jobs:
           - deb
           - apk
           - archlinux
+        arch:
+          - go_name: linux-amd64
+            nfpm: amd64
+            pkg: x86_64
+          - go_name: linux-arm64
+            nfpm: arm64
+            pkg: aarch64
+          - go_name: linux-arm-7
+            nfpm: armhf
+            pkg: armv7
 
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
@@ -159,7 +169,6 @@ jobs:
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: vikunja_bins
-          pattern: vikunja-*-linux-amd64
       - name: Git describe
         id: ghd
         uses: proudust/gh-describe@v2
@@ -170,18 +179,19 @@ jobs:
       - name: Prepare
         env:
           RELEASE_VERSION: ${{ steps.ghd.outputs.describe }}
+          NFPM_ARCH: ${{ matrix.arch.nfpm }}
         run: |
           chmod +x ./mage-static
           ./mage-static release:prepare-nfpm-config
           mkdir -p ./dist/os-packages
-          mv ./vikunja-*-linux-amd64 ./vikunja
+          mv ./vikunja-*-${{ matrix.arch.go_name }} ./vikunja
           chmod +x ./vikunja
       - name: Create package
         id: nfpm
         uses: kolaente/action-gh-nfpm@master
         with:
           packager: ${{ matrix.package }}
-          target: ./dist/os-packages/vikunja-${{ github.ref_type == 'tag' && steps.ghd.outputs.describe || 'unstable' }}-x86_64.${{ matrix.package }}
+          target: ./dist/os-packages/vikunja-${{ github.ref_type == 'tag' && steps.ghd.outputs.describe || 'unstable' }}-${{ matrix.arch.pkg }}.${{ matrix.package }}
           config: ./nfpm.yaml
       - name: Upload
         uses: kolaente/s3-action@41963184b524ccac734ea4d8c964ac74b5b1af89 # v1.2.1
@@ -198,7 +208,7 @@ jobs:
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         if: ${{ github.ref_type == 'tag' }}
         with:
-          name: vikunja_os_package_${{ matrix.package }}
+          name: vikunja_os_package_${{ matrix.package }}_${{ matrix.arch.pkg }}
           path: ./dist/os-packages/*
 
   config-yaml:
@@ -347,25 +357,11 @@ jobs:
         with:
           name: vikunja_bin_packages
 
-      - name: Download OS Package rpm
+      - name: Download OS Packages
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
-          name: vikunja_os_package_rpm
-
-      - name: Download OS Package deb
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
-        with:
-          name: vikunja_os_package_deb
-
-      - name: Download OS Package apk
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
-        with:
-          name: vikunja_os_package_apk
-
-      - name: Download OS Package archlinux
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
-        with:
-          name: vikunja_os_package_archlinux
+          pattern: vikunja_os_package_*
+          merge-multiple: true
 
       - name: Download Desktop Package Linux
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,7 +160,7 @@ jobs:
             nfpm: arm64
             pkg: aarch64
           - go_name: linux-arm-7
-            nfpm: armhf
+            nfpm: arm7
             pkg: armv7
 
     steps:

--- a/magefile.go
+++ b/magefile.go
@@ -1215,10 +1215,14 @@ func (Release) PrepareNFPMConfig() error {
 		return err
 	}
 
-	nfpmArch := os.Getenv("NFPM_ARCH")
-	switch nfpmArch {
-	case "amd64", "arm64", "armhf", "386":
-		// valid arch, use as-is
+	var nfpmArch string
+	switch os.Getenv("NFPM_ARCH") {
+	case "arm64":
+		nfpmArch = "arm64"
+	case "arm7":
+		nfpmArch = "arm7"
+	case "386":
+		nfpmArch = "386"
 	default:
 		nfpmArch = "amd64"
 	}

--- a/magefile.go
+++ b/magefile.go
@@ -1215,8 +1215,14 @@ func (Release) PrepareNFPMConfig() error {
 		return err
 	}
 
+	nfpmArch := os.Getenv("NFPM_ARCH")
+	if nfpmArch == "" {
+		nfpmArch = "amd64"
+	}
+
 	fixedConfig := strings.ReplaceAll(string(nfpmconfig), "<version>", VersionNumber)
 	fixedConfig = strings.ReplaceAll(fixedConfig, "<binlocation>", BinLocation)
+	fixedConfig = strings.ReplaceAll(fixedConfig, "<arch>", nfpmArch)
 	if err := os.WriteFile(nfpmConfigPath, []byte(fixedConfig), 0); err != nil {
 		return err
 	}

--- a/magefile.go
+++ b/magefile.go
@@ -1216,7 +1216,10 @@ func (Release) PrepareNFPMConfig() error {
 	}
 
 	nfpmArch := os.Getenv("NFPM_ARCH")
-	if nfpmArch == "" {
+	switch nfpmArch {
+	case "amd64", "arm64", "armhf", "386":
+		// valid arch, use as-is
+	default:
 		nfpmArch = "amd64"
 	}
 

--- a/nfpm.yaml
+++ b/nfpm.yaml
@@ -1,5 +1,5 @@
 name: "vikunja"
-arch: "amd64"
+arch: "<arch>"
 platform: "linux"
 version: "<version>"
 description: "Vikunja is an open-source todo application, written in Go. It lets you create lists,tasks and share them via teams or directly between users."


### PR DESCRIPTION
## Summary
This PR extends the OS package build pipeline to support multiple CPU architectures (amd64, arm64, and armv7) instead of being limited to x86_64 only.

## Key Changes
- **GitHub Actions Workflow**: Added architecture matrix to the package build job that defines mappings between Go architecture names, nfpm architecture names, and package architecture names
- **Binary Selection**: Updated the artifact download and preparation steps to dynamically select binaries for the target architecture instead of hardcoding linux-amd64
- **Package Naming**: Modified output package filenames to include the architecture identifier (e.g., `vikunja-version-aarch64.deb`)
- **Artifact Management**: Consolidated multiple OS package download steps into a single step using pattern matching and merge-multiple flag
- **Configuration**: Updated nfpm configuration to accept architecture as a template variable, with amd64 as the default fallback
- **Mage Build System**: Modified the `PrepareNFPMConfig` task to read the `NFPM_ARCH` environment variable and substitute it into the nfpm configuration template

## Implementation Details
The architecture matrix defines three build targets:
- `linux-amd64` → nfpm: `amd64` → package: `x86_64`
- `linux-arm64` → nfpm: `arm64` → package: `aarch64`
- `linux-arm-7` → nfpm: `armhf` → package: `armv7`

Each package type (rpm, deb, apk, archlinux) is now built for all three architectures, with the architecture passed through environment variables to the build process.

https://claude.ai/code/session_018MXXUvQZM8M8frZu5iXDzc