### PR TITLE
fix(user): stop double-encoding FrontendSettings on UpdateUser

### DIFF
--- a/pkg/migration/20260627101958.go
+++ b/pkg/migration/20260627101958.go
@@ -1,0 +1,110 @@
+// Vikunja is a to-do list application to facilitate your life.
+// Copyright 2018-present Vikunja and contributors. All rights reserved.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package migration
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+
+	"src.techknowlogick.com/xormigrate"
+	"xorm.io/xorm"
+	"xorm.io/xorm/schemas"
+)
+
+type userFrontendSettings20260627101958 struct {
+	ID int64 `xorm:"bigint autoincr not null unique pk"`
+	// Keep this as a string; interface{} would decode the value before repair.
+	FrontendSettings string `xorm:"frontend_settings json null"`
+}
+
+func (userFrontendSettings20260627101958) TableName() string {
+	return "users"
+}
+
+func frontendSettingsStringWhere20260627101958(dbType schemas.DBType) string {
+	if dbType == schemas.POSTGRES {
+		return `frontend_settings IS NOT NULL AND frontend_settings::text LIKE '"%'`
+	}
+	return `frontend_settings IS NOT NULL AND frontend_settings LIKE '"%'`
+}
+
+// Legacy rows contain base64 JSON because UpdateUser wrote []byte into an xorm json field.
+func decodeLegacyFrontendSettings20260627101958(raw string) (value string, setNull, ok bool) {
+	trimmed := strings.TrimSpace(raw)
+	if len(trimmed) == 0 || trimmed[0] != '"' {
+		return "", false, false
+	}
+
+	var inner string
+	if err := json.Unmarshal([]byte(trimmed), &inner); err != nil {
+		return "", false, false
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(inner)
+	if err != nil {
+		return "", false, false
+	}
+
+	decoded = bytes.TrimSpace(decoded)
+	if bytes.Equal(decoded, []byte("null")) {
+		return "", true, true
+	}
+	if len(decoded) > 0 && decoded[0] == '{' && json.Valid(decoded) {
+		return string(decoded), false, true
+	}
+	return "", false, false
+}
+
+func init() {
+	migrations = append(migrations, &xormigrate.Migration{
+		ID:          "20260627101958",
+		Description: "repair double-encoded frontend_settings",
+		Migrate: func(tx *xorm.Engine) error {
+			users := []*userFrontendSettings20260627101958{}
+			if err := tx.
+				Where(frontendSettingsStringWhere20260627101958(tx.Dialect().URI().DBType)).
+				Find(&users); err != nil {
+				return err
+			}
+
+			for _, u := range users {
+				value, setNull, ok := decodeLegacyFrontendSettings20260627101958(u.FrontendSettings)
+				if !ok {
+					continue
+				}
+
+				if setNull {
+					if _, err := tx.Exec("UPDATE users SET frontend_settings = NULL WHERE id = ?", u.ID); err != nil {
+						return err
+					}
+					continue
+				}
+
+				if _, err := tx.Exec("UPDATE users SET frontend_settings = ? WHERE id = ?", value, u.ID); err != nil {
+					return err
+				}
+			}
+
+			return nil
+		},
+		Rollback: func(tx *xorm.Engine) error {
+			return nil
+		},
+	})
+}

--- a/pkg/migration/20260627101958_test.go
+++ b/pkg/migration/20260627101958_test.go
@@ -1,0 +1,103 @@
+// Vikunja is a to-do list application to facilitate your life.
+// Copyright 2018-present Vikunja and contributors. All rights reserved.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package migration
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"xorm.io/xorm/schemas"
+)
+
+func legacyFrontendSettingsRaw20260627101958(jsonValue string) string {
+	return `"` + base64.StdEncoding.EncodeToString([]byte(jsonValue)) + `"`
+}
+
+func TestDecodeLegacyFrontendSettings20260627101958(t *testing.T) {
+	tests := []struct {
+		name      string
+		raw       string
+		wantValue string
+		wantNull  bool
+		wantOK    bool
+	}{
+		{
+			name:     "legacy null",
+			raw:      legacyFrontendSettingsRaw20260627101958("null"),
+			wantNull: true,
+			wantOK:   true,
+		},
+		{
+			name:      "legacy object",
+			raw:       legacyFrontendSettingsRaw20260627101958(`{"color_schema":"dark"}`),
+			wantValue: `{"color_schema":"dark"}`,
+			wantOK:    true,
+		},
+		{
+			name:   "object",
+			raw:    `{"color_schema":"dark"}`,
+			wantOK: false,
+		},
+		{
+			name:   "string",
+			raw:    `"hello world"`,
+			wantOK: false,
+		},
+		{
+			name:   "encoded scalar",
+			raw:    legacyFrontendSettingsRaw20260627101958("123"),
+			wantOK: false,
+		},
+		{
+			name:   "encoded array",
+			raw:    legacyFrontendSettingsRaw20260627101958("[]"),
+			wantOK: false,
+		},
+		{
+			name:   "empty",
+			raw:    "",
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			value, setNull, ok := decodeLegacyFrontendSettings20260627101958(tt.raw)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if setNull != tt.wantNull {
+				t.Fatalf("setNull = %v, want %v", setNull, tt.wantNull)
+			}
+			if value != tt.wantValue {
+				t.Fatalf("value = %q, want %q", value, tt.wantValue)
+			}
+		})
+	}
+}
+
+func TestFrontendSettingsStringWhere20260627101958(t *testing.T) {
+	postgres := frontendSettingsStringWhere20260627101958(schemas.POSTGRES)
+	if want := `frontend_settings IS NOT NULL AND frontend_settings::text LIKE '"%'`; postgres != want {
+		t.Fatalf("postgres clause\nwant: %s\ngot:  %s", want, postgres)
+	}
+
+	other := frontendSettingsStringWhere20260627101958(schemas.SQLITE)
+	if want := `frontend_settings IS NOT NULL AND frontend_settings LIKE '"%'`; other != want {
+		t.Fatalf("default clause\nwant: %s\ngot:  %s", want, other)
+	}
+}

