### PR TITLE
Fix user count metrics not updated on API user create/delete

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -66,7 +66,7 @@ func InitMetrics() {
 	GetRegistry()
 
 	registerPromMetric(ProjectCountKey, "The number of projects on this instance")
-	registerPromMetric(UserCountKey, "The total number of shares on this instance")
+	registerPromMetric(UserCountKey, "The total number of users on this instance")
 	registerPromMetric(TaskCountKey, "The total number of tasks on this instance")
 	registerPromMetric(TeamCountKey, "The total number of teams on this instance")
 	registerPromMetric(FilesCountKey, "The total number of files on this instance")

--- a/pkg/models/user_delete.go
+++ b/pkg/models/user_delete.go
@@ -21,6 +21,7 @@ import (
 
 	"code.vikunja.io/api/pkg/cron"
 	"code.vikunja.io/api/pkg/db"
+	"code.vikunja.io/api/pkg/events"
 	"code.vikunja.io/api/pkg/log"
 	"code.vikunja.io/api/pkg/notifications"
 	"code.vikunja.io/api/pkg/user"
@@ -81,7 +82,10 @@ func deleteUsers() {
 			err = us.Commit()
 			if err != nil {
 				log.Errorf("Could not commit transaction: %s", err)
+				return
 			}
+
+			events.DispatchPending(us)
 		}()
 	}
 }
@@ -177,6 +181,11 @@ func DeleteUser(s *xorm.Session, u *user.User) (err error) {
 	}
 
 	_, err = s.Where("id = ?", u.ID).Delete(&user.User{})
+	if err != nil {
+		return err
+	}
+
+	events.DispatchOnCommit(s, &user.DeletedEvent{User: u})
 	return err
 }
 

--- a/pkg/models/user_delete_test.go
+++ b/pkg/models/user_delete_test.go
@@ -17,9 +17,14 @@
 package models
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"code.vikunja.io/api/pkg/db"
+	"code.vikunja.io/api/pkg/events"
+	"code.vikunja.io/api/pkg/metrics"
+	"code.vikunja.io/api/pkg/modules/keyvalue"
 	"code.vikunja.io/api/pkg/notifications"
 	"code.vikunja.io/api/pkg/user"
 
@@ -120,5 +125,42 @@ func TestDeleteUser(t *testing.T) {
 		db.AssertMissing(t, "task_assignees", map[string]interface{}{"user_id": 4})
 		db.AssertMissing(t, "subscriptions", map[string]interface{}{"user_id": 4})
 		db.AssertMissing(t, "team_members", map[string]interface{}{"user_id": 4})
+	})
+	t.Run("decrements user count after committed delete is dispatched", func(t *testing.T) {
+		db.LoadAndAssertFixtures(t)
+		s := db.NewSession()
+		defer s.Close()
+		notifications.Fake()
+		events.Unfake()
+		t.Cleanup(events.Fake)
+		user.RegisterListeners()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		ready, err := events.InitEventsForTesting(ctx)
+		require.NoError(t, err)
+		<-ready
+
+		require.NoError(t, keyvalue.Put(metrics.UserCountKey, int64(2)))
+		t.Cleanup(func() {
+			_ = keyvalue.Del(metrics.UserCountKey)
+		})
+
+		err = DeleteUser(s, &user.User{ID: 4})
+		require.NoError(t, err)
+
+		require.NoError(t, s.Commit())
+		events.DispatchPending(s)
+
+		require.Eventually(t, func() bool {
+			value, exists, err := keyvalue.Get(metrics.UserCountKey)
+			if err != nil || !exists {
+				return false
+			}
+
+			count, ok := value.(int64)
+			return ok && count == 1
+		}, time.Second, 10*time.Millisecond)
 	})
 }

--- a/pkg/modules/auth/openid/openid.go
+++ b/pkg/modules/auth/openid/openid.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 
 	"code.vikunja.io/api/pkg/db"
+	"code.vikunja.io/api/pkg/events"
 	"code.vikunja.io/api/pkg/log"
 	"code.vikunja.io/api/pkg/models"
 	"code.vikunja.io/api/pkg/modules/auth"
