### PR TITLE
feat(kanban): inline quick-edit fields on existing task cards

### DIFF
--- a/frontend/src/components/input/DatepickerInline.vue
+++ b/frontend/src/components/input/DatepickerInline.vue
@@ -1,73 +1,77 @@
 <template>
-	<BaseButton
-		v-if="(new Date()).getHours() < 21"
-		class="datepicker__quick-select-date"
-		@click.stop="setDate('today')"
-	>
-		<span class="icon"><Icon :icon="['far', 'calendar-alt']" /></span>
-		<span class="text">
-			<span>{{ $t('input.datepicker.today') }}</span>
-			<span class="weekday">{{ getWeekdayFromStringInterval('today') }}</span>
-		</span>
-	</BaseButton>
-	<BaseButton
-		class="datepicker__quick-select-date"
-		@click.stop="setDate('tomorrow')"
-	>
-		<span class="icon"><Icon :icon="['far', 'sun']" /></span>
-		<span class="text">
-			<span>{{ $t('input.datepicker.tomorrow') }}</span>
-			<span class="weekday">{{ getWeekdayFromStringInterval('tomorrow') }}</span>
-		</span>
-	</BaseButton>
-	<BaseButton
-		class="datepicker__quick-select-date"
-		@click.stop="setDate('nextMonday')"
-	>
-		<span class="icon"><Icon icon="coffee" /></span>
-		<span class="text">
-			<span>{{ $t('input.datepicker.nextMonday') }}</span>
-			<span class="weekday">{{ getWeekdayFromStringInterval('nextMonday') }}</span>
-		</span>
-	</BaseButton>
-	<BaseButton
-		v-if="!((new Date()).getDay() === 0 && (new Date()).getHours() >= 21)"
-		class="datepicker__quick-select-date"
-		@click.stop="setDate('thisWeekend')"
-	>
-		<span class="icon"><Icon icon="cocktail" /></span>
-		<span class="text">
-			<span>{{ $t('input.datepicker.thisWeekend') }}</span>
-			<span class="weekday">{{ getWeekdayFromStringInterval('thisWeekend') }}</span>
-		</span>
-	</BaseButton>
-	<BaseButton
-		class="datepicker__quick-select-date"
-		@click.stop="setDate('laterThisWeek')"
-	>
-		<span class="icon"><Icon icon="chess-knight" /></span>
-		<span class="text">
-			<span>{{ $t('input.datepicker.laterThisWeek') }}</span>
-			<span class="weekday">{{ getWeekdayFromStringInterval('laterThisWeek') }}</span>
-		</span>
-	</BaseButton>
-	<BaseButton
-		class="datepicker__quick-select-date"
-		@click.stop="setDate('nextWeek')"
-	>
-		<span class="icon"><Icon icon="forward" /></span>
-		<span class="text">
-			<span>{{ $t('input.datepicker.nextWeek') }}</span>
-			<span class="weekday">{{ getWeekdayFromStringInterval('nextWeek') }}</span>
-		</span>
-	</BaseButton>
+	<div class="datepicker-inline">
+		<div class="datepicker-inline__shortcuts">
+			<BaseButton
+				v-if="(new Date()).getHours() < 21"
+				class="datepicker__quick-select-date"
+				@click.stop="setDate('today')"
+			>
+				<span class="icon"><Icon :icon="['far', 'calendar-alt']" /></span>
+				<span class="text">
+					<span>{{ $t('input.datepicker.today') }}</span>
+					<span class="weekday">{{ getWeekdayFromStringInterval('today') }}</span>
+				</span>
+			</BaseButton>
+			<BaseButton
+				class="datepicker__quick-select-date"
+				@click.stop="setDate('tomorrow')"
+			>
+				<span class="icon"><Icon :icon="['far', 'sun']" /></span>
+				<span class="text">
+					<span>{{ $t('input.datepicker.tomorrow') }}</span>
+					<span class="weekday">{{ getWeekdayFromStringInterval('tomorrow') }}</span>
+				</span>
+			</BaseButton>
+			<BaseButton
+				class="datepicker__quick-select-date"
+				@click.stop="setDate('nextMonday')"
+			>
+				<span class="icon"><Icon icon="coffee" /></span>
+				<span class="text">
+					<span>{{ $t('input.datepicker.nextMonday') }}</span>
+					<span class="weekday">{{ getWeekdayFromStringInterval('nextMonday') }}</span>
+				</span>
+			</BaseButton>
+			<BaseButton
+				v-if="!((new Date()).getDay() === 0 && (new Date()).getHours() >= 21)"
+				class="datepicker__quick-select-date"
+				@click.stop="setDate('thisWeekend')"
+			>
+				<span class="icon"><Icon icon="cocktail" /></span>
+				<span class="text">
+					<span>{{ $t('input.datepicker.thisWeekend') }}</span>
+					<span class="weekday">{{ getWeekdayFromStringInterval('thisWeekend') }}</span>
+				</span>
+			</BaseButton>
+			<BaseButton
+				class="datepicker__quick-select-date"
+				@click.stop="setDate('laterThisWeek')"
+			>
+				<span class="icon"><Icon icon="chess-knight" /></span>
+				<span class="text">
+					<span>{{ $t('input.datepicker.laterThisWeek') }}</span>
+					<span class="weekday">{{ getWeekdayFromStringInterval('laterThisWeek') }}</span>
+				</span>
+			</BaseButton>
+			<BaseButton
+				class="datepicker__quick-select-date"
+				@click.stop="setDate('nextWeek')"
+			>
+				<span class="icon"><Icon icon="forward" /></span>
+				<span class="text">
+					<span>{{ $t('input.datepicker.nextWeek') }}</span>
+					<span class="weekday">{{ getWeekdayFromStringInterval('nextWeek') }}</span>
+				</span>
+			</BaseButton>
+		</div>
 
-	<div class="flatpickr-container">
-		<flat-pickr
-			ref="flatPickrRef"
-			v-model="flatPickrDate"
-			:config="flatPickerConfig"
-		/>
+		<div class="flatpickr-container">
+			<flat-pickr
+				ref="flatPickrRef"
+				v-model="flatPickrDate"
+				:config="flatPickerConfig"
+			/>
+		</div>
 	</div>
 </template>
 
