### PR TITLE
Add Greek (el-GR) language support

### DIFF
--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -41,6 +41,7 @@ export const SUPPORTED_LOCALES = {
 	'fi-FI': 'Suomi',
 	'he-IL': 'עִבְרִית',
 	'sv-SE': 'Svenska',
+	'el-GR': 'Ελληνικά',
 	// IMPORTANT: Also add new languages to useDayjsLanguageSync
 	// IMPORTANT: Also add new languages to pkg/i18n/i18n.go
 } as const

--- a/frontend/src/i18n/useDayjsLanguageSync.ts
+++ b/frontend/src/i18n/useDayjsLanguageSync.ts
@@ -33,6 +33,7 @@ export const DAYJS_LOCALE_MAPPING = {
 	'fi-fi': 'fi',
 	'he-il': 'he',
 	'sv-se': 'sv',
+	'el-gr': 'el',
 } as Record<SupportedLocale, ISOLanguage>
 
 export const DAYJS_LANGUAGE_IMPORTS = {
@@ -65,6 +66,7 @@ export const DAYJS_LANGUAGE_IMPORTS = {
 	'fi-fi': () => import('dayjs/locale/fi'),
 	'he-il': () => import('dayjs/locale/he'),
 	'sv-se': () => import('dayjs/locale/sv'),
+	'el-gr': () => import('dayjs/locale/el'),
 } as Record<SupportedLocale, () => Promise<ILocale>>
 
 export async function loadDayJsLocale(language: SupportedLocale) {

--- a/pkg/i18n/i18n.go
+++ b/pkg/i18n/i18n.go
@@ -77,6 +77,7 @@ var availableLanguages = map[string]bool{
 	"fi-FI":    true,
 	"he-IL":    true,
 	"sv-SE":    true,
+	"el-GR":    true,
 	// IMPORTANT: Also add new languages to the frontend
 }
 


### PR DESCRIPTION
## Summary
Adds Greek (el-GR) language support to Vikunja across both frontend and backend components.

## Changes
- **Frontend i18n configuration** (`frontend/src/i18n/`):
  - Added Greek locale mapping in `useDayjsLanguageSync.ts` (`'el-gr': 'el'`)
  - Added dayjs locale import for Greek in `useDayjsLanguageSync.ts`
  - Added Greek to supported locales in `index.ts` (`'el-GR': 'Ελληνικά'`)

- **Backend i18n configuration** (`pkg/i18n/`):
  - Added Greek to available languages in `i18n.go` (`"el-GR": true`)

## Notes
All three locations mentioned in the code comments have been updated to maintain consistency across the application.

https://claude.ai/code/session_01Bjatx71iBonkoYFs6xkDTn