### PR TITLE
fix(webhook): use same casing for basic auth fields

### DIFF
--- a/frontend/src/components/misc/WebhookManager.vue
+++ b/frontend/src/components/misc/WebhookManager.vue
@@ -145,7 +145,7 @@ function doDelete() {
 					<template #default="{id}">
 						<FormInput
 							:id="id"
-							v-model="newWebhook.basicauthuser"
+							v-model="newWebhook.basicAuthUser"
 						/>
 					</template>
 				</FormField>
@@ -153,7 +153,7 @@ function doDelete() {
 					<template #default="{id}">
 						<FormInput
 							:id="id"
-							v-model="newWebhook.basicauthpassword"
+							v-model="newWebhook.basicAuthPassword"
 						/>
 					</template>
 				</FormField>

--- a/frontend/src/modelTypes/IWebhook.ts
+++ b/frontend/src/modelTypes/IWebhook.ts
@@ -6,8 +6,8 @@ export interface IWebhook extends IAbstract {
 	projectId: number
 	userId: number
 	secret: string
-	basicauthuser: string
-	basicauthpassword: string
+	basicAuthUser: string
+	basicAuthPassword: string
 	targetUrl: string
 	events: string[]
 	createdBy: IUser

--- a/frontend/src/models/webhook.ts
+++ b/frontend/src/models/webhook.ts
@@ -7,8 +7,8 @@ export default class WebhookModel extends AbstractModel<IWebhook> implements IWe
 	projectId = 0
 	userId = 0
 	secret = ''
-	basicauthuser = ''
-	basicauthpassword = ''
+	basicAuthUser = ''
+	basicAuthPassword = ''
 	targetUrl = ''
 	events = []
 	createdBy = null


### PR DESCRIPTION
Fixes #2687

Webhook basic authentication fields are not persisted because of a mismatch between frontend and backend model names.