### PR TITLE
fix(i18n): improve Crowdin translation change detection

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Check for changes
         id: check_changes
         run: |
-          if git diff --quiet; then
+          if [ -z "$(git status --porcelain pkg/i18n/lang frontend/src/i18n/lang)" ]; then
             echo "changes_exist=0" >> "$GITHUB_OUTPUT"
           else
             echo "changes_exist=1" >> "$GITHUB_OUTPUT"
@@ -51,7 +51,8 @@ jobs:
         run: |
           git config --local user.email "bot@vikunja.io"
           git config --local user.name "Frederick [Bot]"
-          git commit -am "chore(i18n): update translations via Crowdin"
+          git add pkg/i18n/lang frontend/src/i18n/lang
+          git commit -m "chore(i18n): update translations via Crowdin"
       - name: Push changes
         if: steps.check_changes.outputs.changes_exist != '0'
         uses: ad-m/github-push-action@master


### PR DESCRIPTION
## Summary
Improves the Crowdin workflow's change detection logic to only check for modifications in translation directories, and refines the git commit process to explicitly stage only translation files.

## Key Changes
- **Change Detection**: Replaced `git diff --quiet` with `git status --porcelain` filtered to only `pkg/i18n/lang` and `frontend/src/i18n/lang` directories. This ensures the workflow only considers actual translation file changes, avoiding false positives from unrelated modifications.
- **Git Staging**: Changed from `git commit -am` (which stages all modified tracked files) to explicitly `git add` only the translation directories before committing. This ensures only translation updates are included in the commit, even if other files were modified during the workflow.

## Implementation Details
The previous approach using `git diff --quiet` would detect any uncommitted changes in the repository, potentially triggering commits when unrelated files were modified. The new approach is more precise and focused on the actual translation files that Crowdin manages.

https://claude.ai/code/session_018YxwBystW9PrNQ9Ejwonxn