### PR TITLE
chore: add mise.toml and update Renovate grouping to pin tool versions

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,4 @@
+[tools]
+node = "24.13.0"  # keep in sync with frontend/.nvmrc
+pnpm = "10.28.1"  # keep in sync with frontend/package.json#packageManager
+go = "1.25.7"     # keep in sync with go.mod

--- a/renovate.json
+++ b/renovate.json
@@ -75,6 +75,26 @@
       "extends": [
         "schedule:weekly"
       ]
+    },
+    {
+      "groupName": "node",
+      "matchPackageNames": [
+        "node"
+      ],
+      "matchManagers": [
+        "mise",
+        "nvm"
+      ]
+    },
+    {
+      "groupName": "pnpm",
+      "matchPackageNames": [
+        "pnpm"
+      ],
+      "matchManagers": [
+        "mise",
+        "npm"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

This PR adds a `mise.toml` at the repo root so that developers using [mise](https://mise.jdx.dev) can run `mise install` and immediately get the correct Node, pnpm, and Go versions -- without needing to discover and cross-reference the three separate files that currently carry these pins (`.nvmrc`, `package.json#packageManager`, `go.mod`).

It also tightens the Renovate config so that version-bump PRs update all files atomically.

## Problem it solves

mise is widely used in the Go and JS ecosystems as a unified tool version manager. Without a project-level `mise.toml`, mise falls back to the developer's global configuration -- meaning a developer with a different Node version set globally will silently build with the wrong version even though `.nvmrc` is present. Legacy version files (`.nvmrc` etc.) rank below all mise config, including the global one, so the project's pin is simply ignored.

With this change, `mise install` from the repo root activates the right versions of all three tools in one step, regardless of what a developer has configured globally.

## Changes

- `mise.toml` -- pins `node 24.13.0`, `pnpm 10.28.1`, `go 1.25.7`, each with a comment pointing to the canonical source file it mirrors
- `renovate.json` -- adds `packageRules` grouping node updates (`mise` + `nvm` managers) and pnpm updates (`mise` + `npm` managers) so Renovate raises a single PR per tool that updates all relevant files together rather than creating drift between them

**No behavioural changes** -- existing workflows (`pnpm install`, `go build`, CI) are unaffected. This is purely additive for developers who use mise.