### PR TITLE
Improve focus handling in QuickActions modal

### DIFF
--- a/frontend/src/components/quick-actions/QuickActions.vue
+++ b/frontend/src/components/quick-actions/QuickActions.vue
@@ -190,12 +190,17 @@ watchEffect(() => {
 let focusRafId: number | null = null
 
 watchEffect(() => {
-	if (active.value && isQuickAddMode) {
-		selectedCmd.value = commands.value.newTask
+	if (active.value) {
+		if (isQuickAddMode) {
+			selectedCmd.value = commands.value.newTask
+		}
 
 		// The input may not be focusable yet due to:
-		// 1. Modal transition (v-if + <Transition appear>) delaying DOM readiness
-		// 2. Electron window not yet visible (shown after did-finish-load)
+		// 1. Modal mounts the <dialog> via v-if and then calls showModal() in a
+		//    follow-up flush, so v-focus fires while the dialog is still closed
+		//    and the focus() call is dropped.
+		// 2. In quick-add mode the Electron window isn't visible until
+		//    did-finish-load.
 		// Retry with rAF until focus actually lands on the input.
 		const tryFocus = () => {
 			if (!active.value) {


### PR DESCRIPTION
## Summary
Refactored the focus retry logic in QuickActions to better handle timing issues when the modal becomes active, with improved comments explaining the root causes of focus failures.

## Key Changes
- Restructured the `watchEffect` to separate the quick-add mode check from the focus retry logic, allowing focus attempts to proceed regardless of quick-add mode status
- Updated comments to clarify the two specific scenarios where focus can fail:
  1. Modal dialog timing: The `v-focus` directive fires while the dialog is still closed (before `showModal()` is called in the next flush cycle), causing the focus call to be dropped
  2. Electron window visibility: In quick-add mode, the Electron window isn't visible until the `did-finish-load` event fires
- The retry mechanism with `requestAnimationFrame` now applies to both scenarios, improving reliability of input focus

## Implementation Details
The change maintains the same retry behavior but with clearer separation of concerns. The focus retry loop will now continue attempting to focus the input until it succeeds, which is particularly important for the Electron quick-add scenario where the window may not be immediately visible.

https://claude.ai/code/session_0152TW9UXwFRp1MsK6c6aHeC