### PR TITLE
Remove bot users feature flag and make it always enabled

### DIFF
--- a/config-raw.json
+++ b/config-raw.json
@@ -114,11 +114,6 @@
                     "comment": "If true, will allow users to request the complete deletion of their account. When using external authentication methods\nit may be required to coordinate with them in order to delete the account. This setting will not affect the cli commands\nfor user deletion."
                 },
                 {
-                    "key": "enablebotusers",
-                    "default_value": "true",
-                    "comment": "If enabled (default), users can create bot users that interact with Vikunja via the API only. Set to false to disable the feature entirely."
-                },
-                {
                     "key": "maxavatarsize",
                     "default_value": "1024",
                     "comment": "The maximum size clients will be able to request for user avatars.\nIf clients request a size bigger than this, it will be changed on the fly."

--- a/frontend/src/stores/config.ts
+++ b/frontend/src/stores/config.ts
@@ -44,7 +44,6 @@ export interface ConfigState {
 		},
 	},
 	publicTeamsEnabled: boolean,
-	botUsersEnabled: boolean,
 	enabledProFeatures: string[],
 }
 
@@ -85,7 +84,6 @@ export const useConfigStore = defineStore('config', () => {
 			},
 		},
 		publicTeamsEnabled: false,
-		botUsersEnabled: false,
 		enabledProFeatures: [],
 	})
 

--- a/frontend/src/views/user/Settings.vue
+++ b/frontend/src/views/user/Settings.vue
@@ -26,7 +26,6 @@ const migratorsEnabled = computed(() => configStore.migratorsEnabled)
 const isLocalUser = computed(() => authStore.info?.isLocalUser)
 const userDeletionEnabled = computed(() => configStore.userDeletionEnabled)
 const webhooksEnabled = computed(() => configStore.webhooksEnabled)
