### PR TITLE
fix(assignees): resolve 500 error when reading task assignees

### DIFF
--- a/pkg/models/task_assignees.go
+++ b/pkg/models/task_assignees.go
@@ -334,10 +334,9 @@ func (la *TaskAssginee) ReadAll(s *xorm.Session, a web.Auth, search string, page
 	}
 
 	numberOfTotalItems, err = s.Table("task_assignees").
-		Select("users.*").
 		Join("INNER", "users", "task_assignees.user_id = users.id").
 		Where("task_id = ? AND users.username LIKE ?", la.TaskID, "%"+search+"%").
-		Count(&user.User{})
+		Count(&TaskAssginee{})
 	return taskAssignees, len(taskAssignees), numberOfTotalItems, err
 }
 

--- a/pkg/webtests/task_test.go
+++ b/pkg/webtests/task_test.go
@@ -563,3 +563,36 @@ func TestTaskDuplicate(t *testing.T) {
 		assert.Contains(t, getHTTPErrorMessage(err), "Forbidden")
 	})
 }
+
+func TestTaskAssignees(t *testing.T) {
+	testHandler := webHandlerTest{
+		user: &testuser1,
+		strFunc: func() handler.CObject {
+			return &models.TaskAssginee{}
+		},
+		t: t,
+	}
+
+	t.Run("ReadAll", func(t *testing.T) {
+		t.Run("With assignees", func(t *testing.T) {
+			rec, err := testHandler.testReadAllWithUser(nil, map[string]string{"projecttask": "30"})
+			require.NoError(t, err)
+			assert.Equal(t, http.StatusOK, rec.Code)
+			assert.Contains(t, rec.Body.String(), `"id":1`)
+			assert.Contains(t, rec.Body.String(), `"id":2`)
+		})
+
+		t.Run("Without assignees", func(t *testing.T) {
+			rec, err := testHandler.testReadAllWithUser(nil, map[string]string{"projecttask": "1"})
+			require.NoError(t, err)
+			assert.Equal(t, http.StatusOK, rec.Code)
+			assert.Contains(t, rec.Body.String(), `[]`)
+		})
+
+		t.Run("No permission", func(t *testing.T) {
+			_, err := testHandler.testReadAllWithUser(nil, map[string]string{"projecttask": "14"})
+			require.Error(t, err)
+			assert.Equal(t, http.StatusForbidden, getHTTPErrorCode(err))
+		})
+	})
+}


### PR DESCRIPTION
## Summary
Fixes the GET /api/v1/tasks/{taskID}/assignees endpoint returning 500 errors on both SQLite and PostgreSQL.

## How it's fixed
The count query in `TaskAssginee.ReadAll()` was using `Select("users.*")` which produced non-scalar SQL. This causes:
- PostgreSQL: "expected 26 destination arguments in Scan, not 1" (with assignees) or "no rows in result set" (without)
- SQLite: similar count mismatch error

**Fix:** Remove the `Select()` from the count query and count on the driving table (TaskAssginee) instead. The INNER JOIN on users is kept because the WHERE clause filters by username.

## Test coverage
Added `TestTaskAssignees` with tests for:
- Reading assignees when task has assignees (returns 200 with user list)
- Reading assignees when task has no assignees (returns 200 with empty array)
- Permission checks

Tests: FAIL without fix → PASS with fix

Closes/Resolves #2740