### PR TITLE
Improve task assignee search with case-insensitive query

### DIFF
--- a/pkg/models/task_assignees.go
+++ b/pkg/models/task_assignees.go
@@ -335,7 +335,10 @@ func (la *TaskAssginee) ReadAll(s *xorm.Session, a web.Auth, search string, page
 
 	numberOfTotalItems, err = s.Table("task_assignees").
 		Join("INNER", "users", "task_assignees.user_id = users.id").
-		Where("task_id = ? AND users.username LIKE ?", la.TaskID, "%"+search+"%").
+		Where(builder.And(
+			builder.Eq{"task_id": la.TaskID},
+			db.ILIKE("users.username", search),
+		)).
 		Count(&TaskAssginee{})
 	return taskAssignees, len(taskAssignees), numberOfTotalItems, err
 }


### PR DESCRIPTION
## Summary
Refactored the task assignee search query to use case-insensitive username matching and improved query builder patterns for better maintainability.

## Changes
- Replaced raw SQL `LIKE` operator with `db.ILIKE()` for case-insensitive username search
- Migrated from string-based `Where()` clause to builder pattern using `builder.And()` and `builder.Eq{}` for cleaner, more type-safe query construction
- Maintains existing functionality while improving search usability (users can now find assignees regardless of username case)

## Implementation Details
The change uses Xorm's query builder API to construct the WHERE clause more explicitly:
- `builder.Eq{"task_id": la.TaskID}` replaces the positional parameter for task_id equality
- `db.ILIKE("users.username", search)` provides case-insensitive pattern matching instead of `LIKE "%...%"`
- Both conditions are combined with `builder.And()` for logical clarity

https://claude.ai/code/session_01QEafPPNdcX1SbGuheZ5Wqv