### PR TITLE
Add "Tomorrow" date range option

### DIFF
--- a/frontend/src/components/date/dateRanges.ts
+++ b/frontend/src/components/date/dateRanges.ts
@@ -3,6 +3,7 @@ export const DATE_RANGES = {
 	// Key is the title, as a translation string, the first entry of the value array 
 	// is the "from" date, the second one is the "to" date.
 	'today': ['now/d', 'now/d+1d'],
+	'tomorrow': ['now/d+1d', 'now/d+2d'],
 
 	'lastWeek': ['now/w-1w', 'now/w'],
 	'thisWeek': ['now/w', 'now/w+1w'],

--- a/frontend/src/i18n/lang/en.json
+++ b/frontend/src/i18n/lang/en.json
@@ -862,6 +862,7 @@
       "date": "Date",
       "ranges": {
         "today": "Today",
+        "tomorrow": "Tomorrow",
         "thisWeek": "This Week",
         "restOfThisWeek": "The Rest of This Week",
         "nextWeek": "Next Week",


### PR DESCRIPTION
Resolves https://github.com/go-vikunja/vikunja/issues/2734

## Summary
Adds support for selecting "Tomorrow" as a date range filter option, complementing the existing "Today" option.

## Changes
- Added `'tomorrow'` date range to `DATE_RANGES` configuration with appropriate date calculations (`now/d+1d` to `now/d+2d`)
- Added English translation for the "Tomorrow" label in the date ranges i18n file

## Implementation Details
The "Tomorrow" range follows the same pattern as the existing "Today" range, using Elasticsearch date math notation to calculate the full day range for the next day.

https://claude.ai/code/session_01SL6tXAnPvxwyBUXH1TLdqd