### PR TITLE
fix: Correct the API_URL value to replace in index.html

### DIFF
--- a/pkg/routes/static.go
+++ b/pkg/routes/static.go
@@ -118,7 +118,7 @@ func serveIndexFile(c *echo.Context, assetFs http.FileSystem) (err error) {
 			publicURL = "/"
 		}
 
-		scriptConfigString = strings.ReplaceAll(scriptConfigString, "'http://localhost:3456/api/v1'", "'"+publicURL+"api/v1'")
+		scriptConfigString = strings.ReplaceAll(scriptConfigString, "'/api/v1'", "'"+publicURL+"api/v1'")
 	}
 
 	reader := strings.NewReader(scriptConfigString)


### PR DESCRIPTION
This fix will correct the behaviour, where `window.API_URL` in `index.html` will get replaced by `service.publicurl` configured in `config.yml` at run time by the static file handler.

I'm a bit confused about the actual expected behaviour.

In current implementation, `index.html` says

```html
<script>
	//
	// This variable points the frontend to the api.
	// It has to be the full url, including the last /api/v1 part and port.
	// You can change this if your api is not reachable on the same port as the frontend.
	window.API_URL = '/api/v1'
```

However it is just `/api/v1`, not a full url, no domain or port.

In `static.go`, the `index.html` handler is intended to replace the `API_URL` with the actual public URL (`service.publicurl`) value configured in `config.yml`, but the target string for replacement is `'http://localhost:3456/api/v1'`, which mismatches `'/api/v1'` and will clearly fail this intention.

```go
scriptConfigString = strings.ReplaceAll(scriptConfigString, "'http://localhost:3456/api/v1'", "'"+publicURL+"api/v1'")
```