@@ -212,6 +213,8 @@ func HandleCallback(c *echo.Context) error {
 	if err := enforceTOTPIfRequired(s, u, cb.TOTPPasscode); err != nil {
 		if commitErr := s.Commit(); commitErr != nil {
 			log.Errorf("Error committing session after failed OIDC TOTP attempt for user %d: %v", u.ID, commitErr)
+		} else {
+			events.DispatchPending(s)
 		}
 		if user.IsErrInvalidTOTPPasscode(err) {
 			user.HandleFailedTOTPAuth(u)
@@ -232,6 +235,8 @@ func HandleCallback(c *echo.Context) error {
 		log.Errorf("Error creating new team for provider %s: %v", provider.Name, err)
 		return err
 	}
+
+	events.DispatchPending(s)
 
 	// Create token
 	return auth.NewUserAuthTokenResponse(u, c, false)

--- a/pkg/routes/api/v1/login.go
+++ b/pkg/routes/api/v1/login.go
@@ -21,6 +21,7 @@ import (
 
 	"code.vikunja.io/api/pkg/config"
 	"code.vikunja.io/api/pkg/db"
+	"code.vikunja.io/api/pkg/events"
 	"code.vikunja.io/api/pkg/models"
 	"code.vikunja.io/api/pkg/modules/auth"
 	"code.vikunja.io/api/pkg/modules/auth/ldap"
@@ -115,6 +116,8 @@ func Login(c *echo.Context) (err error) {
 		_ = s.Rollback()
 		return err
 	}
+
+	events.DispatchPending(s)
 
 	// Create token
 	return auth.NewUserAuthTokenResponse(user, c, u.LongToken)

--- a/pkg/routes/api/v1/user_register.go
+++ b/pkg/routes/api/v1/user_register.go
@@ -22,6 +22,7 @@ import (
 
 	"code.vikunja.io/api/pkg/config"
 	"code.vikunja.io/api/pkg/db"
+	"code.vikunja.io/api/pkg/events"
 	"code.vikunja.io/api/pkg/models"
 	"code.vikunja.io/api/pkg/user"
 
@@ -92,6 +93,8 @@ func RegisterUser(c *echo.Context) error {
 		_ = s.Rollback()
 		return err
 	}
+
+	events.DispatchPending(s)
 
 	return c.JSON(http.StatusOK, newUser)
 }

--- a/pkg/user/events.go
+++ b/pkg/user/events.go
@@ -25,3 +25,13 @@ type CreatedEvent struct {
 func (t *CreatedEvent) Name() string {
 	return "user.created"
 }
+
+// DeletedEvent represents a DeletedEvent event
+type DeletedEvent struct {
+	User *User
+}
+
+// Name defines the name for DeletedEvent
+func (t *DeletedEvent) Name() string {
+	return "user.deleted"
+}

--- a/pkg/user/listeners.go
+++ b/pkg/user/listeners.go
@@ -25,6 +25,7 @@ import (
 
 func RegisterListeners() {
 	events.RegisterListener((&CreatedEvent{}).Name(), &IncreaseUserCounter{})
+	events.RegisterListener((&DeletedEvent{}).Name(), &DecreaseUserCounter{})
 }
 
 ///////
@@ -42,4 +43,18 @@ func (s *IncreaseUserCounter) Name() string {
 // Handle is executed when the event IncreaseUserCounter listens on is fired
 func (s *IncreaseUserCounter) Handle(_ *message.Message) (err error) {
 	return keyvalue.IncrBy(metrics.UserCountKey, 1)
+}
+
+// DecreaseUserCounter represents a listener
+type DecreaseUserCounter struct {
+}
+
+// Name defines the name for the DecreaseUserCounter listener
+func (s *DecreaseUserCounter) Name() string {
+	return "decrease.user.counter"
+}
+
+// Handle is executed when the event DecreaseUserCounter listens on is fired
+func (s *DecreaseUserCounter) Handle(_ *message.Message) (err error) {
+	return keyvalue.DecrBy(metrics.UserCountKey, 1)
 }

--- a/pkg/user/user_test.go
+++ b/pkg/user/user_test.go
@@ -17,9 +17,14 @@
 package user
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"code.vikunja.io/api/pkg/db"
+	"code.vikunja.io/api/pkg/events"
+	"code.vikunja.io/api/pkg/metrics"
+	"code.vikunja.io/api/pkg/modules/keyvalue"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -37,10 +42,39 @@ func TestCreateUser(t *testing.T) {
 		db.LoadAndAssertFixtures(t)
 		s := db.NewSession()
 		defer s.Close()
+		events.Unfake()
+		t.Cleanup(events.Fake)
+		RegisterListeners()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		ready, err := events.InitEventsForTesting(ctx)
+		require.NoError(t, err)
+		<-ready
+
+		require.NoError(t, keyvalue.Put(metrics.UserCountKey, int64(1)))
+		t.Cleanup(func() {
+			_ = keyvalue.Del(metrics.UserCountKey)
+		})
 
 		createdUser, err := CreateUser(s, dummyuser)
 		require.NoError(t, err)
 		assert.NotZero(t, createdUser.Created)
+
+		err = s.Commit()
+		require.NoError(t, err)
+		events.DispatchPending(s)
+
+		require.Eventually(t, func() bool {
+			value, exists, err := keyvalue.Get(metrics.UserCountKey)
+			if err != nil || !exists {
+				return false
+			}
+
+			count, ok := value.(int64)
+			return ok && count == 2
+		}, time.Second, 10*time.Millisecond)
 	})
 	t.Run("already existing", func(t *testing.T) {
 		db.LoadAndAssertFixtures(t)

--- a/pkg/webtests/register_test.go
+++ b/pkg/webtests/register_test.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"testing"
 
+	"code.vikunja.io/api/pkg/events"
 	apiv1 "code.vikunja.io/api/pkg/routes/api/v1"
 	"code.vikunja.io/api/pkg/user"
 
@@ -29,6 +30,7 @@ import (
 
 func TestRegister(t *testing.T) {
 	t.Run("normal register", func(t *testing.T) {
+		events.ClearDispatchedEvents()
 		rec, err := newTestRequest(t, http.MethodPost, apiv1.RegisterUser, `{
   "username": "newUser",
   "password": "12345678",
@@ -36,6 +38,7 @@ func TestRegister(t *testing.T) {
 }`, nil, nil)
 		require.NoError(t, err)
 		assert.Contains(t, rec.Body.String(), `"username":"newUser"`)
+		assert.Equal(t, 1, events.CountDispatchedEvents("user.created"))
 	})
 	t.Run("Empty payload", func(t *testing.T) {
 		_, err := newTestRequest(t, http.MethodPost, apiv1.RegisterUser, `{}`, nil, nil)


### PR DESCRIPTION
- **Fix metric help text for number of users**
- **Dispatch queued user create event after commit**
- **Dispatch user delete event and decrement user metrics**

Fixes #2650