### PR TITLE
chore(docker): add Dockerfile HEALTHCHECK directive

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,3 +59,5 @@ ENV VIKUNJA_DATABASE_PATH=/db/vikunja.db
 
 COPY --from=apibuilder /build/vikunja-* vikunja
 COPY --from=apibuilder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+
+HEALTHCHECK CMD ["/app/vikunja/vikunja", "healthcheck"]


### PR DESCRIPTION
Use the built-in '/app/vikunja/vikunja healthcheck' command as the health check probe. This allows orchestrators to detect when the container is unhealthy (e.g. after a crash or hang).

Ref: https://docs.docker.com/reference/dockerfile/#healthcheck
Fixes: https://github.com/go-vikunja/vikunja/issues/2220