--- a/pkg/user/user.go
+++ b/pkg/user/user.go
@@ -584,18 +584,17 @@ var baseUserUpdateColumns = [...]string{
 	"extra_settings_links",
 }
 
-// premarshalFrontendSettings is a helper function to marshal frontend settings to JSON before 
-// handing them off to the ORM. This prevents downstream double-encoding issues for clients
-// which expect JSON objects.
-func premarshalFrontendSettings(settings interface{}) (interface{}, error) {
+func premarshalFrontendSettings(settings interface{}) (*string, error) {
 	if settings == nil {
 		return nil, nil
 	}
+
 	settingsJSON, err := json.Marshal(settings)
 	if err != nil {
 		return nil, fmt.Errorf("marshal frontend settings: %w", err)
 	}
-	return string(settingsJSON), nil
+	settingsString := string(settingsJSON)
+	return &settingsString, nil
 }
 
 // UpdateUser updates a user

--- a/pkg/user/user.go
+++ b/pkg/user/user.go
@@ -565,6 +565,39 @@ func getClaimAsString(claims jwt.MapClaims, field string) (string, error) {
 	return value, nil
 }
 
+var baseUserUpdateColumns = [...]string{
+	"username",
+	"email",
+	"avatar_provider",
+	"avatar_file_id",
+	"status",
+	"name",
+	"email_reminders_enabled",
+	"discoverable_by_name",
+	"discoverable_by_email",
+	"overdue_tasks_reminders_enabled",
+	"default_project_id",
+	"week_start",
+	"language",
+	"timezone",
+	"overdue_tasks_reminders_time",
+	"extra_settings_links",
+}
+
+// premarshalFrontendSettings is a helper function to marshal frontend settings to JSON before 
+// handing them off to the ORM. This prevents downstream double-encoding issues for clients
+// which expect JSON objects.
+func premarshalFrontendSettings(settings interface{}) (interface{}, error) {
+	if settings == nil {
+		return nil, nil
+	}
+	settingsJSON, err := json.Marshal(settings)
+	if err != nil {
+		return nil, fmt.Errorf("marshal frontend settings: %w", err)
+	}
+	return string(settingsJSON), nil
+}
+
 // UpdateUser updates a user
 func UpdateUser(s *xorm.Session, user *User, forceOverride bool) (updatedUser *User, err error) {
 
@@ -633,40 +666,24 @@ func UpdateUser(s *xorm.Session, user *User, forceOverride bool) (updatedUser *U
 		return nil, &ErrInvalidTimezone{Name: user.Timezone, LoadError: err}
 	}
 
-	frontendSettingsJSON, err := json.Marshal(user.FrontendSettings)
-	if err != nil {
-		return nil, err
+	updateCols := baseUserUpdateColumns[:]
+	if forceOverride {
+		// forceOverride is set in paths where we should apply the FrontendSettings update.
+		user.FrontendSettings, err = premarshalFrontendSettings(user.FrontendSettings)
+		if err != nil {
+			return nil, err
+		}
+		updateCols = append(updateCols, "frontend_settings")
 	}
-	user.FrontendSettings = frontendSettingsJSON
 
-	// Update it
 	_, err = s.
 		ID(user.ID).
-		Cols(
-			"username",
-			"email",
-			"avatar_provider",
-			"avatar_file_id",
-			"status",
-			"name",
-			"email_reminders_enabled",
-			"discoverable_by_name",
-			"discoverable_by_email",
-			"overdue_tasks_reminders_enabled",
-			"default_project_id",
-			"week_start",
-			"language",
-			"timezone",
-			"overdue_tasks_reminders_time",
-			"frontend_settings",
-			"extra_settings_links",
-		).
+		Cols(updateCols...).
 		Update(user)
 	if err != nil {
 		return &User{}, err
 	}
 
-	// Get the newly updated user
 	updatedUser, err = GetUserByID(s, user.ID)
 	if err != nil && !IsErrUserStatusError(err) {
 		return &User{}, err

--- a/pkg/user/user_test.go
+++ b/pkg/user/user_test.go
@@ -18,6 +18,8 @@ package user
 
 import (
 	"context"
+	"database/sql"
+	"encoding/json"
 	"testing"
 
 	"code.vikunja.io/api/pkg/db"
@@ -474,6 +476,103 @@ func TestUpdateUser(t *testing.T) {
 		}, false)
 		require.Error(t, err)
 		assert.True(t, IsErrUserDoesNotExist(err))
+	})
+	t.Run("frontend settings survive profile-only update", func(t *testing.T) {
+		db.LoadAndAssertFixtures(t)
+		s := db.NewSession()
+		defer s.Close()
+
+		originalSettings := map[string]any{
+			"color_schema": "dark",
+		}
+		settingsJSON, err := json.Marshal(originalSettings)
+		require.NoError(t, err)
+		_, err = s.Table("users").
+			Where("id = ?", 1).
+			Cols("frontend_settings").
+			Update(&struct {
+				FrontendSettings string `xorm:"frontend_settings"`
+			}{
+				FrontendSettings: string(settingsJSON),
+			})
+		require.NoError(t, err)
+
+		updated, err := UpdateUser(s, &User{
+			ID:    1,
+			Email: "testing@example.com",
+		}, false)
+		require.NoError(t, err)
+		require.Equal(t, map[string]interface{}(originalSettings), updated.FrontendSettings)
+
+		var stored sql.NullString
+		has, err := s.Table("users").
+			Where("id = ?", 1).
+			Cols("frontend_settings").
+			Get(&stored)
+		require.NoError(t, err)
+		require.True(t, has)
+		require.True(t, stored.Valid)
+		assert.JSONEq(t, string(settingsJSON), stored.String)
+	})
+	t.Run("frontend settings can be saved from request map", func(t *testing.T) {
+		db.LoadAndAssertFixtures(t)
+		s := db.NewSession()
+		defer s.Close()
+
+		frontendSettings := map[string]any{
+			"color_schema": "dark",
+			"nested": map[string]any{
+				"a": float64(1),
+			},
+		}
+
+		updated, err := UpdateUser(s, &User{
+			ID:               1,
+			FrontendSettings: frontendSettings,
+		}, true)
+		require.NoError(t, err)
+		require.Equal(t, frontendSettings, updated.FrontendSettings)
+
+		var stored sql.NullString
+		has, err := s.Table("users").
+			Where("id = ?", 1).
+			Cols("frontend_settings").
+			Get(&stored)
+		require.NoError(t, err)
+		require.True(t, has)
+		require.True(t, stored.Valid)
+		assert.JSONEq(t, `{"color_schema":"dark","nested":{"a":1}}`, stored.String)
+	})
+	t.Run("frontend settings can be cleared", func(t *testing.T) {
+		db.LoadAndAssertFixtures(t)
+		s := db.NewSession()
+		defer s.Close()
+
+		_, err := s.Table("users").
+			Where("id = ?", 1).
+			Cols("frontend_settings").
+			Update(&struct {
+				FrontendSettings string `xorm:"frontend_settings"`
+			}{
+				FrontendSettings: `{"color_schema":"dark"}`,
+			})
+		require.NoError(t, err)
+
+		updated, err := UpdateUser(s, &User{
+			ID:               1,
+			FrontendSettings: nil,
+		}, true)
+		require.NoError(t, err)
+		require.Nil(t, updated.FrontendSettings)
+
+		var stored sql.NullString
+		has, err := s.Table("users").
+			Where("id = ?", 1).
+			Cols("frontend_settings").
+			Get(&stored)
+		require.NoError(t, err)
+		require.True(t, has)
+		assert.False(t, stored.Valid)
 	})
 }
 


### PR DESCRIPTION
UpdateUser was manually json.Marshal'ing user.FrontendSettings and re-assigning the []byte back to the interface{} field before passing the user to xorm. The column is declared:

```go
FrontendSettings interface{} `xorm:"json null" json:"-"`
```

xorm's `json` modifier already marshals the field on write. Pre-marshalling to []byte and stuffing it back into the interface causes xorm to JSON-encode a []byte (which serializes as a base64 string). The DB ends up storing `"bnVsbA=="` (base64 of "null") for users whose FrontendSettings is nil, or a double-encoded blob for users with real settings.

On read, xorm unmarshals that string back into the interface as a Go `string`, and the API response then contains:

  `"frontend_settings": "bnVsbA=="`

instead of a JSON object or null. The Flutter mobile client (go-vikunja/app) typed-casts `frontend_settings` to `Map<String, dynamic>?` and crashes with:

  `type 'String' is not a subtype of type 'Map<String, dynamic>?'`

which the app surfaces as "could not connect to this server". The web client tolerates it silently (JS spread over a string).

Trigger path: every OIDC login of an existing user calls UpdateUser (pkg/modules/auth/openid/openid.go), so the row is corrupted on every re-login. See go-vikunja/app#265.

Fix: Pre-encode frontend_settings values to JSON-objects, which prevents it from getting to the client as a JSON string and breaking the app. Also create a DB migration to upgrade any existing string values to objects.

The migration repairs existing legacy rows where frontend_settings is a string representing base64-encoded JSON null or object. Other valid JSON values are left unchanged.

Fixes go-vikunja/app#265
