### PR TITLE
feat: add configurable task identifier display format (service.taskidentifierdisplay)

### DIFF
--- a/config-raw.json
+++ b/config-raw.json
@@ -139,6 +139,11 @@
                     "comment": "Allow using a custom logo for dark mode via external URL. If not set, the regular logo will be used for both light and dark modes."
                 },
                 {
+                    "key": "taskidentifierdisplay",
+                    "default_value": "{identifier}",
+                    "comment": "Format string controlling how task identifiers render in the UI.\nSupported placeholders:\n  {identifier} - the per-project value (e.g. 'TAL-5' if the project has an identifier prefix, otherwise '#5'). This is the recommended placeholder for the empty-prefix case.\n  {id}         - the global database id (stable, never changes; used by the API).\n  {index}      - the per-project numeric index.\n  {prefix}     - the project identifier prefix (e.g. 'TAL'); empty string if not set.\nExamples:\n  '{identifier}'             - default; shows 'TAL-5' or '#5'.\n  '#{id}'                    - shows the global database id (e.g. '#42').\n  '{identifier} (ID #{id})'  - shows both; renders as 'TAL-5 (ID #42)' or '#5 (ID #42)'. The 'ID' label disambiguates the database id from the project index when no prefix is set.\nNote: '{prefix}-{index}' renders as '-5' for projects without an identifier prefix; prefer {identifier} unless you control all projects."
+                },
+                {
                     "key": "enablepublicteams",
                     "default_value": "false",
                     "comment": "Enables the public team feature. If enabled, it is possible to configure teams to be public, which makes them\ndiscoverable when sharing a project, therefore not only showing teams the user is member of."

--- a/frontend/src/components/project/views/ProjectTable.vue
+++ b/frontend/src/components/project/views/ProjectTable.vue
@@ -198,12 +198,7 @@
 								>
 									<td v-if="activeColumns.index">
 										<RouterLink :to="taskDetailRoutes[t.id]">
-											<template v-if="t.identifier === ''">
-												#{{ t.index }}
-											</template>
-											<template v-else>
-												{{ t.identifier }}
-											</template>
+											{{ getTaskIdentifier(t) }}
 										</RouterLink>
 									</td>
 									<td v-if="activeColumns.done">
@@ -321,6 +316,7 @@ import type {SortBy} from '@/composables/useTaskList'
 import {useTaskList} from '@/composables/useTaskList'
 import type {ITask} from '@/modelTypes/ITask'
 import type {IProject} from '@/modelTypes/IProject'
+import {getTaskIdentifier} from '@/models/task'
 import AssigneeList from '@/components/tasks/partials/AssigneeList.vue'
 import type {IProjectView} from '@/modelTypes/IProjectView'
 import { camelCase } from 'change-case'

--- a/frontend/src/components/tasks/partials/KanbanCard.vue
+++ b/frontend/src/components/tasks/partials/KanbanCard.vue
@@ -29,12 +29,7 @@
 						:is-done="task.done"
 						variant="small"
 					/>
-					<template v-if="task.identifier === ''">
-						#{{ task.index }}
-					</template>
-					<template v-else>
-						{{ task.identifier }}
-					</template>
+					{{ getTaskIdentifier(task) }}
 					<span
 						v-if="showTaskPosition"
 						class="tw:text-red-600 tw:ps-2"
@@ -126,7 +121,7 @@ import Labels from '@/components/tasks/partials/Labels.vue'
 import ChecklistSummary from './ChecklistSummary.vue'
 import CommentCount from './CommentCount.vue'
 
-import {getHexColor} from '@/models/task'
+import {getHexColor, getTaskIdentifier} from '@/models/task'
 import type {ITask} from '@/modelTypes/ITask'
 import type {IProject} from '@/modelTypes/IProject'
 import {SUPPORTED_IMAGE_SUFFIX} from '@/models/attachment'

--- a/frontend/src/models/task.test.ts
+++ b/frontend/src/models/task.test.ts
@@ -1,0 +1,97 @@
+import {describe, it, expect} from 'vitest'
+import {getTaskIdentifier} from './task'
+import type {ITask} from '@/modelTypes/ITask'
+
+function makeTask(overrides: Partial<ITask> = {}): ITask {
+	// Test focuses on getTaskIdentifier which only reads id, index, identifier.
+	// Cast to ITask to avoid enumerating all unrelated required fields.
+	return {
+		id: 42,
+		index: 5,
+		identifier: 'TAL-5',
+		title: 'Some task',
+		...overrides,
+	} as ITask
+}
+
+describe('getTaskIdentifier', () => {
+	it('returns empty string for null task', () => {
+		expect(getTaskIdentifier(null, '{identifier}')).toBe('')
+	})
+
+	it('returns empty string for undefined task', () => {
+		expect(getTaskIdentifier(undefined, '{identifier}')).toBe('')
+	})
+
+	describe('with default {identifier} format', () => {
+		it('returns prefix-index when project has an identifier', () => {
+			const task = makeTask({identifier: 'TAL-5', index: 5})
+			expect(getTaskIdentifier(task, '{identifier}')).toBe('TAL-5')
+		})
+
+		it('returns #index when project has no identifier prefix', () => {
+			const task = makeTask({identifier: '', index: 5})
+			expect(getTaskIdentifier(task, '{identifier}')).toBe('#5')
+		})
+	})
+
+	describe('with #{id} format', () => {
+		it('returns the global database id', () => {
+			const task = makeTask({id: 42})
+			expect(getTaskIdentifier(task, '#{id}')).toBe('#42')
+		})
+
+		it('returns the same value regardless of prefix presence', () => {
+			const withPrefix = makeTask({id: 42, identifier: 'TAL-5'})
+			const withoutPrefix = makeTask({id: 42, identifier: '', index: 5})
+			expect(getTaskIdentifier(withPrefix, '#{id}')).toBe('#42')
+			expect(getTaskIdentifier(withoutPrefix, '#{id}')).toBe('#42')
+		})
+	})
+
+	describe('with combined {identifier} (#{id}) format', () => {
+		it('renders both with prefix', () => {
+			const task = makeTask({id: 42, identifier: 'TAL-5', index: 5})
+			expect(getTaskIdentifier(task, '{identifier} (#{id})')).toBe('TAL-5 (#42)')
+		})
+
+		it('renders both without prefix', () => {
+			const task = makeTask({id: 42, identifier: '', index: 5})
+			expect(getTaskIdentifier(task, '{identifier} (#{id})')).toBe('#5 (#42)')
+		})
+	})
+
+	describe('with raw {prefix}-{index} format (footgun)', () => {
+		it('renders prefix-index when prefix is set', () => {
+			const task = makeTask({identifier: 'TAL-5', index: 5})
+			expect(getTaskIdentifier(task, '{prefix}-{index}')).toBe('TAL-5')
+		})
+
+		it('renders -N (broken) when no prefix is set -- documented user-responsibility caveat', () => {
+			const task = makeTask({identifier: '', index: 5})
+			expect(getTaskIdentifier(task, '{prefix}-{index}')).toBe('-5')
+		})
+	})
+
+	describe('placeholder edge cases', () => {
+		it('returns the literal string when format has no placeholders', () => {
+			const task = makeTask()
+			expect(getTaskIdentifier(task, 'task')).toBe('task')
+		})
+
+		it('leaves unknown placeholders intact', () => {
+			const task = makeTask()
+			expect(getTaskIdentifier(task, '{xyz}-{id}')).toBe('{xyz}-42')
+		})
+
+		it('substitutes all placeholders independently', () => {
+			const task = makeTask({id: 42, identifier: 'TAL-5', index: 5})
+			expect(getTaskIdentifier(task, '{prefix}/{index}/#{id}')).toBe('TAL/5/#42')
+		})
+
+		it('handles repeated placeholders', () => {
+			const task = makeTask({id: 42})
+			expect(getTaskIdentifier(task, '{id}-{id}')).toBe('42-42')
+		})
+	})
+})

--- a/frontend/src/models/task.ts
+++ b/frontend/src/models/task.ts
@@ -14,6 +14,7 @@ import {TASK_REPEAT_MODES, type IRepeatMode} from '@/types/IRepeatMode'
 
 import {parseDateOrNull} from '@/helpers/parseDateOrNull'
 import {secondsToPeriod} from '@/helpers/time/period'
+import {useConfigStore} from '@/stores/config'
 
 import AbstractModel from './abstractModel'
 import LabelModel from './label'
@@ -45,16 +46,48 @@ export function parseRepeatAfter(repeatAfterSeconds: number): IRepeatAfter {
 	}
 }
 
