### PR TITLE
refactor(projects): use getAllProjectsForUser in getProjectsToDelete

### DIFF
--- a/pkg/models/user_delete.go
+++ b/pkg/models/user_delete.go
@@ -88,17 +88,15 @@ func deleteUsers() {
 
 func getProjectsToDelete(s *xorm.Session, u *user.User) (projectsToDelete []*Project, err error) {
 	projectsToDelete = []*Project{}
-	lm := &Project{IsArchived: true}
-	res, _, _, err := lm.ReadAll(s, u, "", 0, -1)
+	projects, _, err := getAllProjectsForUser(s, u.ID, &projectOptions{
+		page:        0,
+		perPage:     -1,
+		getArchived: true,
+	})
 	if err != nil {
 		return nil, err
 	}
 
-	if res == nil {
-		return nil, nil
-	}
-
-	projects := res.([]*Project)
 	for _, l := range projects {
 		if l.ID < 0 {
 			continue

--- a/pkg/models/user_delete_test.go
+++ b/pkg/models/user_delete_test.go
@@ -73,6 +73,19 @@ func TestDeleteUser(t *testing.T) {
 		db.AssertMissing(t, "users", map[string]interface{}{"id": u.ID})
 		db.AssertMissing(t, "projects", map[string]interface{}{"id": 37}) // only user16 had access to this project, and it was their default
 	})
+	t.Run("disabled user", func(t *testing.T) {
+		db.LoadAndAssertFixtures(t)
+		s := db.NewSession()
+		defer s.Close()
+		notifications.Fake()
+
+		u := &user.User{ID: 17}
+		err := DeleteUser(s, u)
+
+		require.NoError(t, err)
+		require.NoError(t, s.Commit())
+		db.AssertMissing(t, "users", map[string]interface{}{"id": u.ID})
+	})
 	t.Run("cleans up task assignments and subscriptions", func(t *testing.T) {
 		db.LoadAndAssertFixtures(t)
 		s := db.NewSession()


### PR DESCRIPTION
## Summary
Refactored the `getProjectsToDelete` function to use the existing `getAllProjectsForUser` helper method instead of directly calling `ReadAll`, improving code reusability and consistency.

## Key Changes
- Replaced direct `ReadAll` call with `getAllProjectsForUser` helper function in `getProjectsToDelete`
- Simplified project retrieval logic by using `projectOptions` struct with `getArchived: true` flag
- Removed unnecessary nil check on the result since `getAllProjectsForUser` returns a properly typed slice
- Added test case for deleting a disabled user (user ID 17) to ensure the refactored code handles this scenario correctly

## Implementation Details
- The refactoring maintains the same functionality while reducing code duplication
- Uses `projectOptions` with `page: 0`, `perPage: -1`, and `getArchived: true` to match the previous behavior
- The new test verifies that disabled users can be successfully deleted and properly removed from the database

https://claude.ai/code/session_01W4dMPFj321sB3oFdTi6qwc