### PR TITLE
Improve modal responsive sizing with inline-size constraints

### DIFF
--- a/frontend/src/components/misc/Modal.vue
+++ b/frontend/src/components/misc/Modal.vue
@@ -235,6 +235,8 @@ $modal-width: 1024px;
 	inset-block-start: 50%;
 	inset-inline-start: 50%;
 	transform: translate(-50%, -50%);
+	inline-size: calc(100% - 2rem);
+	max-inline-size: 640px;
 
 	[dir="rtl"] & {
 		transform: translate(50%, -50%);
@@ -244,6 +246,8 @@ $modal-width: 1024px;
 		margin: 0;
 		position: static;
 		transform: none;
+		inline-size: 100%;
+		max-inline-size: none;
 	}
 
 	.modal-header {

--- a/frontend/src/components/misc/Modal.vue
+++ b/frontend/src/components/misc/Modal.vue
@@ -235,8 +235,6 @@ $modal-width: 1024px;
 	inset-block-start: 50%;
 	inset-inline-start: 50%;
 	transform: translate(-50%, -50%);
-	inline-size: calc(100% - 2rem);
-	max-inline-size: 640px;
 
 	[dir="rtl"] & {
 		transform: translate(50%, -50%);
@@ -246,8 +244,6 @@ $modal-width: 1024px;
 		margin: 0;
 		position: static;
 		transform: none;
-		inline-size: 100%;
-		max-inline-size: none;
 	}
 
 	.modal-header {
@@ -257,6 +253,20 @@ $modal-width: 1024px;
 
 	.button {
 		margin: 0 0.5rem;
+	}
+}
+
+// Default width for centered modals. Scoped with :not(.is-wide) so the
+// `wide` prop can still expand the modal (the .is-wide rule below would
+// otherwise be outranked by .default .modal-content's specificity).
+.default .modal-content:not(.is-wide),
+.hint-modal .modal-content:not(.is-wide) {
+	inline-size: calc(100% - 2rem);
+	max-inline-size: 640px;
+
+	@media screen and (max-width: $tablet) {
+		inline-size: 100%;
+		max-inline-size: none;
 	}
 }
 


### PR DESCRIPTION
## Summary
Updated the Modal component's CSS to improve responsive behavior by adding inline-size (width) constraints that adapt based on viewport size.

## Key Changes
- Added `inline-size: calc(100% - 2rem)` to the modal container for responsive width with padding
- Added `max-inline-size: 640px` to cap the modal's maximum width on larger screens
- Reset inline-size to `100%` and `max-inline-size: none` for mobile/small viewport breakpoints to ensure full-width display

## Implementation Details
- Uses logical CSS properties (`inline-size`, `max-inline-size`) for better internationalization support (RTL/LTR compatibility)
- The `calc(100% - 2rem)` provides 1rem margin on each side for breathing room on smaller screens
- Mobile breakpoint overrides ensure the modal takes full available width on small devices while respecting the 640px max-width constraint on larger screens

https://claude.ai/code/session_01CBATVbygHpjZuHRuV1Ykcx