-const botUsersEnabled = computed(() => configStore.botUsersEnabled)
 
 const navigationItems = computed(() => {
 	const items = [
@@ -84,7 +83,6 @@ const navigationItems = computed(() => {
 		{
 			title: t('user.settings.bots.title'),
 			routeName: 'user.settings.bots',
-			condition: botUsersEnabled.value,
 		},
 		{
 			title: t('user.deletion.title'),

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -64,7 +64,6 @@ const (
 	ServiceTestingtoken                   Key = `service.testingtoken`
 	ServiceEnableEmailReminders           Key = `service.enableemailreminders`
 	ServiceEnableUserDeletion             Key = `service.enableuserdeletion`
-	ServiceEnableBotUsers                 Key = `service.enablebotusers`
 	ServiceMaxAvatarSize                  Key = `service.maxavatarsize`
 	ServiceAllowIconChanges               Key = `service.allowiconchanges`
 	ServiceCustomLogoURL                  Key = `service.customlogourl`
@@ -361,7 +360,6 @@ func InitDefaultConfig() {
 	ServiceEnableTotp.setDefault(true)
 	ServiceEnableEmailReminders.setDefault(true)
 	ServiceEnableUserDeletion.setDefault(true)
-	ServiceEnableBotUsers.setDefault(true)
 	ServiceMaxAvatarSize.setDefault(1024)
 	ServiceDemoMode.setDefault(false)
 	ServiceAllowIconChanges.setDefault(true)

--- a/pkg/routes/api/v1/info.go
+++ b/pkg/routes/api/v1/info.go
@@ -55,7 +55,6 @@ type vikunjaInfos struct {
 	DemoModeEnabled            bool              `json:"demo_mode_enabled"`
 	WebhooksEnabled            bool              `json:"webhooks_enabled"`
 	PublicTeamsEnabled         bool              `json:"public_teams_enabled"`
-	BotUsersEnabled            bool              `json:"bot_users_enabled"`
 	EnabledProFeatures         []license.Feature `json:"enabled_pro_features"`
 }
 
@@ -108,7 +107,6 @@ func Info(c *echo.Context) error {
 		DemoModeEnabled:        config.ServiceDemoMode.GetBool(),
 		WebhooksEnabled:        config.WebhooksEnabled.GetBool(),
 		PublicTeamsEnabled:     config.ServiceEnablePublicTeams.GetBool(),
-		BotUsersEnabled:        config.ServiceEnableBotUsers.GetBool(),
 		EnabledProFeatures:     license.EnabledProFeatures(),
 		AvailableMigrators: []string{
 			(&vikunja_file.FileMigrator{}).Name(),

--- a/pkg/routes/routes.go
+++ b/pkg/routes/routes.go
@@ -482,18 +482,16 @@ func registerAPIRoutes(a *echo.Group) {
 	}
 
 	// Bot users
-	if config.ServiceEnableBotUsers.GetBool() {
-		botHandler := &handler.WebHandler{
-			EmptyStruct: func() handler.CObject {
-				return &models.BotUser{}
-			},
-		}
-		u.PUT("/bots", botHandler.CreateWeb)
-		u.GET("/bots", botHandler.ReadAllWeb)
-		u.GET("/bots/:bot", botHandler.ReadOneWeb)
-		u.POST("/bots/:bot", botHandler.UpdateWeb)
-		u.DELETE("/bots/:bot", botHandler.DeleteWeb)
+	botHandler := &handler.WebHandler{
+		EmptyStruct: func() handler.CObject {
+			return &models.BotUser{}
+		},
 	}
+	u.PUT("/bots", botHandler.CreateWeb)
+	u.GET("/bots", botHandler.ReadAllWeb)
+	u.GET("/bots/:bot", botHandler.ReadOneWeb)
+	u.POST("/bots/:bot", botHandler.UpdateWeb)
+	u.DELETE("/bots/:bot", botHandler.DeleteWeb)
 
 	projectHandler := &handler.WebHandler{
 		EmptyStruct: func() handler.CObject {

--- a/pkg/user/error.go
+++ b/pkg/user/error.go
@@ -820,31 +820,6 @@ func (err *ErrAccountIsBot) HTTPError() web.HTTPError {
 	}
 }
 
-// ErrBotUsersDisabled represents an error where the bot users feature is disabled.
-type ErrBotUsersDisabled struct{}
-
-// IsErrBotUsersDisabled checks if an error is a ErrBotUsersDisabled.
-func IsErrBotUsersDisabled(err error) bool {
-	_, ok := err.(*ErrBotUsersDisabled)
-	return ok
-}
-
-func (err *ErrBotUsersDisabled) Error() string {
-	return "Bot users feature is disabled"
-}
-
-// ErrCodeBotUsersDisabled holds the unique world-error code of this error
-const ErrCodeBotUsersDisabled = 1032
-
-// HTTPError holds the http error description
-func (err *ErrBotUsersDisabled) HTTPError() web.HTTPError {
-	return web.HTTPError{
-		HTTPCode: http.StatusForbidden,
-		Code:     ErrCodeBotUsersDisabled,
-		Message:  "Bot users are disabled on this instance.",
-	}
-}
-
 // ErrBotNotOwned represents an error where a user tried to operate on a bot they do not own.
 type ErrBotNotOwned struct {
 	UserID int64

--- a/pkg/user/error_test.go
+++ b/pkg/user/error_test.go
@@ -30,13 +30,6 @@ func TestErrAccountIsBot(t *testing.T) {
 	assert.Equal(t, 1031, err.HTTPError().Code)
 }
 
-func TestErrBotUsersDisabled(t *testing.T) {
-	err := &ErrBotUsersDisabled{}
-	assert.True(t, IsErrBotUsersDisabled(err))
-	assert.Equal(t, http.StatusForbidden, err.HTTPError().HTTPCode)
-	assert.Equal(t, 1032, err.HTTPError().Code)
-}
-
 func TestErrBotNotOwned(t *testing.T) {
 	err := &ErrBotNotOwned{UserID: 7}
 	assert.True(t, IsErrBotNotOwned(err))


### PR DESCRIPTION
This PR removes the `ServiceEnableBotUsers` configuration option and makes bot users a permanently enabled feature in Vikunja.

## Summary
The bot users feature is no longer gated behind a configuration flag. The feature is now always available to users, and all conditional logic checking if bot users are enabled has been removed.

## Key Changes
- Removed `ServiceEnableBotUsers` configuration key from `pkg/config/config.go`
- Removed the `ErrBotUsersDisabled` error type and related functions from `pkg/user/error.go`
- Removed the configuration check in `pkg/routes/routes.go` that conditionally registered bot user API endpoints - they are now always registered
- Removed `botUsersEnabled` from the frontend config store in `frontend/src/stores/config.ts`
- Removed the `botUsersEnabled` computed property and its condition check from the user settings navigation in `frontend/src/views/user/Settings.vue`
- Removed the `bot_users_enabled` field from the API info endpoint response in `pkg/routes/api/v1/info.go`
- Removed the corresponding test case for `ErrBotUsersDisabled` from `pkg/user/error_test.go`
- Removed the configuration entry from `config-raw.json`

## Implementation Details
The bot user API endpoints (`PUT /bots`, `GET /bots`, `GET /bots/:bot`, `POST /bots/:bot`, `DELETE /bots/:bot`) are now unconditionally registered and available to all users. The bot settings page in the frontend is also always visible in the user settings navigation.

https://claude.ai/code/session_01VhAR6xnoCdG1fpX52bzaCC