### PR TITLE
fix(frontend): ensure text color inherits in filter autocomplete

### DIFF
--- a/frontend/src/components/input/filter/FilterCommandsList.vue
+++ b/frontend/src/components/input/filter/FilterCommandsList.vue
@@ -135,6 +135,7 @@ defineExpose({
 	inline-size: 100%;
 	text-align: start;
 	background: transparent;
+	color: inherit;
 	border-radius: $radius;
 	border: 0;
 	padding: 0.375rem 0.5rem;


### PR DESCRIPTION
<img width="370" height="144" alt="Screenshot 2026-05-15 173804" src="https://github.com/user-attachments/assets/c1edc695-d831-4f41-b999-3337e6b5a324" />

<img width="394" height="100" alt="Screenshot 2026-05-15 180222" src="https://github.com/user-attachments/assets/b8a80395-d2b4-427f-bd74-af0dcfdfd346" />

use dark mode contrasting color for filter autocomplete by inhering color in scss