-export function getTaskIdentifier(task: ITask | null | undefined): string {
+/**
+ * Format a task identifier for display.
+ *
+ * The format string supports four placeholders:
+ *   {identifier} - per-project value (e.g. 'TAL-5' if the project has an
+ *                  identifier prefix, otherwise '#5'). Recommended.
+ *   {id}         - global database id (stable, never changes).
+ *   {index}      - per-project numeric index.
+ *   {prefix}     - project identifier prefix (e.g. 'TAL'); empty if not set.
+ *
+ * Example: '{identifier} (ID #{id})' renders as 'TAL-5 (ID #42)' or '#5 (ID #42)'.
+ * The 'ID' label disambiguates the database id from the project index when no prefix is set.
+ *
+ * If `format` is omitted, the configured `service.taskidentifierdisplay`
+ * value is used (default '{identifier}').
+ */
+export function getTaskIdentifier(task: ITask | null | undefined, format?: string): string {
 	if (task === null || typeof task === 'undefined') {
 		return ''
 	}
-	
-	if (task.identifier === '') {
-		return `#${task.index}`
+
+	let fmt = format
+	if (typeof fmt === 'undefined') {
+		try {
+			fmt = useConfigStore().taskIdentifierDisplay
+		} catch {
+			// store may not be initialised in some test contexts
+			fmt = undefined
+		}
+	}
+	if (!fmt) {
+		fmt = '{identifier}'
 	}
 
-	return task.identifier
+	const identifierValue = task.identifier === '' ? `#${task.index}` : task.identifier
+	const prefixValue = task.identifier ? task.identifier.replace(/-\d+$/, '') : ''
+
+	return fmt
+		.replace(/\{identifier\}/g, identifierValue)
+		.replace(/\{id\}/g, String(task.id))
+		.replace(/\{index\}/g, String(task.index))
+		.replace(/\{prefix\}/g, prefixValue)
 }
 
 export default class TaskModel extends AbstractModel<ITask> implements ITask {

--- a/frontend/src/stores/config.ts
+++ b/frontend/src/stores/config.ts
@@ -45,6 +45,7 @@ export interface ConfigState {
 	},
 	publicTeamsEnabled: boolean,
 	enabledProFeatures: string[],
+	taskIdentifierDisplay: string,
 }
 
 export const useConfigStore = defineStore('config', () => {
@@ -85,6 +86,7 @@ export const useConfigStore = defineStore('config', () => {
 		},
 		publicTeamsEnabled: false,
 		enabledProFeatures: [],
+		taskIdentifierDisplay: '{identifier}',
 	})
 
 	const migratorsEnabled = computed(() => state.availableMigrators?.length > 0)
@@ -115,6 +117,13 @@ export const useConfigStore = defineStore('config', () => {
 		}
 
 		setConfig(objectToCamelCase(config) as ConfigState)
+
+		if (state.taskIdentifierDisplay?.includes('{prefix}-{index}')) {
+			console.warn(
+				'Configured service.taskidentifierdisplay contains \'{prefix}-{index}\'. The {prefix} placeholder is empty for projects without an identifier prefix, which renders as \'-N\'. Use {identifier} instead -- it handles the empty-prefix case (renders \'#N\').',
+			)
+		}
+
 		return !!config
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -68,6 +68,7 @@ const (
 	ServiceAllowIconChanges               Key = `service.allowiconchanges`
 	ServiceCustomLogoURL                  Key = `service.customlogourl`
 	ServiceCustomLogoURLDark              Key = `service.customlogourldark`
+	ServiceTaskIdentifierDisplay          Key = `service.taskidentifierdisplay`
 	ServiceEnablePublicTeams              Key = `service.enablepublicteams`
 	ServiceBcryptRounds                   Key = `service.bcryptrounds`
 	ServiceEnableOpenIDTeamUserOnlySearch Key = `service.enableopenidteamusersearch`
@@ -363,6 +364,7 @@ func InitDefaultConfig() {
 	ServiceMaxAvatarSize.setDefault(1024)
 	ServiceDemoMode.setDefault(false)
 	ServiceAllowIconChanges.setDefault(true)
+	ServiceTaskIdentifierDisplay.setDefault("{identifier}")
 	ServiceEnablePublicTeams.setDefault(false)
 	ServiceBcryptRounds.setDefault(11)
 	ServiceEnableOpenIDTeamUserOnlySearch.setDefault(false)
@@ -669,6 +671,13 @@ func InitConfig() {
 
 	if loader := PluginsLoader.GetString(); loader != "yaegi" && loader != "native" {
 		log.Fatalf("Invalid value for plugins.loader: %q (must be \"yaegi\" or \"native\")", loader)
+	}
+
+	if tidFormat := ServiceTaskIdentifierDisplay.GetString(); strings.Contains(tidFormat, "{prefix}-{index}") {
+		log.Warningf(
+			"Configured %s contains '{prefix}-{index}'. The {prefix} placeholder is empty for projects without an identifier prefix, which renders as '-N'. Use {identifier} instead -- it handles the empty-prefix case (renders '#N').",
+			ServiceTaskIdentifierDisplay,
+		)
 	}
 
 	if CorsEnable.GetBool() && ServicePublicURL.GetString() == "" {

--- a/pkg/routes/api/v1/info.go
+++ b/pkg/routes/api/v1/info.go
@@ -56,6 +56,7 @@ type vikunjaInfos struct {
 	WebhooksEnabled            bool              `json:"webhooks_enabled"`
 	PublicTeamsEnabled         bool              `json:"public_teams_enabled"`
 	EnabledProFeatures         []license.Feature `json:"enabled_pro_features"`
+	TaskIdentifierDisplay      string            `json:"task_identifier_display"`
 }
 
 type authInfo struct {
@@ -108,6 +109,7 @@ func Info(c *echo.Context) error {
 		WebhooksEnabled:        config.WebhooksEnabled.GetBool(),
 		PublicTeamsEnabled:     config.ServiceEnablePublicTeams.GetBool(),
 		EnabledProFeatures:     license.EnabledProFeatures(),
+		TaskIdentifierDisplay:  config.ServiceTaskIdentifierDisplay.GetString(),
 		AvailableMigrators: []string{
 			(&vikunja_file.FileMigrator{}).Name(),
 			(&ticktick.Migrator{}).Name(),


### PR DESCRIPTION
## Motivation

Closes #2698.

The task identifier shown in the UI (`TAL-5`, `#5`) is the per-project index form. This is useful for human navigation but problematic for integrations and API consumers, because the project index is not stable over time: tasks pick up a new index when moved between projects, and indexes are reassigned as tasks are deleted, so a reference like `TAL-5` can silently point to a different task than it did previously. The only stable identifier is the global database `id`, which appears in every API response and URL but is not currently shown anywhere in the UI.

This PR introduces a server-side configuration key that lets admins choose how task identifiers render throughout the frontend, including exposing the stable global `id` alongside the existing per-project display.

Screenshots (task, Table view, Kanban view) when running with `VIKUNJA_SERVICE_TASKIDENTIFIERDISPLAY={identifier} (ID #{id})` :

<img width="316" height="98" alt="Screenshot 2026-04-28 at 08 44 52" src="https://github.com/user-attachments/assets/b941f5c2-9157-43d5-94ae-9efa0674ed56" />
<img width="639" height="278" alt="Screenshot 2026-04-28 at 08 44 13" src="https://github.com/user-attachments/assets/98776a93-504d-45d7-aad8-76af181ea141" />
<img width="953" height="373" alt="Screenshot 2026-04-28 at 08 44 32" src="https://github.com/user-attachments/assets/d16be782-2d9e-41a2-bf56-5fc471af69e8" />


## Implementation

### Backend

A new config key `service.taskidentifierdisplay` is added (env: `VIKUNJA_SERVICE_TASKIDENTIFIERDISPLAY`, default: `{identifier}`). The value is a format string exposed verbatim via `/api/v1/info` as `task_identifier_display` so the frontend can read it. No backend interpretation of the format string occurs beyond passing it through.

A startup warning (at `WARN` level) is emitted when the configured string contains `{prefix}-{index}`, which renders as `-5` for projects with no identifier prefix set (see footgun note below).

### Frontend

`getTaskIdentifier(task, format?)` in `models/task.ts` now supports format strings. When `format` is omitted the function reads from `useConfigStore().taskIdentifierDisplay`, falling back to `{identifier}`. The substitution is plain `String.prototype.replace()` against fixed placeholder patterns — no parser, no expression evaluation, no XSS surface.

Supported placeholders:

| Placeholder | Value |
|---|---|
| `{identifier}` | Per-project value: `TAL-5` if the project has an identifier prefix, otherwise `#5`. Handles the empty-prefix case automatically. **Recommended.** |
| `{id}` | Global database id (stable, never reassigned). |
| `{index}` | Per-project numeric index (same number as in `{identifier}`, without the prefix). |
| `{prefix}` | Project identifier prefix (e.g. `TAL`); empty string if not set. |

`KanbanCard.vue` and `ProjectTable.vue` are updated to call `getTaskIdentifier(task)` in place of their inline `v-if identifier === ''` templates, consolidating the display logic in one place.

`stores/config.ts` adds `taskIdentifierDisplay` to `ConfigState`, populated automatically by the existing `objectToCamelCase` step on the `/info` response. A `console.warn` is emitted on first load when the footgun pattern is detected.

### Footgun: `{prefix}-{index}`

A format string using `{prefix}-{index}` directly renders as `-5` (a leading dash) for projects that have no identifier prefix set. This is not blocked — an admin who only uses projects with prefixes will get correct output — but both the backend (startup log) and frontend (`console.warn`) warn when this pattern is present in the configured string. The recommended alternative is `{identifier}`, which encapsulates the `prefix-index`/`#index` conditional automatically.

### Default behaviour

The default value of `{identifier}` is identical to the current hardcoded behaviour. Existing deployments that do not set this key see no change.

## Examples

| Format string | Project with prefix | Project without prefix |
|---|---|---|
| `{identifier}` *(default)* | `TAL-5` | `#5` |
| `#{id}` | `#42` | `#42` |
| `{identifier} (ID #{id})` | `TAL-5 (ID #42)` | `#5 (ID #42)` |
| `{prefix}-{index}` *(footgun)* | `TAL-5` | `-5` |

## Tests

14 Vitest unit tests added in `frontend/src/models/task.test.ts` covering: null/undefined task, `{identifier}` with and without prefix, `{id}`, combined formats, the footgun case (documented `-5` output), literal strings without placeholders, unknown placeholders left intact, and repeated placeholder substitution.

Existing E2E test assertions at `tests/e2e/task/task.spec.ts` (lines 281 and 331) remain valid because the default format `{identifier}` produces identical output to the previous hardcoded logic.