### PR TITLE
Add a small light border around the text editor input field

### DIFF
--- a/frontend/src/components/input/editor/EditorToolbar.vue
+++ b/frontend/src/components/input/editor/EditorToolbar.vue
@@ -395,6 +395,7 @@ function setLink(event: MouseEvent) {
 	border-radius: $radius;
 	display: flex;
 	flex-wrap: wrap;
+	margin-block-end: 2px;
 
 	> * + * {
 		border-inline-start: 1px solid var(--grey-200);

--- a/frontend/src/components/input/editor/EditorToolbar.vue
+++ b/frontend/src/components/input/editor/EditorToolbar.vue
@@ -395,7 +395,7 @@ function setLink(event: MouseEvent) {
 	border-radius: $radius;
 	display: flex;
 	flex-wrap: wrap;
-	margin-block-end: 4px;
+	margin-block-end: 3px;
 
 	> * + * {
 		border-inline-start: 1px solid var(--grey-200);

--- a/frontend/src/components/input/editor/EditorToolbar.vue
+++ b/frontend/src/components/input/editor/EditorToolbar.vue
@@ -395,7 +395,7 @@ function setLink(event: MouseEvent) {
 	border-radius: $radius;
 	display: flex;
 	flex-wrap: wrap;
-	margin-block-end: 2px;
+	margin-block-end: 4px;
 
 	> * + * {
 		border-inline-start: 1px solid var(--grey-200);

--- a/frontend/src/components/input/editor/TipTap.vue
+++ b/frontend/src/components/input/editor/TipTap.vue
@@ -894,6 +894,7 @@ watch(
 	
 	&.tiptap__editor-is-edit-enabled {
 		min-block-size: 10rem;
+		border: 1px solid var(--grey-200);
 
 		.ProseMirror {
 			padding: .5rem;


### PR DESCRIPTION
- Add a small light border around the text editor input field, since it was hard to find where to click and add text (especially on mobile)
- Works with both light and dark themes
- Add some margin between the toolbar & text area
  - **Note:** Adding a border around the full toolbar + text area doesn't make sense, since that will break the highlighting of the text area section (which is currently already in place)

---

See screenshot, **BEFORE** (no border / no indication of the text area):

<img width="948" height="336" alt="no_indicator" src="https://github.com/user-attachments/assets/96b2a86a-36a3-461d-a139-64fb9a919702" />

And **AFTER** (both dark and light):

<img width="947" height="329" alt="with_border_indicator" src="https://github.com/user-attachments/assets/6940ccf1-ae80-46bb-a62e-6d9f3a4ead4b" />

<img width="948" height="314" alt="with_border_indicator_light" src="https://github.com/user-attachments/assets/b3dddd47-d7ff-426d-be8a-286989f95a6c" />

Improving also accessibility. 
