### PR TITLE
fix(desktop): rebuild tray menu in place instead of recreating the Tray

### DIFF
--- a/desktop/main.js
+++ b/desktop/main.js
@@ -332,12 +332,20 @@ function toggleQuickEntry() {
 
 // ─── System tray ─────────────────────────────────────────────────────
 function setupTray() {
-	if (tray) {
-		tray.destroy()
+	if (!tray) {
+		const iconPath = path.join(__dirname, 'build', 'icon.png')
+		const icon = nativeImage.createFromPath(iconPath).resize({width: 16, height: 16})
+		tray = new Tray(icon)
+		tray.setToolTip('Vikunja')
+		tray.on('click', () => {
+			if (mainWindow) {
+				mainWindow.show()
+				mainWindow.focus()
+			} else {
+				createMainWindow()
+			}
+		})
 	}
-	const iconPath = path.join(__dirname, 'build', 'icon.png')
-	const icon = nativeImage.createFromPath(iconPath).resize({width: 16, height: 16})
-	tray = new Tray(icon)
 
 	const contextMenu = Menu.buildFromTemplate([
 		{
@@ -366,17 +374,7 @@ function setupTray() {
 		},
 	])
 
-	tray.setToolTip('Vikunja')
 	tray.setContextMenu(contextMenu)
-
-	tray.on('click', () => {
-		if (mainWindow) {
-			mainWindow.show()
-			mainWindow.focus()
-		} else {
-			createMainWindow()
-		}
-	})
 }
 
 // ─── IPC handlers ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

On KDE Plasma 6 Wayland, tray-menu item clicks stop firing their JS callbacks shortly after the app starts. This fix keeps the `Tray` object alive across menu updates so the dbusmenu event routing stays intact.

## Symptom

On KDE Plasma 6 + Wayland (reproduced on Plasma 6.6.1, also reported generically against Electron on other SNI-driven desktops):

1. Launch the desktop app. Tray icon appears.
2. Right-click the tray. Context menu opens, items render correctly.
3. Click any menu item. Nothing happens. The handler never fires. Show Vikunja doesn't show, Quick Add Task doesn't open, Quit doesn't quit.
4. `tray.on('click')` also stops firing.

Triggered every time the frontend auth store finishes loading settings.

## Root cause

After the auth store loads settings it calls `window.vikunjaDesktop.updateQuickEntryShortcut(...)` from `frontend/src/stores/auth.ts`. That sends a `desktop:update-quick-entry-shortcut` IPC, and the handler in `desktop/main.js` calls `setupTray()` so the menu's accelerator label matches the new shortcut.

The old `setupTray()` starts with `tray.destroy()` and then creates a fresh `Tray(icon)`. On Linux with KDE Plasma 6 Wayland:

- `tray.destroy()` does not actually remove the icon from plasmashell (see [electron/electron#49517](https://github.com/electron/electron/issues/49517), open).
- The new `Tray` registers a fresh dbusmenu connection, but plasmashell keeps talking to the old (now orphaned) one.
- The menu items still render (plasmashell already has the DBusMenu layout cached), but every `com.canonical.dbusmenu.Event("clicked", ...)` method call from plasmashell hits the destroyed handler and is dropped.

Confirmed via `dbus-monitor`: plasmashell correctly sends `Event(int32 <id>, "clicked", ...)` to the app's dbus connection on every menu click, but Electron never invokes the JS callback. A minimal Electron reproduction where `tray.setContextMenu(newMenu)` is called without destroying the Tray works correctly in the same environment.

## Fix

Don't recreate the `Tray`. Create it once, and only swap the context menu in place when the accelerator changes:

- Move the one-time initialization (`new Tray(icon)`, `setToolTip`, `on('click')`) behind a `!tray` guard.
- Always rebuild and set the context menu, since that is the part that actually changes.

The `desktop:update-quick-entry-shortcut` IPC handler keeps calling `setupTray()`, and the right thing happens without touching the native `Tray` object.

## Test plan

- [x] Fedora 43, KDE Plasma 6.6.1, Wayland, Electron 40.9.1. Verified across multiple login cycles that Show Vikunja, Quick Add Task, and Quit all fire from the tray menu.
- [x] Also verified with Electron 39.8.8 that the bug and the fix behave the same, ruling out a recent Electron regression.
- [x] `dbus-monitor` trace confirms `Event \"clicked\"` method calls from plasmashell now reach the JS callbacks after the frontend triggers a menu rebuild.
- [x] Minimal reproduction: with `tray.destroy(); new Tray(...)` the click events drop; with `tray.setContextMenu(newMenu)` the click events fire.

## Related

- [electron/electron#49517](https://github.com/electron/electron/issues/49517): Tray icon can't be destroyed on Linux. Upstream, open.
- [electron/electron#28837](https://github.com/electron/electron/issues/28837): Menu instance events not firing when used as tray context menu on Linux. Upstream, closed as stale, same class of bug.