### PR TITLE
feat(task): move new comment form to match sort order

### DIFF
--- a/frontend/src/components/tasks/partials/Comments.vue
+++ b/frontend/src/components/tasks/partials/Comments.vue
@@ -664,14 +664,6 @@ function getCommentUrl(commentId: string) {
 
 .new-comment-top {
 	order: -1;
-	// Override the top separator inherited from .media + .media (DOM order places this last)
-	border-block-start: none;
-	margin-block-start: 0;
-	padding-block-start: 0;
-	// Provide the separator on the bottom side instead, toward the first existing comment
-	border-block-end: 1px solid rgba(var(--border-rgb), 0.5);
-	margin-block-end: 1rem;
-	padding-block-end: 1rem;
 }
 
 .comments-container {

--- a/frontend/src/components/tasks/partials/Comments.vue
+++ b/frontend/src/components/tasks/partials/Comments.vue
@@ -146,6 +146,7 @@
 			<div
 				v-if="canWrite"
 				class="media comment d-print-none"
+				:class="{'new-comment-top': commentSortOrder === 'desc'}"
 			>
 				<figure class="media-left is-hidden-mobile">
 					<img
@@ -654,6 +655,23 @@ function getCommentUrl(commentId: string) {
 	&:hover {
 		color: var(--grey-700);
 	}
+}
+
+.comments {
+	display: flex;
+	flex-direction: column;
+}
+
+.new-comment-top {
+	order: -1;
+	// Override the top separator inherited from .media + .media (DOM order places this last)
+	border-block-start: none;
+	margin-block-start: 0;
+	padding-block-start: 0;
+	// Provide the separator on the bottom side instead, toward the first existing comment
+	border-block-end: 1px solid rgba(var(--border-rgb), 0.5);
+	margin-block-end: 1rem;
+	padding-block-end: 1rem;
 }
 
 .comments-container {


### PR DESCRIPTION
## Summary

- When comments are sorted **Newest First**, the new comment form now appears at the top of the list, keeping the input adjacent to the most recent comments
- When sorted **Oldest First**, the form remains at the bottom (existing behavior)
- Implemented via CSS `order` on a flex column — no DOM restructuring or template duplication

## After Screenshots

<img width="788" height="794" alt="telegram-cloud-photo-size-1-4936171163172408366-x" src="https://github.com/user-attachments/assets/aa677e81-21bc-4da4-9ec9-013770c7700c" />
<img width="791" height="807" alt="telegram-cloud-photo-size-1-4936171163172408367-y" src="https://github.com/user-attachments/assets/eb4761d4-39ce-41ad-8977-acb2ffac28f8" />