@@ -223,6 +227,11 @@ function getWeekdayFromStringInterval(dateString: string) {
 </script>
 
 <style lang="scss" scoped>
+.datepicker-inline {
+	display: flex;
+	flex-direction: column;
+}
+
 .datepicker__quick-select-date {
 	display: flex;
 	align-items: center;
@@ -230,14 +239,17 @@ function getWeekdayFromStringInterval(dateString: string) {
 	inline-size: 100%;
 	block-size: 2.25rem;
 	color: var(--text);
-	transition: all $transition;
+	cursor: pointer;
+	border-radius: $radius;
+	transition: background-color $transition, color $transition;
 
 	&:first-child {
 		border-radius: $radius $radius 0 0;
 	}
 
 	&:hover {
-		background: var(--grey-100);
+		background: var(--primary-light);
+		color: var(--primary-dark);
 	}
 
 	.text {
@@ -245,6 +257,7 @@ function getWeekdayFromStringInterval(dateString: string) {
 		font-size: .85rem;
 		display: flex;
 		justify-content: space-between;
+		gap: .75rem;
 		padding-inline-end: .25rem;
 
 		.weekday {

--- a/frontend/src/components/project/views/InlineQuickAddFields.vue
+++ b/frontend/src/components/project/views/InlineQuickAddFields.vue
@@ -75,13 +75,13 @@
 			<EditAssignees
 				v-else-if="openPopup === 'assignee'"
 				v-model="fields.assignees"
-				:task-id="0"
+				:task-id="props.task?.id ?? 0"
 				:project-id="projectId"
 			/>
 			<EditLabels
 				v-else-if="openPopup === 'labels'"
 				v-model="fields.labels"
-				:task-id="0"
+				:task-id="props.task?.id ?? 0"
 				:creatable="false"
 			/>
 			<Reminders
@@ -134,21 +134,26 @@ import Reminders from '@/components/tasks/partials/Reminders.vue'
 import ColorPicker from '@/components/input/ColorPicker.vue'
 import XButton from '@/components/input/Button.vue'
 
-import {formatDateShort} from '@/helpers/time/formatDate'
+import {formatDateShort, formatDisplayDate} from '@/helpers/time/formatDate'
 import {closeWhenClickedOutside} from '@/helpers/closeWhenClickedOutside'
 import {DEFAULT_INLINE_QUICK_ADD_FIELDS} from '@/modelTypes/IUserSettings'
 import type {IUser} from '@/modelTypes/IUser'
 import type {ILabel} from '@/modelTypes/ILabel'
+import type {ITask} from '@/modelTypes/ITask'
 import type {ITaskReminder} from '@/modelTypes/ITaskReminder'
 import type {IReminderPeriodRelativeTo} from '@/types/IReminderPeriodRelativeTo'
 import {REMINDER_PERIOD_RELATIVE_TO_TYPES} from '@/types/IReminderPeriodRelativeTo'
 
 import {useAuthStore} from '@/stores/auth'
+import {useTaskStore} from '@/stores/tasks'
 
-defineProps<{
+const props = defineProps<{
 	projectId: number
 	disabled: boolean
+	task?: ITask
 }>()
+
+const isEditMode = computed(() => props.task !== undefined)
 
 defineOptions({name: 'InlineQuickAddFields'})
 
@@ -176,6 +181,80 @@ const fields = ref({
 	color: '',
 	percentDone: 0,
 })
+
+// --- Edit mode: init fields from task ---
+
+const taskStore = useTaskStore()
+let suppressSave = false
+
+function isDateSet(d: Date | null): boolean {
+	return d !== null && d.getTime() > 0
+}
+
+function initFieldsFromTask(task: ITask) {
+	suppressSave = true
+	fields.value = {
+		dueDate: isDateSet(task.dueDate) ? task.dueDate : null,
+		startDate: isDateSet(task.startDate) ? task.startDate : null,
+		endDate: isDateSet(task.endDate) ? task.endDate : null,
+		priority: task.priority,
+		assignees: [...task.assignees],
+		labels: [...task.labels],
+		reminders: [...task.reminders],
+		color: task.hexColor ?? '',
+		percentDone: task.percentDone * 100,
+	}
+	nextTick(() => { suppressSave = false })
+}
+
+if (props.task) {
+	initFieldsFromTask(props.task)
+}
+
+function datesEqual(a: Date | null, b: Date | null): boolean {
+	if (a === b) return true
+	if (a === null || b === null) return false
+	return a.getTime() === b.getTime()
+}
+
+async function saveEditField(popup: Exclude<PopupKind, null>) {
+	if (!isEditMode.value || !props.task || suppressSave) return
+
+	const task = props.task
+	switch (popup) {
+		case 'due':
+			if (datesEqual(fields.value.dueDate, task.dueDate)) return
+			await taskStore.update({...task, dueDate: fields.value.dueDate})
+			break
+		case 'start':
+			if (datesEqual(fields.value.startDate, task.startDate)) return
+			await taskStore.update({...task, startDate: fields.value.startDate})
+			break
+		case 'endDate':
+			if (datesEqual(fields.value.endDate, task.endDate)) return
+			await taskStore.update({...task, endDate: fields.value.endDate})
+			break
+		case 'priority':
+			if (fields.value.priority === task.priority) return
+			await taskStore.update({...task, priority: fields.value.priority})
+			break
+		case 'color':
+			if (fields.value.color === (task.hexColor ?? '')) return
+			await taskStore.update({...task, hexColor: fields.value.color})
+			break
+		case 'percentDone':
+			if (fields.value.percentDone / 100 === task.percentDone) return
+			await taskStore.update({...task, percentDone: fields.value.percentDone / 100})
+			break
+		case 'reminder':
+			if (fields.value.reminders.length === task.reminders.length) return
+			await taskStore.update({...task, reminders: [...fields.value.reminders]})
+			break
+		case 'assignee':
+		case 'labels':
+			break
+	}
+}
 
 // --- Enabled fields ---
 
@@ -255,8 +334,15 @@ function clampPopupToViewport() {
 	}
 	const margin = 8
 	const popupRect = popup.getBoundingClientRect()
-	const top = chipRect.bottom + 4
+	let top = chipRect.bottom + 4
 	let left = chipRect.left
+
+	if (top + popupRect.height + margin > window.innerHeight) {
+		top = chipRect.top - popupRect.height - 4
+	}
+	if (top < margin) {
+		top = margin
+	}
 
 	if (left + popupRect.width + margin > window.innerWidth) {
 		left = Math.max(margin, window.innerWidth - popupRect.width - margin)
@@ -284,11 +370,14 @@ function disconnectPopupResize() {
 	}
 }
 
-watch(openPopup, (value) => {
-	if (value === null) {
+watch(openPopup, (newVal, oldVal) => {
+	if (newVal === null) {
 		disconnectPopupResize()
 		anchorChipRect.value = null
 		isPopupReady.value = false
+	}
+	if (oldVal !== null && newVal === null && isEditMode.value) {
+		saveEditField(oldVal)
 	}
 })
 
@@ -357,11 +446,12 @@ const reminderChipLabel = computed(() => {
 })
 
 const inlineChips = computed<InlineChip[]>(() => {
+	const formatDate = isEditMode.value ? formatDisplayDate : formatDateShort
 	const chipLabel: Record<string, () => string> = {
 		assignee: () => assigneeChipLabel.value,
-		dueDate: () => fields.value.dueDate !== null ? formatDateShort(fields.value.dueDate) : t('task.attributes.dueDate'),
-		startDate: () => fields.value.startDate !== null ? formatDateShort(fields.value.startDate) : t('task.attributes.startDate'),
-		endDate: () => fields.value.endDate !== null ? formatDateShort(fields.value.endDate) : t('task.attributes.endDate'),
+		dueDate: () => fields.value.dueDate !== null ? formatDate(fields.value.dueDate) : t('task.attributes.dueDate'),
+		startDate: () => fields.value.startDate !== null ? formatDate(fields.value.startDate) : t('task.attributes.startDate'),
+		endDate: () => fields.value.endDate !== null ? formatDate(fields.value.endDate) : t('task.attributes.endDate'),
 		priority: () => fields.value.priority !== 0 ? t(`task.priority.${PRIORITY_LABEL_KEYS[fields.value.priority]}`) : t('task.attributes.priority'),
 		labels: () => labelsChipLabel.value,
 		reminder: () => reminderChipLabel.value,
@@ -380,7 +470,7 @@ const inlineChips = computed<InlineChip[]>(() => {
 		percentDone: () => fields.value.percentDone > 0,
 	}
 
-	return enabledFields.value.map(field => {
+	const chips = enabledFields.value.map(field => {
 		const cfg = CHIP_CONFIG[field]
 		return {
 			field,
@@ -392,6 +482,12 @@ const inlineChips = computed<InlineChip[]>(() => {
 			colorValue: field === 'color' && fields.value.color ? fields.value.color : undefined,
 		}
 	})
+
+	if (isEditMode.value) {
+		return chips.filter(c => !c.isSet)
+	}
+
+	return chips
 })
 
 function clearField(field: string) {
@@ -407,6 +503,13 @@ function clearField(field: string) {
 		percentDone: () => { fields.value.percentDone = 0 },
 	}
 	clearMap[field]?.()
+
+	if (isEditMode.value) {
+		const popup = CHIP_CONFIG[field]?.popup
+		if (popup) {
+			saveEditField(popup)
+		}
+	}
 }
 
 // --- Public API ---
@@ -447,6 +550,30 @@ function containsElement(el: Element | null): boolean {
 const isPopupOpen = computed(() => openPopup.value !== null)
 const taskColor = computed(() => fields.value.color)
 
+function openForField(field: string, anchorEl: HTMLElement) {
+	const cfg = CHIP_CONFIG[field]
+	if (!cfg) return
+
+	if (openPopup.value === cfg.popup) {
+		openPopup.value = null
+		return
+	}
+
+	const rect = anchorEl.getBoundingClientRect()
+	anchorChipRect.value = rect
+	popupPosition.value = {
+		top: rect.bottom + 4,
+		left: rect.left,
+	}
+	isPopupReady.value = false
+	openPopup.value = cfg.popup
+	nextTick(() => {
+		clampPopupToViewport()
+		isPopupReady.value = true
+		observePopupResize()
+	})
+}
+
 defineExpose({
 	getFieldValues,
 	reset,
@@ -454,6 +581,7 @@ defineExpose({
 	hasAnyField,
 	isPopupOpen,
 	taskColor,
+	openForField,
 })
 </script>
 
@@ -482,9 +610,9 @@ defineExpose({
 	transition: background-color $transition, color $transition, border-color $transition, box-shadow $transition;
 
 	&:hover:not(:disabled) {
-		background: var(--white);
-		color: var(--grey-900);
-		box-shadow: 0 1px 3px hsla(var(--grey-900-hsl), .12);
+		background: var(--primary-light);
+		color: var(--primary-dark);
+		box-shadow: 0 1px 4px hsla(var(--primary-hsl), .2);
 	}
 
 	&:focus-visible {

--- a/frontend/src/components/project/views/InlineQuickAddFields.vue
+++ b/frontend/src/components/project/views/InlineQuickAddFields.vue
@@ -1,0 +1,747 @@
+<template>
+	<div
+		v-if="hasAnyField"
+		class="inline-quick-add-chip-bar"
+	>
+		<button
+			v-for="chip in inlineChips"
+			:key="chip.field"
+			type="button"
+			class="inline-quick-add-chip"
+			:class="[`inline-quick-add-chip--${chip.modifier}`, {'is-set': chip.isSet}]"
+			:disabled="disabled || undefined"
+			@click.stop="toggleInlinePopup(chip.popup, $event)"
+		>
+			<span
+				v-if="chip.colorValue"
+				class="inline-quick-add-chip__swatch"
+				:style="{background: chip.colorValue}"
+			/>
+			<Icon
+				v-else
+				:icon="chip.icon"
+				class="inline-quick-add-chip__icon"
+				:class="`inline-quick-add-chip__icon--${chip.modifier}`"
+			/>
+			<span>{{ chip.label }}</span>
+			<span
+				v-if="chip.isSet"
+				class="inline-quick-add-chip__clear"
+				@click.stop="clearField(chip.field)"
+			>
+				<Icon icon="times" />
+			</span>
+		</button>
+	</div>
+
+	<Teleport to="body">
+		<div
+			v-if="openPopup !== null"
+			ref="popupRef"
+			class="inline-quick-add-popup"
+			:class="[
+				`inline-quick-add-popup--${popupVariant}`,
+				openPopup === 'reminder' ? 'inline-quick-add-popup--wide' : null,
+				isPopupReady ? null : 'inline-quick-add-popup--measuring',
+			]"
+			:style="{top: `${popupPosition.top}px`, left: `${popupPosition.left}px`}"
+		>
+			<DatepickerInline
+				v-if="openPopup === 'due'"
+				v-model="fields.dueDate"
+			/>
+			<DatepickerInline
+				v-else-if="openPopup === 'start'"
+				v-model="fields.startDate"
+			/>
+			<ul
+				v-else-if="openPopup === 'priority'"
+				class="inline-quick-add-priority-options"
+			>
+				<li
+					v-for="option in PRIORITY_OPTIONS"
+					:key="option.value"
+				>
+					<button
+						type="button"
+						class="inline-quick-add-priority-option"
+						:class="{'is-active': fields.priority === option.value}"
+						@click="selectPriority(option.value)"
+					>
+						{{ $t(option.labelKey) }}
+					</button>
+				</li>
+			</ul>
+			<EditAssignees
+				v-else-if="openPopup === 'assignee'"
+				v-model="fields.assignees"
+				:task-id="0"
+				:project-id="projectId"
+			/>
+			<EditLabels
+				v-else-if="openPopup === 'labels'"
+				v-model="fields.labels"
+				:task-id="0"
+				:creatable="false"
+			/>
+			<Reminders
+				v-else-if="openPopup === 'reminder'"
+				v-model="fields.reminders"
+				:default-relative-to="reminderDefaultRelativeTo"
+			/>
+			<DatepickerInline
+				v-else-if="openPopup === 'endDate'"
+				v-model="fields.endDate"
+			/>
+			<ColorPicker
+				v-else-if="openPopup === 'color'"
+				v-model="fields.color"
+			/>
+			<div
+				v-else-if="openPopup === 'percentDone'"
+				class="inline-quick-add-percent-done"
+			>
+				<input
+					v-model.number="fields.percentDone"
+					type="range"
+					min="0"
+					max="100"
+					step="10"
+					class="inline-quick-add-percent-done__slider"
+				>
+				<span class="inline-quick-add-percent-done__label">{{ fields.percentDone }}%</span>
+			</div>
+			<XButton
+				v-if="openPopup !== 'priority'"
+				class="inline-quick-add-popup__confirm"
+				:shadow="false"
+				@click="openPopup = null"
+			>
+				{{ $t('misc.confirm') }}
+			</XButton>
+		</div>
+	</Teleport>
+</template>
+
+<script setup lang="ts">
+import {computed, nextTick, onBeforeUnmount, onMounted, ref, watch} from 'vue'
+import {useI18n} from 'vue-i18n'
+
+import DatepickerInline from '@/components/input/DatepickerInline.vue'
+import EditAssignees from '@/components/tasks/partials/EditAssignees.vue'
+import EditLabels from '@/components/tasks/partials/EditLabels.vue'
+import Reminders from '@/components/tasks/partials/Reminders.vue'
+import ColorPicker from '@/components/input/ColorPicker.vue'
+import XButton from '@/components/input/Button.vue'
+
+import {formatDateShort} from '@/helpers/time/formatDate'
+import {closeWhenClickedOutside} from '@/helpers/closeWhenClickedOutside'
+import {DEFAULT_INLINE_QUICK_ADD_FIELDS} from '@/modelTypes/IUserSettings'
+import type {IUser} from '@/modelTypes/IUser'
+import type {ILabel} from '@/modelTypes/ILabel'
+import type {ITaskReminder} from '@/modelTypes/ITaskReminder'
+import type {IReminderPeriodRelativeTo} from '@/types/IReminderPeriodRelativeTo'
+import {REMINDER_PERIOD_RELATIVE_TO_TYPES} from '@/types/IReminderPeriodRelativeTo'
+
+import {useAuthStore} from '@/stores/auth'
+
+defineProps<{
+	projectId: number
+	disabled: boolean
+}>()
+
+defineOptions({name: 'InlineQuickAddFields'})
+
+const {t} = useI18n({useScope: 'global'})
+const authStore = useAuthStore()
+
+const PRIORITY_LABEL_KEYS: Record<number, string> = {
+	1: 'low',
+	2: 'medium',
+	3: 'high',
+	4: 'urgent',
+	5: 'doNow',
+}
+
+// --- Field state ---
+
+const fields = ref({
+	dueDate: null as Date | null,
+	startDate: null as Date | null,
+	endDate: null as Date | null,
+	priority: 0,
+	assignees: [] as IUser[],
+	labels: [] as ILabel[],
+	reminders: [] as ITaskReminder[],
+	color: '',
+	percentDone: 0,
+})
+
+// --- Enabled fields ---
+
+const enabledFields = computed(
+	() => authStore.settings.frontendSettings.inlineQuickAddFields ?? DEFAULT_INLINE_QUICK_ADD_FIELDS,
+)
+const hasAnyField = computed(() => enabledFields.value.length > 0)
+
+function isEnabled(field: string) {
+	return enabledFields.value.includes(field as typeof enabledFields.value[number])
+}
+
+// --- Popup ---
+
+type PopupKind = 'due' | 'start' | 'endDate' | 'assignee' | 'labels' | 'reminder' | 'priority' | 'color' | 'percentDone' | null
+const openPopup = ref<PopupKind>(null)
+const popupRef = ref<HTMLElement | null>(null)
+const popupPosition = ref<{top: number, left: number}>({top: 0, left: 0})
+const isPopupReady = ref(false)
+
+const PRIORITY_OPTIONS = [
+	{value: 0, labelKey: 'task.priority.unset'},
+	{value: 1, labelKey: 'task.priority.low'},
+	{value: 2, labelKey: 'task.priority.medium'},
+	{value: 3, labelKey: 'task.priority.high'},
+	{value: 4, labelKey: 'task.priority.urgent'},
+	{value: 5, labelKey: 'task.priority.doNow'},
+] as const
+
+function selectPriority(value: number) {
+	fields.value.priority = value
+	openPopup.value = null
+}
+
+const popupVariant = computed(() => {
+	if (openPopup.value === 'due' || openPopup.value === 'start' || openPopup.value === 'endDate') {
+		return 'date'
+	}
+	return 'picker'
+})
+
+const reminderDefaultRelativeTo = computed<IReminderPeriodRelativeTo | null>(
+	() => fields.value.dueDate !== null ? REMINDER_PERIOD_RELATIVE_TO_TYPES.DUEDATE : null,
+)
+
+// --- Popup positioning ---
+
+const anchorChipRect = ref<DOMRect | null>(null)
+let popupResizeObserver: ResizeObserver | null = null
+
+function toggleInlinePopup(which: Exclude<PopupKind, null>, event: MouseEvent) {
+	if (openPopup.value === which) {
+		openPopup.value = null
+		return
+	}
+	const chip = event.currentTarget as HTMLElement
+	const rect = chip.getBoundingClientRect()
+	anchorChipRect.value = rect
+	popupPosition.value = {
+		top: rect.bottom + 4,
+		left: rect.left,
+	}
+	isPopupReady.value = false
+	openPopup.value = which
+	nextTick(() => {
+		clampPopupToViewport()
+		isPopupReady.value = true
+		observePopupResize()
+	})
+}
+
+function clampPopupToViewport() {
+	const popup = popupRef.value
+	const chipRect = anchorChipRect.value
+	if (!popup || !chipRect) {
+		return
+	}
+	const margin = 8
+	const popupRect = popup.getBoundingClientRect()
+	const top = chipRect.bottom + 4
+	let left = chipRect.left
+
+	if (left + popupRect.width + margin > window.innerWidth) {
+		left = Math.max(margin, window.innerWidth - popupRect.width - margin)
+	}
+
+	popupPosition.value = {top, left}
+}
+
+function observePopupResize() {
+	disconnectPopupResize()
+	const popup = popupRef.value
+	if (!popup || typeof ResizeObserver === 'undefined') {
+		return
+	}
+	popupResizeObserver = new ResizeObserver(() => {
+		requestAnimationFrame(() => clampPopupToViewport())
+	})
+	popupResizeObserver.observe(popup)
+}
+
+function disconnectPopupResize() {
+	if (popupResizeObserver) {
+		popupResizeObserver.disconnect()
+		popupResizeObserver = null
+	}
+}
+
+watch(openPopup, (value) => {
+	if (value === null) {
+		disconnectPopupResize()
+		anchorChipRect.value = null
+		isPopupReady.value = false
+	}
+})
+
+watch(() => fields.value.assignees.length, (newLen, oldLen) => {
+	if (newLen > oldLen && openPopup.value === 'assignee') {
+		openPopup.value = null
+	}
+})
+
+function onDocumentClick(e: MouseEvent) {
+	if (openPopup.value !== null && popupRef.value) {
+		closeWhenClickedOutside(e, popupRef.value, () => {
+			openPopup.value = null
+		})
+	}
+}
+
+onMounted(() => document.addEventListener('click', onDocumentClick))
+onBeforeUnmount(() => {
+	document.removeEventListener('click', onDocumentClick)
+	disconnectPopupResize()
+})
+
+// --- Chip rendering ---
+
+type InlineChip = {
+	field: string
+	modifier: string
+	icon: string
+	popup: Exclude<PopupKind, null>
+	isSet: boolean
+	label: string
+	colorValue?: string
+}
+
+const CHIP_CONFIG: Record<string, {modifier: string, icon: string, popup: Exclude<PopupKind, null>}> = {
+	assignee: {modifier: 'assignee', icon: 'user', popup: 'assignee'},
+	dueDate: {modifier: 'due', icon: 'calendar', popup: 'due'},
+	startDate: {modifier: 'start', icon: 'play', popup: 'start'},
+	endDate: {modifier: 'end', icon: 'stop', popup: 'endDate'},
+	priority: {modifier: 'priority', icon: 'exclamation', popup: 'priority'},
+	labels: {modifier: 'labels', icon: 'tags', popup: 'labels'},
+	reminder: {modifier: 'reminder', icon: 'bell', popup: 'reminder'},
+	color: {modifier: 'color', icon: 'fill-drip', popup: 'color'},
+	percentDone: {modifier: 'percent', icon: 'percent', popup: 'percentDone'},
+}
+
+const assigneeChipLabel = computed(() => {
+	const count = fields.value.assignees.length
+	if (count === 0) return t('task.attributes.assignees')
+	if (count === 1) return fields.value.assignees[0].name || fields.value.assignees[0].username
+	return t('task.attributes.assigneesN', count)
+})
+
+const labelsChipLabel = computed(() => {
+	const count = fields.value.labels.length
+	if (count === 0) return t('task.attributes.labels')
+	if (count === 1) return fields.value.labels[0].title
+	return t('task.attributes.labelsN', count)
+})
+
+const reminderChipLabel = computed(() => {
+	const count = fields.value.reminders.length
+	if (count === 0) return t('task.attributes.reminders')
+	return t('task.attributes.remindersN', count)
+})
+
+const inlineChips = computed<InlineChip[]>(() => {
+	const chipLabel: Record<string, () => string> = {
+		assignee: () => assigneeChipLabel.value,
+		dueDate: () => fields.value.dueDate !== null ? formatDateShort(fields.value.dueDate) : t('task.attributes.dueDate'),
+		startDate: () => fields.value.startDate !== null ? formatDateShort(fields.value.startDate) : t('task.attributes.startDate'),
+		endDate: () => fields.value.endDate !== null ? formatDateShort(fields.value.endDate) : t('task.attributes.endDate'),
+		priority: () => fields.value.priority !== 0 ? t(`task.priority.${PRIORITY_LABEL_KEYS[fields.value.priority]}`) : t('task.attributes.priority'),
+		labels: () => labelsChipLabel.value,
+		reminder: () => reminderChipLabel.value,
+		color: () => t('task.attributes.color'),
+		percentDone: () => fields.value.percentDone > 0 ? `${fields.value.percentDone}%` : t('task.attributes.percentDone'),
+	}
+	const chipIsSet: Record<string, () => boolean> = {
+		assignee: () => fields.value.assignees.length > 0,
+		dueDate: () => fields.value.dueDate !== null,
+		startDate: () => fields.value.startDate !== null,
+		endDate: () => fields.value.endDate !== null,
+		priority: () => fields.value.priority !== 0,
+		labels: () => fields.value.labels.length > 0,
+		reminder: () => fields.value.reminders.length > 0,
+		color: () => fields.value.color !== '',
+		percentDone: () => fields.value.percentDone > 0,
+	}
+
+	return enabledFields.value.map(field => {
+		const cfg = CHIP_CONFIG[field]
+		return {
+			field,
+			modifier: cfg.modifier,
+			icon: cfg.icon,
+			popup: cfg.popup,
+			isSet: chipIsSet[field](),
+			label: chipLabel[field](),
+			colorValue: field === 'color' && fields.value.color ? fields.value.color : undefined,
+		}
+	})
+})
+
+function clearField(field: string) {
+	const clearMap: Record<string, () => void> = {
+		assignee: () => { fields.value.assignees = [] },
+		dueDate: () => { fields.value.dueDate = null },
+		startDate: () => { fields.value.startDate = null },
+		endDate: () => { fields.value.endDate = null },
+		priority: () => { fields.value.priority = 0 },
+		labels: () => { fields.value.labels = [] },
+		reminder: () => { fields.value.reminders = [] },
+		color: () => { fields.value.color = '' },
+		percentDone: () => { fields.value.percentDone = 0 },
+	}
+	clearMap[field]?.()
+}
+
+// --- Public API ---
+
+function getFieldValues() {
+	return {
+		dueDate: isEnabled('dueDate') && fields.value.dueDate !== null ? fields.value.dueDate : undefined,
+		startDate: isEnabled('startDate') && fields.value.startDate !== null ? fields.value.startDate : undefined,
+		endDate: isEnabled('endDate') && fields.value.endDate !== null ? fields.value.endDate : undefined,
+		priority: isEnabled('priority') && fields.value.priority !== 0 ? fields.value.priority : undefined,
+		hexColor: isEnabled('color') && fields.value.color !== '' ? fields.value.color : undefined,
+		percentDone: isEnabled('percentDone') && fields.value.percentDone > 0 ? fields.value.percentDone : undefined,
+		assignees: isEnabled('assignee') ? [...fields.value.assignees] : [],
+		labels: isEnabled('labels') ? [...fields.value.labels] : [],
+		reminders: isEnabled('reminder') ? [...fields.value.reminders] : [],
+	}
+}
+
+function reset() {
+	fields.value = {
+		dueDate: null,
+		startDate: null,
+		endDate: null,
+		priority: 0,
+		assignees: [],
+		labels: [],
+		reminders: [],
+		color: '',
+		percentDone: 0,
+	}
+	openPopup.value = null
+}
+
+function containsElement(el: Element | null): boolean {
+	return el !== null && popupRef.value?.contains(el) === true
+}
+
+const isPopupOpen = computed(() => openPopup.value !== null)
+const taskColor = computed(() => fields.value.color)
+
+defineExpose({
+	getFieldValues,
+	reset,
+	containsElement,
+	hasAnyField,
+	isPopupOpen,
+	taskColor,
+})
+</script>
+
+<style lang="scss" scoped>
+.inline-quick-add-chip-bar {
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	gap: .375rem;
+	margin-block-start: .5rem;
+}
+
+.inline-quick-add-chip {
+	position: relative;
+	display: inline-flex;
+	align-items: center;
+	gap: .4rem;
+	padding: .3rem .65rem;
+	border: 1px solid transparent;
+	border-radius: $radius;
+	background: transparent;
+	color: var(--grey-700);
+	font-size: .8rem;
+	font-weight: 500;
+	line-height: 1.2;
+	cursor: pointer;
+	transition: background-color $transition, color $transition, border-color $transition, box-shadow $transition;
+
+	&:hover:not(:disabled) {
+		background: var(--white);
+		color: var(--grey-900);
+		box-shadow: 0 1px 3px hsla(var(--grey-900-hsl), .12);
+	}
+
+	&:focus-visible {
+		outline: none;
+		box-shadow: 0 0 0 2px var(--primary-light);
+	}
+
+	&:disabled {
+		cursor: not-allowed;
+		opacity: .5;
+	}
+}
+
+.inline-quick-add-chip__icon {
+	font-size: .85rem;
+
+	&--due {
+		color: var(--danger);
+	}
+
+	&--start {
+		color: var(--success);
+	}
+
+	&--priority {
+		color: var(--warning);
+	}
+
+	&--assignee,
+	&--labels,
+	&--reminder {
+		color: var(--primary);
+	}
+
+	&--end,
+	&--color,
+	&--percent {
+		color: var(--grey-500);
+	}
+}
+
+.inline-quick-add-chip__swatch {
+	display: inline-block;
+	inline-size: .85rem;
+	block-size: .85rem;
+	border-radius: .2rem;
+	border: 1px solid var(--grey-300);
+	flex-shrink: 0;
+}
+
+.inline-quick-add-chip__clear {
+	display: none;
+	align-items: center;
+	justify-content: center;
+	position: absolute;
+	inset-inline-end: 0;
+	inset-block-start: 0;
+	block-size: 100%;
+	padding-inline: .25rem;
+	font-size: .65rem;
+	background: transparent;
+	border-radius: 0 $radius $radius 0;
+	z-index: 1;
+	color: inherit;
+
+	&:hover {
+		color: var(--danger);
+	}
+}
+
+.inline-quick-add-chip:hover .inline-quick-add-chip__clear {
+	display: flex;
+}
+
+.inline-quick-add-chip--due.is-set {
+	background: var(--danger-light);
+	color: var(--danger-dark);
+}
+
+.inline-quick-add-chip--start.is-set,
+.inline-quick-add-chip--end.is-set {
+	background: var(--success-light);
+	color: var(--success-dark);
+}
+
+.inline-quick-add-chip--priority.is-set {
+	background: var(--warning-light);
+	color: var(--warning-dark);
+}
+
+.inline-quick-add-chip--assignee.is-set,
+.inline-quick-add-chip--labels.is-set,
+.inline-quick-add-chip--reminder.is-set,
+.inline-quick-add-chip--percent.is-set,
+.inline-quick-add-chip--color.is-set {
+	background: var(--primary-light);
+	color: var(--primary-dark);
+}
+
+.inline-quick-add-popup {
+	position: fixed;
+	z-index: 50;
+	padding: .5rem;
+	background: var(--white);
+	border: 1px solid var(--grey-200);
+	border-radius: $radius;
+	box-shadow: var(--shadow-md);
+}
+
+.inline-quick-add-popup--picker.inline-quick-add-popup--wide {
+	inline-size: min(28rem, calc(100vw - 2rem));
+}
+
+.inline-quick-add-popup--measuring {
+	visibility: hidden;
+}
+
+.inline-quick-add-priority-options {
+	display: flex;
+	flex-direction: column;
+	gap: .125rem;
+	margin: 0;
+	padding: 0;
+	list-style: none;
+}
+
+.inline-quick-add-priority-option {
+	inline-size: 100%;
+	padding: .5rem .75rem;
+	border: 0;
+	border-radius: $radius;
+	background: transparent;
+	color: var(--text);
+	text-align: start;
+	font-size: .9rem;
+	cursor: pointer;
+
+	&:hover {
+		background: var(--primary-light);
+		color: var(--primary-dark);
+	}
+
+	&.is-active {
+		background: var(--primary-light);
+		color: var(--primary-dark);
+		font-weight: 600;
+	}
+}
+
+.inline-quick-add-percent-done {
+	display: flex;
+	align-items: center;
+	gap: .75rem;
+	padding: .5rem .25rem;
+
+	&__slider {
+		flex: 1;
+		accent-color: var(--primary);
+	}
+
+	&__label {
+		min-inline-size: 3rem;
+		text-align: end;
+		font-weight: 600;
+		font-size: .9rem;
+	}
+}
+
+.inline-quick-add-popup--picker {
+	inline-size: min(18rem, calc(100vw - 2rem));
+
+	:deep(.color-picker-container) {
+		justify-content: start;
+	}
+
+	:deep(.popup) {
+		inset-inline-start: 0 !important;
+		inset-inline-end: auto !important;
+		inline-size: 100%;
+	}
+
+	:deep(.reminder-options-popup) {
+		inline-size: 100% !important;
+		max-inline-size: 100%;
+	}
+
+	:deep(.reminder-options-popup .datepicker-inline) {
+		flex-direction: row;
+		gap: .75rem;
+		align-items: stretch;
+	}
+
+	:deep(.reminder-options-popup .datepicker-inline__shortcuts) {
+		display: flex;
+		flex-direction: column;
+		flex-shrink: 0;
+	}
+
+	:deep(.reminder-options-popup .datepicker-inline__shortcuts .datepicker__quick-select-date) {
+		flex: 1 1 auto;
+		block-size: auto;
+	}
+
+	:deep(.reminder-options-popup .flatpickr-container) {
+		flex: 0 1 auto;
+	}
+
+	:deep(.reminder-options-popup .flatpickr-container > input) {
+		display: none;
+	}
+
+	@media (width <= 520px) {
+		:deep(.reminder-options-popup .datepicker-inline) {
+			flex-direction: column;
+		}
+	}
+}
+
+.inline-quick-add-popup--date {
+	display: flex;
+	flex-direction: column;
+	max-inline-size: calc(100vw - 1rem);
+}
+
+.inline-quick-add-popup--date :deep(.datepicker-inline) {
+	flex-direction: row;
+	gap: .75rem;
+	align-items: stretch;
+}
+
+.inline-quick-add-popup--date :deep(.datepicker-inline__shortcuts) {
+	display: flex;
+	flex-direction: column;
+	flex-shrink: 0;
+}
+
+.inline-quick-add-popup--date :deep(.datepicker-inline__shortcuts .datepicker__quick-select-date) {
+	flex: 1 1 auto;
+	block-size: auto;
+}
+
+.inline-quick-add-popup--date :deep(.flatpickr-container) {
+	flex: 0 1 auto;
+}
+
+.inline-quick-add-popup--date :deep(.flatpickr-container > input) {
+	display: none;
+}
+
+.inline-quick-add-popup__confirm {
+	inline-size: 100%;
+	margin-block-start: .5rem;
+}
+
+@media (width <= 520px) {
+	.inline-quick-add-popup--date :deep(.datepicker-inline) {
+		flex-direction: column;
+	}
+}
+</style>

--- a/frontend/src/components/project/views/ProjectKanban.vue
+++ b/frontend/src/components/project/views/ProjectKanban.vue
@@ -147,6 +147,71 @@
 									</Dropdown>
 								</div>
 
+								<div
+									v-if="canCreateTasks"
+									class="bucket-top"
+								>
+									<div
+										v-if="showNewTaskInput === bucket.id"
+										class="field add-task-inline"
+										:class="{'has-task-color': inlineFieldsRef?.taskColor, 'has-light-text': inlineFieldsRef?.taskColor && !colorIsDark(inlineFieldsRef.taskColor)}"
+										:style="inlineFieldsRef?.taskColor ? {'--task-color': inlineFieldsRef.taskColor} : undefined"
+										@focusout="handleAddTaskFocusOut($event, bucket.id)"
+									>
+										<div
+											class="control add-task-inline__control"
+											:class="{'is-loading': loading || taskLoading}"
+										>
+											<input
+												v-model="newTaskText"
+												v-focus.always
+												class="input"
+												:disabled="loading || taskLoading || undefined"
+												:placeholder="$t('project.kanban.addTaskPlaceholder')"
+												type="text"
+												@focusin="() => newTaskInputFocused = true"
+												@keyup.enter="addTaskToBucket(bucket.id)"
+												@keyup.esc="toggleShowNewTaskInput(bucket.id)"
+											>
+											<button
+												v-if="newTaskText.trim() !== ''"
+												type="button"
+												class="add-task-inline__submit"
+												:disabled="loading || taskLoading || undefined"
+												:title="$t('misc.save')"
+												@click="addTaskToBucket(bucket.id)"
+											>
+												<Icon icon="check" />
+											</button>
+										</div>
+										<p
+											v-if="newTaskError[bucket.id] && newTaskText === ''"
+											class="help is-danger"
+										>
+											{{ $t('project.create.addTitleRequired') }}
+										</p>
+										<InlineQuickAddFields
+											ref="inlineFieldsRef"
+											:project-id="projectIdWithFallback"
+											:disabled="loading || taskLoading"
+										/>
+									</div>
+									<XButton
+										v-else
+										v-tooltip="bucket.limit > 0 && bucket.count >= bucket.limit ? $t('project.kanban.bucketLimitReached') : ''"
+										class="is-fullwidth has-text-centered"
+										:shadow="false"
+										icon="plus"
+										variant="secondary"
+										:disabled="bucket.limit > 0 && bucket.count >= bucket.limit"
+										@click="toggleShowNewTaskInput(bucket.id)"
+									>
+										{{
+											bucket.tasks.length === 0 ? $t('project.kanban.addTask') : $t('project.kanban.addAnotherTask')
+										}}
+									</XButton>
+								</div>
+
 								<draggable
 									v-bind="DRAG_OPTIONS"
 									:handle="taskDragHandle"
@@ -162,56 +227,6 @@
 									@start="handleTaskDragStart"
 									@end="updateTaskPosition"
 								>
-									<template #footer>
-										<div
-											v-if="canCreateTasks"
-											class="bucket-footer"
-										>
-											<div
-												v-if="showNewTaskInput === bucket.id"
-												class="field"
-											>
-												<div
-													class="control"
-													:class="{'is-loading': loading || taskLoading}"
-												>
-													<input
-														v-model="newTaskText"
-														v-focus.always
-														class="input"
-														:disabled="loading || taskLoading || undefined"
-														:placeholder="$t('project.kanban.addTaskPlaceholder')"
-														type="text"
-														@focusout="toggleShowNewTaskInput(bucket.id)"
-														@focusin="() => newTaskInputFocused = true"
-														@keyup.enter="addTaskToBucket(bucket.id)"
-														@keyup.esc="toggleShowNewTaskInput(bucket.id)"
-													>
-												</div>
-												<p
-													v-if="newTaskError[bucket.id] && newTaskText === ''"
-													class="help is-danger"
-												>
-													{{ $t('project.create.addTitleRequired') }}
-												</p>
-											</div>
-											<XButton
-												v-else
-												v-tooltip="bucket.limit > 0 && bucket.count >= bucket.limit ? $t('project.kanban.bucketLimitReached') : ''"
-												class="is-fullwidth has-text-centered"
-												:shadow="false"
-												icon="plus"
-												variant="secondary"
-												:disabled="bucket.limit > 0 && bucket.count >= bucket.limit"
-												@click="toggleShowNewTaskInput(bucket.id)"
-											>
-												{{
-													bucket.tasks.length === 0 ? $t('project.kanban.addTask') : $t('project.kanban.addAnotherTask')
-												}}
-											</XButton>
-										</div>
-									</template>
-
 									<template #item="{element: task}">
 										<div
 											class="task-item"
@@ -298,11 +313,11 @@ import draggable from 'zhyswan-vuedraggable'
 import {klona} from 'klona/lite'
 
 import {PERMISSIONS as Permissions} from '@/constants/permissions'
+import type {Priority} from '@/constants/priorities'
 import BucketModel from '@/models/bucket'
 
 import type {IBucket} from '@/modelTypes/IBucket'
 import type {ITask} from '@/modelTypes/ITask'
-
 import {useBaseStore} from '@/stores/base'
 import {useTaskStore} from '@/stores/tasks'
 import {useKanbanStore} from '@/stores/kanban'
@@ -311,8 +326,16 @@ import {useAuthStore} from '@/stores/auth'
 import ProjectWrapper from '@/components/project/ProjectWrapper.vue'
 import FilterPopup from '@/components/project/partials/FilterPopup.vue'
 import KanbanCard from '@/components/tasks/partials/KanbanCard.vue'
+import InlineQuickAddFields from '@/components/project/views/InlineQuickAddFields.vue'
+import {colorIsDark} from '@/helpers/color/colorIsDark'
 import Dropdown from '@/components/misc/Dropdown.vue'
 import DropdownItem from '@/components/misc/DropdownItem.vue'
+
+const props = defineProps<{
+	isLoadingProject: boolean,
+	projectId: number,
+	viewId: IProjectView['id'],
+}>()
 
 import {
 	type CollapsedBuckets,
@@ -334,12 +357,6 @@ import ProjectViewService from '@/services/projectViews'
 import ProjectViewModel from '@/models/projectView'
 import TaskBucketService from '@/services/taskBucket'
 import TaskBucketModel from '@/models/taskBucket'
-
-const props = defineProps<{
-	isLoadingProject: boolean,
-	projectId: number,
-	viewId: IProjectView['id'],
-}>()
 
 const projectId = toRef(props, 'projectId')
 
@@ -388,6 +405,8 @@ const newBucketTitle = ref('')
 const showNewBucketInput = ref(false)
 const newTaskError = ref<{ [id: IBucket['id']]: boolean }>({})
 const newTaskInputFocused = ref(false)
+
+const inlineFieldsRef = ref<InstanceType<typeof InlineQuickAddFields> | null>(null)
 
 const showSetLimitInput = ref(false)
 const collapsedBuckets = ref<CollapsedBuckets>({})
@@ -657,10 +676,35 @@ function toggleShowNewTaskInput(bucketId: IBucket['id']) {
 	if (loading.value || taskLoading.value) {
 		return
 	}
-	showNewTaskInput.value = showNewTaskInput.value === bucketId 
+	showNewTaskInput.value = showNewTaskInput.value === bucketId
 		? null
 		: bucketId
 	newTaskInputFocused.value = false
+	// Whether the user is opening or closing the form, start from a clean
+	// slate. This also fixes a stale-title bug where dismissing the form
+	// (by clicking outside) left newTaskText around, so the next opening
+	// pre-filled the old draft.
+	newTaskText.value = ''
+	newTaskError.value[bucketId] = false
+	inlineFieldsRef.value?.reset()
+}
+
+function handleAddTaskFocusOut(event: FocusEvent, bucketId: IBucket['id']) {
+	// Inline quick-add popups are teleported to <body>, so focus legitimately
+	// moves outside this container while one is open. Treat the popup as part
+	// of the add-task workflow and keep the form alive until the popup closes.
+	if (inlineFieldsRef.value?.isPopupOpen) {
+		return
+	}
+	const container = event.currentTarget as HTMLElement | null
+	const nextFocus = event.relatedTarget as HTMLElement | null
+	if (container && nextFocus && container.contains(nextFocus)) {
+		return
+	}
+	if (nextFocus && inlineFieldsRef.value?.containsElement(nextFocus)) {
+		return
+	}
+	toggleShowNewTaskInput(bucketId)
 }
 
 async function addTaskToBucket(bucketId: IBucket['id']) {
@@ -670,18 +714,49 @@ async function addTaskToBucket(bucketId: IBucket['id']) {
 	}
 	newTaskError.value[bucketId] = false
 
+	// Capture inline field values before resetting so the follow-up attach
+	// calls aren't affected by the UI state being cleared.
+	const fieldValues = inlineFieldsRef.value?.getFieldValues()
+
 	const task = await taskStore.createNewTask({
 		title: newTaskText.value,
 		bucketId,
 		projectId: projectIdWithFallback.value,
+		dueDate: fieldValues?.dueDate,
+		startDate: fieldValues?.startDate,
+		endDate: fieldValues?.endDate,
+		priority: fieldValues?.priority as Priority | undefined,
+		hexColor: fieldValues?.hexColor,
+		percentDone: fieldValues?.percentDone,
 	})
-	newTaskText.value = ''
+
+	const capturedAssignees = fieldValues?.assignees ?? []
+	const capturedLabels = fieldValues?.labels ?? []
+	const capturedReminders = fieldValues?.reminders ?? []
 	kanbanStore.addTaskToBucket(task)
 	scrollTaskContainerToTop(bucketId)
-
-	const bucket = kanbanStore.getBucketById(bucketId)
-	if (bucket && bucket.limit && bucket.count >= bucket.limit) {
+	// Close the add-task form after a successful submission. Upstream keeps
+	// it open for rapid entry; we intentionally diverge because a new task
+	// popping into the bucket while the user is still looking at the form
+	// was jarring — each submit should be an explicit action.
+	// Also clears newTaskText and the inline quick-add fields via the
+	// shared reset path.
+	if (showNewTaskInput.value === bucketId) {
 		toggleShowNewTaskInput(bucketId)
+	}
+
+	// Attach multi-valued fields that the create endpoint doesn't accept
+	// directly. Sequential to keep ordering stable and errors isolated; the
+	// task itself is already saved, so a failed extra attach should not
+	// block the rest.
+	for (const user of capturedAssignees) {
+		await taskStore.addAssignee({user, taskId: task.id})
+	}
+	for (const label of capturedLabels) {
+		await taskStore.addLabel({label, taskId: task.id})
+	}
+	if (capturedReminders.length > 0) {
+		await taskStore.update({...task, reminders: capturedReminders})
 	}
 }
 
@@ -922,6 +997,441 @@ function unCollapseBucket(bucket: IBucket) {
 	--loader-border-color: var(--grey-500);
   }
 }
+
+.add-task-inline {
+	padding: .5rem;
+	background: var(--grey-200);
+	border-radius: $radius;
+	transition: background-color $transition;
+
+	&.has-task-color {
+		background-color: var(--task-color);
+
+		.inline-quick-add-chip,
+		.inline-quick-add-chip__icon,
+		.add-task-inline__submit {
+			color: rgba(0, 0, 0, .7);
+		}
+
+		.inline-quick-add-chip.is-set {
+			background: rgba(255, 255, 255, .35);
+			color: rgba(0, 0, 0, .8);
+		}
+
+		:deep(.input) {
+			color: rgba(0, 0, 0, .85);
+
+			&::placeholder {
+				color: rgba(0, 0, 0, .45);
+			}
+		}
+	}
+
+	&.has-light-text {
+		.inline-quick-add-chip,
+		.inline-quick-add-chip__icon,
+		.add-task-inline__submit {
+			color: rgba(255, 255, 255, .85);
+		}
+
+		.inline-quick-add-chip.is-set {
+			background: rgba(255, 255, 255, .2);
+			color: #ffffff;
+		}
+
+		:deep(.input) {
+			color: #ffffff;
+
+			&::placeholder {
+				color: rgba(255, 255, 255, .6);
+			}
+		}
+	}
+
+	// Let the title input blend into the container rather than stand on its own.
+	:deep(.input) {
+		background: transparent;
+		border-color: transparent;
+		box-shadow: none;
+		// Reserve space on the right for the inline submit button.
+		padding-inline-end: 2.25rem;
+
+		&:focus {
+			border-color: var(--primary);
+		}
+	}
+}
+
+.add-task-inline__control {
+	position: relative;
+}
+
+.add-task-inline__submit {
+	position: absolute;
+	inset-block-start: 50%;
+	inset-inline-end: .25rem;
+	transform: translateY(-50%);
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	inline-size: 1.75rem;
+	block-size: 1.75rem;
+	padding: 0;
+	border: 0;
+	border-radius: $radius;
+	background: transparent;
+	color: var(--success);
+	cursor: pointer;
+	transition: background-color $transition, color $transition;
+
+	&:hover:not(:disabled) {
+		background: var(--success-light);
+		color: var(--success-dark);
+	}
+
+	&:disabled {
+		cursor: not-allowed;
+		opacity: .5;
+	}
+}
+
+.inline-quick-add-chip-bar {
+	// Two-column grid with equal-width tracks. Chips stretch to fill their
+	// column so full rows occupy the whole bar (not floating as an island),
+	// and a partial last row lands in column 1 — left-aligned half-width.
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	gap: .375rem;
+	margin-block-start: .5rem;
+}
+
+.inline-quick-add-chip {
+	position: relative;
+	display: inline-flex;
+	align-items: center;
+	gap: .4rem;
+	padding: .3rem .65rem;
+	border: 1px solid transparent;
+	border-radius: $radius;
+	background: transparent;
+	color: var(--grey-700);
+	font-size: .8rem;
+	font-weight: 500;
+	line-height: 1.2;
+	cursor: pointer;
+	transition: background-color $transition, color $transition, border-color $transition, box-shadow $transition;
+
+	&:hover:not(:disabled) {
+		background: var(--white);
+		color: var(--grey-900);
+		box-shadow: 0 1px 3px hsla(var(--grey-900-hsl), .12);
+	}
+
+	&:focus-visible {
+		outline: none;
+		box-shadow: 0 0 0 2px var(--primary-light);
+	}
+
+	&:disabled {
+		cursor: not-allowed;
+		opacity: .5;
+	}
+}
+
+// Semantic icon tint, applied whether the chip is set or not.
+.inline-quick-add-chip__icon {
+	font-size: .85rem;
+
+	&--due {
+		color: var(--danger);
+	}
+
+	&--start {
+		color: var(--success);
+	}
+
+	&--priority {
+		color: var(--warning);
+	}
+
+	&--assignee {
+		color: var(--primary);
+	}
+
+	&--labels {
+		color: var(--primary);
+	}
+
+	&--reminder {
+		color: var(--primary);
+	}
+
+	&--end {
+		color: var(--grey-500);
+	}
+
+	&--color {
+		color: var(--grey-500);
+	}
+
+	&--percent {
+		color: var(--grey-500);
+	}
+}
+
+.inline-quick-add-chip__swatch {
+	display: inline-block;
+	inline-size: .85rem;
+	block-size: .85rem;
+	border-radius: .2rem;
+	border: 1px solid var(--grey-300);
+	flex-shrink: 0;
+}
+
+.inline-quick-add-chip__clear {
+	display: none;
+	align-items: center;
+	justify-content: center;
+	position: absolute;
+	inset-inline-end: 0;
+	inset-block-start: 0;
+	block-size: 100%;
+	padding-inline: .25rem;
+	font-size: .65rem;
+	background: transparent;
+	border-radius: 0 $radius $radius 0;
+	z-index: 1;
+	color: inherit;
+
+	&:hover {
+		color: var(--danger);
+	}
+}
+
+.inline-quick-add-chip:hover .inline-quick-add-chip__clear {
+	display: flex;
+}
+
+// Set state: chip fills with the field's semantic light background and
+// text shifts to the matching dark tone. No border — the color does the work.
+.inline-quick-add-chip--due.is-set {
+	background: var(--danger-light);
+	color: var(--danger-dark);
+}
+
+.inline-quick-add-chip--start.is-set {
+	background: var(--success-light);
+	color: var(--success-dark);
+}
+
+.inline-quick-add-chip--priority.is-set {
+	background: var(--warning-light);
+	color: var(--warning-dark);
+}
+
+.inline-quick-add-chip--assignee.is-set,
+.inline-quick-add-chip--labels.is-set,
+.inline-quick-add-chip--reminder.is-set,
+.inline-quick-add-chip--percent.is-set {
+	background: var(--primary-light);
+	color: var(--primary-dark);
+}
+
+.inline-quick-add-chip--end.is-set {
+	background: var(--success-light);
+	color: var(--success-dark);
+}
+
+.inline-quick-add-chip--color.is-set {
+	background: var(--primary-light);
+	color: var(--primary-dark);
+}
+
+.inline-quick-add-popup {
+	position: fixed;
+	z-index: 50;
+	padding: .5rem;
+	background: var(--white);
+	border: 1px solid var(--grey-200);
+	border-radius: $radius;
+	box-shadow: var(--shadow-md);
+}
+
+// Picker variant hosts assignee/label/reminder/priority components. The
+// default compact width suits assignee, labels and priority. Reminder
+// opts in to the wider variant so its nested two-column date form fits.
+.inline-quick-add-popup--picker.inline-quick-add-popup--wide {
+	inline-size: min(28rem, calc(100vw - 2rem));
+}
+
+// Keep the popup in the DOM but invisible until the clamp has positioned
+// it. Using visibility (not display) preserves getBoundingClientRect so
+// the clamp can measure the real size.
+.inline-quick-add-popup--measuring {
+	visibility: hidden;
+}
+
+.inline-quick-add-priority-options {
+	display: flex;
+	flex-direction: column;
+	gap: .125rem;
+	margin: 0;
+	padding: 0;
+	list-style: none;
+}
+
+.inline-quick-add-priority-option {
+	inline-size: 100%;
+	padding: .5rem .75rem;
+	border: 0;
+	border-radius: $radius;
+	background: transparent;
+	color: var(--text);
+	text-align: start;
+	font-size: .9rem;
+	cursor: pointer;
+
+	&:hover {
+		background: var(--primary-light);
+		color: var(--primary-dark);
+	}
+
+	&.is-active {
+		background: var(--primary-light);
+		color: var(--primary-dark);
+		font-weight: 600;
+	}
+}
+
+.inline-quick-add-percent-done {
+	display: flex;
+	align-items: center;
+	gap: .75rem;
+	padding: .5rem .25rem;
+
+	&__slider {
+		flex: 1;
+		accent-color: var(--primary);
+	}
+
+	&__label {
+		min-inline-size: 3rem;
+		text-align: end;
+		font-weight: 600;
+		font-size: .9rem;
+	}
+}
+
+.inline-quick-add-popup--picker {
+	inline-size: min(18rem, calc(100vw - 2rem));
+
+	:deep(.color-picker-container) {
+		justify-content: start;
+	}
+
+	// The nested reminder Popup's .popup container defaults to natural
+	// inline position (right-of-trigger), which can push the date form
+	// past the outer popup's right edge. Pin it to the outer popup's
+	// left edge instead so it stays within our already-clamped bounds.
+	// !important is needed because Popup.vue's scoped .popup style wins
+	// the specificity tie otherwise.
+	:deep(.popup) {
+		inset-inline-start: 0 !important;
+		inset-inline-end: auto !important;
+		inline-size: 100%;
+	}
+
+	// Constrain the nested card to the outer popup's content width so it
+	// cannot overflow horizontally. The card's own scoped 310px width
+	// (from ReminderDetail) is overridden here.
+	:deep(.reminder-options-popup) {
+		inline-size: 100% !important;
+		max-inline-size: 100%;
+	}
+
+	:deep(.reminder-options-popup .datepicker-inline) {
+		flex-direction: row;
+		gap: .75rem;
+		align-items: stretch;
+	}
+
+	:deep(.reminder-options-popup .datepicker-inline__shortcuts) {
+		display: flex;
+		flex-direction: column;
+		flex-shrink: 0;
+	}
+
+	:deep(.reminder-options-popup .datepicker-inline__shortcuts .datepicker__quick-select-date) {
+		flex: 1 1 auto;
+		block-size: auto;
+	}
+
+	:deep(.reminder-options-popup .flatpickr-container) {
+		flex: 0 1 auto;
+	}
+
+	:deep(.reminder-options-popup .flatpickr-container > input) {
+		display: none;
+	}
+
+	@media (width <= 520px) {
+		:deep(.reminder-options-popup .datepicker-inline) {
+			flex-direction: column;
+		}
+	}
+}
+
+.inline-quick-add-popup--date {
+	display: flex;
+	flex-direction: column;
+	max-inline-size: calc(100vw - 1rem);
+}
+
+// Two-column layout: shortcuts (auto width) on the left, calendar on the
+// right. flex: 1 on each shortcut makes them share the full calendar
+// height, so the shortcut column stretches exactly as tall as the
+// calendar+time regardless of whether 4, 5 or 6 shortcuts are rendered.
+.inline-quick-add-popup--date :deep(.datepicker-inline) {
+	flex-direction: row;
+	gap: .75rem;
+	align-items: stretch;
+}
+
+.inline-quick-add-popup--date :deep(.datepicker-inline__shortcuts) {
+	display: flex;
+	flex-direction: column;
+	flex-shrink: 0;
+}
+
+.inline-quick-add-popup--date :deep(.datepicker-inline__shortcuts .datepicker__quick-select-date) {
+	flex: 1 1 auto;
+	block-size: auto;
+}
+
+.inline-quick-add-popup--date :deep(.flatpickr-container) {
+	flex: 0 1 auto;
+}
+
+// Hide only flatpickr's top-level text input (duplicates the picker
+// value as plain text). Time hour/minute inputs live inside
+// .flatpickr-calendar and must stay visible — hence the direct-child
+// selector.
+.inline-quick-add-popup--date :deep(.flatpickr-container > input) {
+	display: none;
+}
+
+.inline-quick-add-popup__confirm {
+	inline-size: 100%;
+	margin-block-start: .5rem;
+}
+
+// Fall back to vertical (original) layout when the viewport is too narrow
+// to reasonably fit two columns.
+@media (width <= 520px) {
+	.inline-quick-add-popup--date :deep(.datepicker-inline) {
+		flex-direction: column;
+	}
+}
 </style>
 
 
@@ -1052,7 +1562,7 @@ $filter-container-height: '1rem - #{$switch-view-height}';
 			margin-inline-end: calc((#{$bucket-width} - #{$bucket-header-height} - #{$bucket-right-margin}) * -1);
 			cursor: pointer;
 
-			.tasks, .bucket-footer {
+			.tasks, .bucket-top {
 				display: none;
 			}
 		}
@@ -1091,15 +1601,13 @@ $filter-container-height: '1rem - #{$switch-view-height}';
 		padding: .5rem;
 	}
 
-	.bucket-footer {
+	.bucket-top {
 		position: sticky;
-		inset-block-end: 0;
+		inset-block-start: 0;
+		z-index: 2;
 		block-size: min-content;
 		padding: .5rem;
 		background-color: var(--grey-100);
-		border-end-start-radius: $radius;
-		border-end-end-radius: $radius;
-		transform: none;
 
 		.button {
 			background-color: transparent;

--- a/frontend/src/components/tasks/partials/EditAssignees.vue
+++ b/frontend/src/components/tasks/partials/EditAssignees.vue
@@ -49,6 +49,9 @@ import AssigneeList from '@/components/tasks/partials/AssigneeList.vue'
 
 const props = withDefaults(defineProps<{
 	modelValue: IUser[] | undefined,
+	// Pass 0 to use this picker in pre-creation contexts (e.g. inline
+	// quick-add). Assignees are then emitted via v-model only — the caller
+	// is responsible for persisting them once the task exists.
 	taskId: number,
 	projectId: number,
 	disabled?: boolean,
@@ -84,6 +87,12 @@ async function addAssignee(user: IUser) {
 		return
 	}
 
+	if (props.taskId === 0) {
+		// taskId 0 means the task doesn't exist yet; skip the API call and let the caller persist on creation.
+		emit('update:modelValue', assignees.value)
+		return
+	}
+
 	try {
 		nextTick(() => isAdding = true)
 
@@ -96,14 +105,19 @@ async function addAssignee(user: IUser) {
 }
 
 async function removeAssignee(user: IUser) {
-	await taskStore.removeAssignee({user: user, taskId: props.taskId})
+	if (props.taskId !== 0) {
+		await taskStore.removeAssignee({user: user, taskId: props.taskId})
+	}
 
 	// Remove the assignee from the project
 	const idx = assignees.value.findIndex(a => a.id === user.id)
 	if (idx !== -1) {
 		assignees.value.splice(idx, 1)
 	}
-	success({message: t('task.assignee.unassignSuccess')})
+	emit('update:modelValue', assignees.value)
+	if (props.taskId !== 0) {
+		success({message: t('task.assignee.unassignSuccess')})
+	}
 }
 
 async function findUser(query: string) {

--- a/frontend/src/components/tasks/partials/KanbanCard.vue
+++ b/frontend/src/components/tasks/partials/KanbanCard.vue
@@ -46,6 +46,7 @@
 					v-if="task.dueDate > 0"
 					v-tooltip="formatDateLong(task.dueDate)"
 					class="due-date"
+					@click.stop="openFieldPopup('dueDate', $event)"
 				>
 					<span class="icon">
 						<Icon :icon="['far', 'calendar-alt']" />
@@ -71,11 +72,15 @@
 				:value="task.percentDone * 100"
 			/>
 			<div class="footer">
-				<Labels :labels="task.labels" />
+				<Labels
+					:labels="task.labels"
+					@click.stop="openFieldPopup('labels', $event)"
+				/>
 				<PriorityLabel
 					:priority="task.priority"
 					:done="task.done"
 					class="is-inline-flex is-align-items-center"
+					@click.stop="openFieldPopup('priority', $event)"
 				/>
 				<span
 					v-if="task.attachments.length > 0"
@@ -103,18 +108,45 @@
 					v-if="task.assignees.length > 0"
 					:assignees="task.assignees"
 					:avatar-size="24"
+					@click.stop="openFieldPopup('assignee', $event)"
 				/>
 				<ChecklistSummary
 					:task="task"
 					class="checklist"
 				/>
 			</div>
+			<div
+				v-if="!task.done"
+				class="kanban-card__quick-edit"
+				@click.stop
+				@mouseenter="onQuickEditMouseEnter"
+				@mouseleave="onQuickEditMouseLeave"
+			>
+				<div
+					class="kanban-card__inline-fields"
+					:class="{'is-open': isExpanded}"
+				>
+					<InlineQuickAddFields
+						ref="inlineFieldsRef"
+						:task="task"
+						:project-id="projectId"
+						:disabled="false"
+					/>
+				</div>
+				<button
+					type="button"
+					class="kanban-card__toggle"
+					@click="isExpanded = !isExpanded"
+				>
+					<Icon :icon="isExpanded ? 'times' : 'plus'" />
+				</button>
+			</div>
 		</div>
 	</div>
 </template>
 
 <script lang="ts" setup>
-import {computed, ref, watch} from 'vue'
+import {computed, onBeforeUnmount, ref, watch, type ComponentInstance} from 'vue'
 import {useRouter} from 'vue-router'
 
 import {useGlobalNow} from '@/composables/useGlobalNow'
@@ -136,6 +168,7 @@ import {formatDateLong, formatDisplayDate, formatISO} from '@/helpers/time/forma
 import {colorIsDark} from '@/helpers/color/colorIsDark'
 import {useTaskStore} from '@/stores/tasks'
 import AssigneeList from '@/components/tasks/partials/AssigneeList.vue'
+import InlineQuickAddFields from '@/components/project/views/InlineQuickAddFields.vue'
 import {playPopSound} from '@/helpers/playPop'
 import {isEditorContentEmpty} from '@/helpers/editorContentEmpty'
 import {useProjectStore} from '@/stores/projects'
@@ -156,6 +189,29 @@ const emit = defineEmits<{
 const router = useRouter()
 
 const loadingInternal = ref(false)
+const isExpanded = ref(false)
+const inlineFieldsRef = ref<ComponentInstance<typeof InlineQuickAddFields> | null>(null)
+const hasPopupOpen = computed(() => inlineFieldsRef.value?.isPopupOpen ?? false)
+
+let collapseTimer: ReturnType<typeof setTimeout> | null = null
+
+function scheduleCollapse() {
+	if (collapseTimer) clearTimeout(collapseTimer)
+	collapseTimer = setTimeout(() => {
+		if (!hasPopupOpen.value) {
+			isExpanded.value = false
+		}
+	}, 650)
+}
+
+function cancelCollapse() {
+	if (collapseTimer) {
+		clearTimeout(collapseTimer)
+		collapseTimer = null
+	}
+}
+
+onBeforeUnmount(() => cancelCollapse())
 
 const color = computed(() => getHexColor(props.task.hexColor))
 
@@ -202,6 +258,22 @@ async function toggleTaskDone(task: ITask) {
 	} finally {
 		loadingInternal.value = false
 	}
+}
+
+function onQuickEditMouseEnter() {
+	cancelCollapse()
+}
+
+function onQuickEditMouseLeave() {
+	if (isExpanded.value) {
+		scheduleCollapse()
+	}
+}
+
+function openFieldPopup(field: string, event: MouseEvent) {
+	if (props.task.done) return
+	const el = (event.currentTarget ?? event.target) as HTMLElement
+	inlineFieldsRef.value?.openForField(field, el)
 }
 
 function openTaskDetail() {
@@ -295,6 +367,7 @@ $task-background: var(--white);
 		align-items: center;
 		gap: .25rem;
 		margin-block-start: .25rem;
+		min-block-size: 1.5rem;
 
 		:deep(.checklist-summary) {
 			padding-inline-start: 0;
@@ -402,5 +475,50 @@ $task-background: var(--white);
 	background: var(--grey-100);
 	border-radius: $radius;
 	padding: 0.25rem;
+}
+
+.kanban-card__quick-edit {
+	position: relative;
+}
+
+.kanban-card__toggle {
+	position: absolute;
+	inset-inline-end: -.5rem;
+	inset-block-start: -.65rem;
+	display: none;
+	align-items: center;
+	justify-content: center;
+	inline-size: 1.75rem;
+	block-size: 1.75rem;
+	border: 0;
+	border-radius: $radius;
+	background: transparent;
+	color: var(--grey-400);
+	font-size: .7rem;
+	cursor: pointer;
+
+	&:hover {
+		color: var(--grey-700);
+		background: var(--grey-100);
+	}
+}
+
+.task:hover .kanban-card__toggle,
+.kanban-card__inline-fields.is-open + .kanban-card__toggle {
+	display: flex;
+}
+
+.kanban-card__inline-fields {
+	display: grid;
+	grid-template-rows: 0fr;
+	transition: grid-template-rows .2s ease;
+
+	> :deep(*) {
+		overflow: hidden;
+	}
+
+	&.is-open {
+		grid-template-rows: 1fr;
+	}
 }
 </style>

--- a/frontend/src/i18n/lang/en.json
+++ b/frontend/src/i18n/lang/en.json
@@ -158,6 +158,22 @@
         "quickAddDefaultReminders": "Default reminders for quick add",
         "quickAddDefaultRemindersDescription": "These reminders will be added automatically to every task created via quick add magic that has a due date.",
         "quickAddDefaultRemindersHint": "Add one or more reminders relative to the task's due date. Leave empty to disable.",
+        "inlineQuickAddFields": {
+          "title": "Inline fields when adding a task",
+          "description": "Selected fields appear inline in the add-task form so you can set them without opening the full task editor.",
+          "field": {
+            "assignee": "Assignee",
+            "dueDate": "Due date",
+            "startDate": "Start date",
+            "priority": "Priority",
+            "labels": "Labels",
+            "reminder": "Reminder",
+            "color": "Color",
+            "percentDone": "Progress",
+            "endDate": "End date"
+          },
+          "addField": "Add field"
+        },
         "filterUsedOnOverview": "Saved filter used on the overview page",
         "showLastViewed": "Show last viewed projects on the overview page",
         "minimumPriority": "Minimum visible task priority",

--- a/frontend/src/i18n/lang/en.json
+++ b/frontend/src/i18n/lang/en.json
@@ -1012,6 +1012,9 @@
     },
     "attributes": {
       "assignees": "Assignees",
+      "assigneesN": "{count} assignee | {count} assignees",
+      "labelsN": "{count} label | {count} labels",
+      "remindersN": "{count} reminder | {count} reminders",
       "color": "Color",
       "created": "Created",
       "createdBy": "Created By",

--- a/frontend/src/modelTypes/IUserSettings.ts
+++ b/frontend/src/modelTypes/IUserSettings.ts
@@ -10,6 +10,22 @@ import type {DateDisplay} from '@/constants/dateDisplay'
 import type {TimeFormat} from '@/constants/timeFormat'
 import type {IRelationKind} from '@/types/IRelationKind'
 
+export const INLINE_QUICK_ADD_FIELDS = [
+	'assignee',
+	'dueDate',
+	'startDate',
+	'endDate',
+	'priority',
+	'labels',
+	'reminder',
+	'color',
+	'percentDone',
+] as const
+
+export type InlineQuickAddField = typeof INLINE_QUICK_ADD_FIELDS[number]
+
+export const DEFAULT_INLINE_QUICK_ADD_FIELDS: InlineQuickAddField[] = ['assignee', 'dueDate']
+
 export interface IFrontendSettings {
 	playSoundWhenDone: boolean
 	quickAddMagicMode: PrefixMode
@@ -28,6 +44,7 @@ export interface IFrontendSettings {
 	commentSortOrder: 'asc' | 'desc'
 	desktopQuickEntryShortcut: string
 	quickAddDefaultReminders: ITaskReminder[]
+	inlineQuickAddFields: InlineQuickAddField[]
 }
 
 export interface IExtraSettingsLink {

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -18,6 +18,7 @@ import {
 } from '@/helpers/redirectToProvider'
 import {AUTH_TYPES, type IUser} from '@/modelTypes/IUser'
 import type {IUserSettings} from '@/modelTypes/IUserSettings'
+import {DEFAULT_INLINE_QUICK_ADD_FIELDS} from '@/modelTypes/IUserSettings'
 import router from '@/router'
 import {useConfigStore} from '@/stores/config'
 import UserSettingsModel from '@/models/userSettings'
@@ -144,6 +145,7 @@ export const useAuthStore = defineStore('auth', () => {
 				sidebarWidth: null,
 				commentSortOrder: 'asc',
 				desktopQuickEntryShortcut: 'CmdOrCtrl+Shift+A',
+				inlineQuickAddFields: DEFAULT_INLINE_QUICK_ADD_FIELDS,
 				...newSettings.frontendSettings,
 			},
 		})

--- a/frontend/src/stores/tasks.ts
+++ b/frontend/src/stores/tasks.ts
@@ -447,7 +447,13 @@ export const useTaskStore = defineStore('task', () => {
 		projectId,
 		position,
 		index,
-	} : 
+		dueDate: explicitDueDate,
+		startDate: explicitStartDate,
+		endDate: explicitEndDate,
+		priority: explicitPriority,
+		hexColor: explicitHexColor,
+		percentDone: explicitPercentDone,
+	} :
 		Partial<ITask>,
 	) {
 		const cancel = setModuleLoading(setIsLoading)
@@ -463,17 +469,23 @@ export const useTaskStore = defineStore('task', () => {
 					bucketId,
 					position,
 					index,
+					dueDate: explicitDueDate,
+					startDate: explicitStartDate,
+					endDate: explicitEndDate,
+					priority: explicitPriority,
+					hexColor: explicitHexColor,
+					percentDone: explicitPercentDone,
 				}))
 			} finally {
 				cancel()
 			}
 		}
-	
+
 		const foundProjectId = await findProjectId({
 			project: parsedTask.project,
 			projectId: projectId || 0,
 		})
-		
+
 		if(foundProjectId === null || foundProjectId === 0) {
 			cancel()
 			throw new Error('NO_PROJECT')
@@ -491,17 +503,26 @@ export const useTaskStore = defineStore('task', () => {
 		}
 
 		// I don't know why, but it all goes up in flames when I just pass in the date normally.
-		const dueDate = parsedTask.date !== null ? new Date(parsedTask.date).toISOString() : null
-	
+		const parsedDueDate = parsedTask.date !== null ? new Date(parsedTask.date).toISOString() : null
+		// Explicit values from the caller override QuickAddMagic parsing.
+		const dueDate = explicitDueDate ? new Date(explicitDueDate).toISOString() : parsedDueDate
+		const startDate = explicitStartDate ? new Date(explicitStartDate).toISOString() : null
+		const endDate = explicitEndDate ? new Date(explicitEndDate).toISOString() : null
+		const priority = explicitPriority ?? parsedTask.priority
+
 		const task = new TaskModel({
 			title: cleanedTitle,
 			projectId: foundProjectId,
 			dueDate,
-			priority: parsedTask.priority,
+			startDate,
+			endDate,
+			priority,
 			assignees,
 			bucketId: bucketId || 0,
 			position,
 			index,
+			hexColor: explicitHexColor,
+			percentDone: explicitPercentDone,
 		})
 		task.repeatAfter = parsedTask.repeats
 		task.reminders = buildDefaultRemindersForQuickAdd(

--- a/frontend/src/views/user/settings/General.vue
+++ b/frontend/src/views/user/settings/General.vue
@@ -195,6 +195,60 @@
 					:allow-absolute="false"
 				/>
 			</div>
+			<div class="field">
+				<label class="label">{{ $t('user.settings.general.inlineQuickAddFields.title') }}</label>
+				<p class="help">
+					{{ $t('user.settings.general.inlineQuickAddFields.description') }}
+				</p>
+				<draggable
+					v-model="enabledInlineFields"
+					item-key="field"
+					handle=".handle"
+					:animation="150"
+					ghost-class="sortable-ghost-hidden"
+					class="inline-quick-add-fields-list"
+					@end="syncInlineFieldsToSettings"
+				>
+					<template #item="{element}">
+						<div class="inline-quick-add-field-row">
+							<span class="icon handle">
+								<Icon icon="grip-lines" />
+							</span>
+							<span class="inline-quick-add-field-row__label">
+								{{ $t(`user.settings.general.inlineQuickAddFields.field.${element.field}`) }}
+							</span>
+							<button
+								type="button"
+								class="inline-quick-add-field-row__remove"
+								@click="removeInlineField(element.field)"
+							>
+								<Icon icon="times" />
+							</button>
+						</div>
+					</template>
+				</draggable>
+				<Dropdown
+					v-if="availableInlineFields.length > 0"
+					class="inline-quick-add-field-adder"
+				>
+					<template #trigger="{toggleOpen}">
+						<BaseButton
+							class="inline-quick-add-field-adder__toggle"
+							@click="toggleOpen"
+						>
+							<Icon icon="plus" />
+							<span>{{ $t('user.settings.general.inlineQuickAddFields.addField') }}</span>
+						</BaseButton>
+					</template>
+					<DropdownItem
+						v-for="field in availableInlineFields"
+						:key="field"
+						@click="addInlineField(field)"
+					>
+						{{ $t(`user.settings.general.inlineQuickAddFields.field.${field}`) }}
+					</DropdownItem>
+				</Dropdown>
+			</div>
 			<FormField
 				:label="$t('user.settings.general.defaultTaskRelationType')"
 				layout="two-col"
@@ -297,6 +351,10 @@ import FormField from '@/components/input/FormField.vue'
 import FormInput from '@/components/input/FormInput.vue'
 import FormSelect from '@/components/input/FormSelect.vue'
 import FormCheckbox from '@/components/input/FormCheckbox.vue'
+import draggable from 'zhyswan-vuedraggable'
+import Dropdown from '@/components/misc/Dropdown.vue'
+import DropdownItem from '@/components/misc/DropdownItem.vue'
+import BaseButton from '@/components/base/BaseButton.vue'
 
 import {SUPPORTED_LOCALES} from '@/i18n'
 import {AuthenticatedHTTPFactory} from '@/helpers/fetcher'
@@ -306,7 +364,8 @@ import {useTitle} from '@/composables/useTitle'
 
 import {useProjectStore} from '@/stores/projects'
 import {useAuthStore} from '@/stores/auth'
-import type {IUserSettings} from '@/modelTypes/IUserSettings'
+import type {IUserSettings, InlineQuickAddField} from '@/modelTypes/IUserSettings'
+import {INLINE_QUICK_ADD_FIELDS, DEFAULT_INLINE_QUICK_ADD_FIELDS} from '@/modelTypes/IUserSettings'
 import {isSavedFilter} from '@/services/savedFilter'
 import {DEFAULT_PROJECT_VIEW_SETTINGS} from '@/modelTypes/IProjectView'
 import {PRIORITIES} from '@/constants/priorities'
@@ -416,6 +475,8 @@ const settings = ref<IUserSettings>({
 		defaultTaskRelationType: authStore.settings.frontendSettings.defaultTaskRelationType ?? 'related',
 		// Clone to escape the store's readonly array type.
 		quickAddDefaultReminders: [...(authStore.settings.frontendSettings.quickAddDefaultReminders ?? [])],
+		// Fallback for users whose settings predate this field.
+		inlineQuickAddFields: [...(authStore.settings.frontendSettings.inlineQuickAddFields ?? DEFAULT_INLINE_QUICK_ADD_FIELDS)],
 	},
 })
 
@@ -545,11 +606,35 @@ watch(
 			frontendSettings: {
 				...authStore.settings.frontendSettings,
 				quickAddDefaultReminders: [...(authStore.settings.frontendSettings.quickAddDefaultReminders ?? [])],
+				inlineQuickAddFields: [...(authStore.settings.frontendSettings.inlineQuickAddFields ?? DEFAULT_INLINE_QUICK_ADD_FIELDS)],
 			},
 		}
 	},
 	{immediate: true},
 )
+
+const enabledInlineFields = ref<{field: InlineQuickAddField}[]>([])
+onBeforeMount(() => {
+	const fields = settings.value.frontendSettings.inlineQuickAddFields ?? DEFAULT_INLINE_QUICK_ADD_FIELDS
+	enabledInlineFields.value = fields.map(f => ({field: f}))
+})
+const availableInlineFields = computed(() =>
+	INLINE_QUICK_ADD_FIELDS.filter(f => !enabledInlineFields.value.some(e => e.field === f)),
+)
+
+function syncInlineFieldsToSettings() {
+	settings.value.frontendSettings.inlineQuickAddFields = enabledInlineFields.value.map(i => i.field)
+}
+
+function addInlineField(field: InlineQuickAddField) {
+	enabledInlineFields.value.push({field})
+	syncInlineFieldsToSettings()
+}
+
+function removeInlineField(field: InlineQuickAddField) {
+	enabledInlineFields.value = enabledInlineFields.value.filter(i => i.field !== field)
+	syncInlineFieldsToSettings()
+}
 
 const projectStore = useProjectStore()
 const defaultProject = computed({
@@ -593,6 +678,73 @@ async function updateSettings() {
 .field-group {
 	display: grid;
 	grid-template-columns: 1fr;
+}
+
+.inline-quick-add-fields-list {
+	max-inline-size: 24rem;
+
+	:deep(.sortable-ghost-hidden) {
+		opacity: 0;
+	}
+}
+
+.inline-quick-add-field-row {
+	display: flex;
+	align-items: center;
+	gap: .5rem;
+	padding: .35rem .5rem;
+	border-radius: $radius;
+
+	&:hover {
+		background: var(--grey-100);
+	}
+
+	.handle {
+		cursor: grab;
+		color: var(--grey-400);
+	}
+
+	&__label {
+		flex: 1;
+	}
+
+	&__remove {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		padding: 0;
+		border: none;
+		background: none;
+		color: var(--grey-400);
+		cursor: pointer;
+		inline-size: 1.5rem;
+		block-size: 1.5rem;
+		border-radius: $radius;
+
+		&:hover {
+			color: var(--danger);
+			background: var(--grey-100);
+		}
+	}
+}
+
+.inline-quick-add-field-adder {
+	margin-block-start: .25rem;
+
+	&__toggle {
+		display: flex;
+		align-items: center;
+		gap: .5rem;
+		padding: .35rem .5rem;
+		color: var(--text);
+		opacity: .6;
+		border-radius: $radius;
+
+		&:hover {
+			opacity: 1;
+			background: var(--grey-100);
+		}
+	}
 }
 
 .sticky-save {


### PR DESCRIPTION
## Summary

- Extends the inline quick-add chip bar (#2663) to work as an inline editor on existing Kanban cards
- Clicking due date, labels, priority, or assignees on a card opens the corresponding popup for quick editing
- A collapsible "+" button reveals unset fields that can be added to the task
- Chip bar only shows fields not yet set, avoiding duplication with the existing card footer
- Auto-collapses on mouse leave with a 650ms grace period
- Dirty-checks values before saving to avoid no-op API calls

> **Depends on #2663** — this PR includes those commits and will auto-rebase once #2663 is merged.

Relates to #1383

## Test plan

- [x] Open a Kanban board with tasks that have various fields set (due date, priority, labels, assignees)
- [x] Hover over a non-done card — the "+" toggle appears in the bottom-right corner
- [x] Click "+" — only unset fields appear as chips
- [x] Click a chip (e.g. start date) — popup opens, set a value, confirm — verify it saves
- [x] Click an existing due date badge on the card — popup opens for editing
- [x] Click existing labels/priority/assignees on the card — respective popup opens
- [x] Move mouse away from expanded chip bar — auto-collapses after ~650ms
- [x] Verify done tasks do not show the "+" toggle or inline edit popups
- [x] Verify user's inline quick-add field settings are respected

🤖 Generated with [Claude Code](https://claude.com/claude-code)