### PR TITLE
Conditionally embed logo in conversational emails

### DIFF
--- a/pkg/notifications/mail_render.go
+++ b/pkg/notifications/mail_render.go
@@ -407,9 +407,12 @@ func RenderMail(m *Mail, lang string) (mailOpts *mail.Opts, err error) {
 		HTMLMessage: htmlContent.String(),
 		Boundary:    boundary,
 		ThreadID:    m.threadID,
-		EmbedFS: map[string]*embed.FS{
+	}
+
+	if !m.conversational {
+		mailOpts.EmbedFS = map[string]*embed.FS{
 			"logo.png": &logo,
-		},
+		}
 	}
 
 	return mailOpts, nil

--- a/pkg/notifications/mail_test.go
+++ b/pkg/notifications/mail_test.go
@@ -533,6 +533,7 @@ func TestConversationalMail(t *testing.T) {
 		// Should NOT have logo (completely removed)
 		assert.NotContains(t, mailopts.HTMLMessage, "logo.png")
 		assert.NotContains(t, mailopts.HTMLMessage, "Vikunja")
+		assert.NotContains(t, mailopts.EmbedFS, "logo.png")
 
 		// Should have inline action link with arrow
 		assert.Contains(t, mailopts.HTMLMessage, "View Task →")
@@ -571,6 +572,7 @@ func TestConversationalMail(t *testing.T) {
 		// Should HAVE logo in formal emails
 		assert.Contains(t, mailopts.HTMLMessage, "logo.png")
 		assert.Contains(t, mailopts.HTMLMessage, "Vikunja")
+		assert.Contains(t, mailopts.EmbedFS, "logo.png")
 
 		// Should have formal button styling
 		assert.Contains(t, mailopts.HTMLMessage, "background-color: #1973ff")


### PR DESCRIPTION
## Summary
Refactored email rendering to conditionally include the logo embed only for formal (non-conversational) emails. This prevents unnecessary embedded assets in conversational email threads while maintaining logo inclusion in standard email notifications.

## Changes
- **Mail rendering logic**: Moved `EmbedFS` assignment into a conditional block that only executes when `m.conversational` is `false`
- **Test coverage**: Added assertions to verify that:
  - Conversational emails do NOT contain the embedded logo in `EmbedFS`
  - Formal emails DO contain the embedded logo in `EmbedFS`

## Implementation Details
The logo embedding is now gated behind the conversational flag, ensuring that conversational email threads remain lightweight while formal notifications retain their branded appearance with embedded assets.

https://claude.ai/code/session_01SHGEwDaTUrGNAK85ZCa2VT