### PR TITLE
Make avatar size configurable via CSS variable

### DIFF
--- a/frontend/src/components/misc/User.vue
+++ b/frontend/src/components/misc/User.vue
@@ -2,6 +2,7 @@
 	<div
 		class="user"
 		:class="{'is-inline': isInline}"
+		:style="{'--avatar-size': `${avatarSize}px`}"
 	>
 		<span class="avatar-wrapper">
 			<img
@@ -74,6 +75,8 @@ watch(() => [props.user, props.avatarSize], loadAvatar, { immediate: true })
 }
 
 .avatar {
+	inline-size: var(--avatar-size);
+	block-size: var(--avatar-size);
 	border-radius: 100%;
 	vertical-align: middle;
 }


### PR DESCRIPTION
## Summary
Refactored the User component to use a CSS custom property for avatar sizing, enabling dynamic control over avatar dimensions without hardcoding pixel values.

## Changes
- Added `--avatar-size` CSS variable binding to the component root element, derived from the `avatarSize` prop
- Updated `.avatar` styles to use `inline-size` and `block-size` properties with the CSS variable instead of relying on implicit sizing
- This allows the avatar size to be easily customized at runtime and makes the component more flexible for different use cases

## Implementation Details
- The CSS variable is set inline on the component's root div using Vue's `:style` binding
- The avatar image now explicitly uses the CSS variable for both width and height dimensions
- This approach maintains backward compatibility while providing better control over avatar rendering

https://claude.ai/code/session_01TrjG1BFtZxJV3nR77qUKAx