### PR TITLE
Fix tooltip visibility in dialog elements

### DIFF
--- a/frontend/src/directives/tooltip.ts
+++ b/frontend/src/directives/tooltip.ts
@@ -1,0 +1,49 @@
+import type {Directive, DirectiveBinding} from 'vue'
+import {vTooltip} from 'floating-vue'
+
+// When a tooltip target lives inside a <dialog> opened via showModal(), the
+// dialog is in the browser's top layer. floating-vue teleports tooltips to
+// <body> by default, so they render *below* the dialog's ::backdrop and are
+// not visible. Teleporting them into the dialog keeps them in the top layer.
+function buildBinding(el: Element, binding: DirectiveBinding): DirectiveBinding {
+	const dialog = el.closest('dialog')
+	if (!dialog) {
+		return binding
+	}
+
+	const value = binding.value
+	let normalized: Record<string, unknown>
+	if (typeof value === 'string') {
+		normalized = {content: value}
+	} else if (value && typeof value === 'object') {
+		normalized = {...value as Record<string, unknown>}
+	} else {
+		return binding
+	}
+
+	if (normalized.container === undefined) {
+		normalized.container = dialog
+	}
+
+	return {...binding, value: normalized}
+}
+
+// Bind via `mounted` rather than `beforeMount` so the element is already
+// attached to the DOM — otherwise `el.closest('dialog')` cannot find the
+// dialog ancestor.
+const tooltip: Directive<Element, unknown> = {
+	mounted(el, binding) {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		;(vTooltip as any).beforeMount(el, buildBinding(el, binding))
+	},
+	updated(el, binding) {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		;(vTooltip as any).updated(el, buildBinding(el, binding))
+	},
+	beforeUnmount(el) {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		;(vTooltip as any).beforeUnmount(el)
+	},
+}
+
+export default tooltip

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -38,7 +38,7 @@ if (window.API_URL.endsWith('/')) {
 
 // directives
 import focus from '@/directives/focus'
-import {vTooltip} from 'floating-vue'
+import tooltip from '@/directives/tooltip'
 import 'floating-vue/dist/style.css'
 import shortcut from '@/directives/shortcut'
 import testid from '@/directives/testid'
@@ -66,7 +66,7 @@ setLanguage(browserLanguage).then(() => {
 	app.use(Notifications)
 
 	app.directive('focus', focus)
-	app.directive('tooltip', vTooltip)
+	app.directive('tooltip', tooltip)
 	app.directive('shortcut', shortcut)
 	app.directive('cy', testid)
 


### PR DESCRIPTION
## Summary
Fixes tooltips not being visible when their target element is inside a `<dialog>` opened via `showModal()`. The issue occurs because floating-vue teleports tooltips to `<body>` by default, placing them below the dialog's `::backdrop` in the browser's top layer.

## Changes
- **New directive** (`frontend/src/directives/tooltip.ts`): Created a custom tooltip directive that wraps floating-vue's `vTooltip` and automatically teleports tooltips into the dialog container when the target element is inside a `<dialog>`. The directive:
  - Detects if the tooltip target is within a dialog using `el.closest('dialog')`
  - Normalizes the tooltip binding value to an object format
  - Sets the `container` option to the dialog element, keeping tooltips in the top layer
  - Delegates to floating-vue's lifecycle hooks (`beforeMount`, `updated`, `beforeUnmount`)
  - Uses `mounted` instead of `beforeMount` to ensure the element is attached to the DOM for ancestor detection

- **Updated registration** (`frontend/src/main.ts`): Replaced the direct `vTooltip` directive registration with the new custom tooltip directive

## Implementation Details
- The directive handles both string and object tooltip values for flexibility
- Only overrides the `container` option if not explicitly provided by the user
- Preserves all other tooltip configuration options
- Maintains compatibility with floating-vue's API through delegation

https://claude.ai/code/session_013HPe27ZVgFQXdRPuRiFXQr