### PR TITLE
fix: preserve login username on tab unfocus

### DIFF
--- a/frontend/src/views/user/Login.test.ts
+++ b/frontend/src/views/user/Login.test.ts
@@ -1,0 +1,130 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+import {mount} from '@vue/test-utils'
+
+import Login from './Login.vue'
+
+const login = vi.fn()
+
+vi.mock('vue-i18n', () => ({
+	useI18n: () => ({
+		t: (key: string) => key,
+	}),
+}))
+
+vi.mock('vue-router', () => ({
+	useRouter: () => ({
+		push: vi.fn(),
+	}),
+}))
+
+vi.mock('@/composables/useTitle', () => ({
+	useTitle: vi.fn(),
+}))
+
+vi.mock('@/composables/useRedirectToLastVisited', () => ({
+	useRedirectToLastVisited: () => ({
+		redirectIfSaved: vi.fn(),
+	}),
+}))
+
+vi.mock('@/helpers/desktopAuth', () => ({
+	isDesktopApp: () => false,
+}))
+
+vi.mock('@/helpers/redirectToProvider', () => ({
+	redirectToProvider: vi.fn(),
+}))
+
+vi.mock('@/message', () => ({
+	getErrorText: vi.fn(),
+}))
+
+vi.mock('@/stores/auth', () => ({
+	useAuthStore: () => ({
+		authenticated: false,
+		isLoading: false,
+		needsTotpPasscode: false,
+		verifyEmail: () => Promise.resolve(false),
+		login,
+		setNeedsTotpPasscode: vi.fn(),
+	}),
+}))
+
+vi.mock('@/stores/config', () => ({
+	useConfigStore: () => ({
+		auth: {
+			local: {
+				enabled: true,
+				registrationEnabled: false,
+			},
+			ldap: {
+				enabled: false,
+			},
+			openidConnect: {
+				enabled: false,
+				providers: [],
+			},
+		},
+	}),
+}))
+
+describe('Login', () => {
+	beforeEach(() => {
+		login.mockReset()
+		sessionStorage.clear()
+		document.body.innerHTML = ''
+	})
+
+	function mountLogin() {
+		return mount(Login, {
+			attachTo: document.body,
+			global: {
+				directives: {
+					focus: {mounted: vi.fn()},
+					tooltip: {mounted: vi.fn()},
+				},
+				mocks: {
+					$t: (key: string) => key,
+				},
+				stubs: {
+					DesktopLogin: true,
+					Icon: true,
+					RouterLink: true,
+					XButton: {
+						template: '<button type="button" @click="$emit(\'click\', $event)"><slot /></button>',
+					},
+				},
+			},
+		})
+	}
+
+	it('mirrors the username while still submitting the DOM value', async () => {
+		login.mockResolvedValue(undefined)
+
+		const wrapper = mountLogin()
+
+		const username = wrapper.get<HTMLInputElement>('input#username')
+		await username.setValue('alice')
+		expect(username.element.value).toBe('alice')
+
+		// Simulate browser autofill after Vue's input event: the submit path must
+		// keep using the DOM value for browsers which do not update bindings.
+		username.element.value = 'alice@example.com'
+		await wrapper.get<HTMLInputElement>('input#password').setValue('secret')
+		await wrapper.get('form').trigger('submit')
+
+		expect(login).toHaveBeenCalledWith({
+			username: 'alice@example.com',
+			password: 'secret',
+			longToken: false,
+		})
+	})
+
+	it('restores the username if the login form remounts', async () => {
+		sessionStorage.setItem('loginUsername', 'alice')
+
+		const wrapper = mountLogin()
+
+		expect(wrapper.get<HTMLInputElement>('input#username').element.value).toBe('alice')
+	})
+})

--- a/frontend/src/views/user/Login.vue
+++ b/frontend/src/views/user/Login.vue
@@ -35,8 +35,10 @@
 				autocomplete="username"
 				tabindex="1"
 				:error="usernameValid ? null : $t('user.auth.usernameRequired')"
+				@input="updateUsername"
+				@change="updateUsername"
 				@keyup.enter="submit"
-				@focusout="validateUsernameField()"
+				@focusout="validateUsernameField(); updateUsername()"
 			/>
 			<div class="field">
 				<div class="label-with-link">
@@ -120,7 +122,7 @@
 </template>
 
 <script setup lang="ts">
-import {computed, onBeforeMount, ref} from 'vue'
+import {computed, onBeforeMount, onMounted, ref} from 'vue'
 import {useI18n} from 'vue-i18n'
 import {useRouter} from 'vue-router'
 import {useDebounceFn} from '@vueuse/core'
@@ -161,6 +163,8 @@ const isDesktop = isDesktopApp()
 
 const confirmedEmailSuccess = ref(false)
 const errorMessage = ref('')
+const usernameCacheKey = 'loginUsername'
+const username = ref(sessionStorage.getItem(usernameCacheKey) ?? '')
 const password = ref('')
 const validatePasswordInitially = ref(false)
 const rememberMe = ref(false)
@@ -186,6 +190,19 @@ onBeforeMount(() => {
 
 const usernameValid = ref(true)
 const usernameRef = ref<HTMLInputElement | null>(null)
+
+onMounted(() => {
+	const usernameInput = document.getElementById('username') as HTMLInputElement | null
+	if (usernameInput !== null && username.value !== '') {
+		usernameInput.value = username.value
+	}
+})
+
+function updateUsername() {
+	username.value = usernameRef.value?.value ?? ''
+	sessionStorage.setItem(usernameCacheKey, username.value)
+}
+
 const validateUsernameField = useDebounceFn(() => {
 	usernameValid.value = usernameRef.value?.value !== ''
 }, 100)
@@ -194,13 +211,20 @@ const validateUsernameField = useDebounceFn(() => {
 const needsTotpPasscode = computed(() => authStore.needsTotpPasscode)
 const totpPasscode = ref<HTMLInputElement | null>(null)
 
+interface LoginCredentials {
+	username: string
+	password: string
+	longToken: boolean
+	totpPasscode?: string
+}
+
 async function submit() {
 	errorMessage.value = ''
 	// Some browsers prevent Vue bindings from working with autofilled values.
 	// To work around this, we're manually getting the values here instead of relying on vue bindings.
 	// For more info, see https://kolaente.dev/vikunja/frontend/issues/78
-	const credentials = {
-		username: usernameRef.value?.value,
+	const credentials: LoginCredentials = {
+		username: usernameRef.value?.value || username.value,
 		password: password.value,
 		longToken: rememberMe.value,
 	}
@@ -218,11 +242,13 @@ async function submit() {
 
 	try {
 		await authStore.login(credentials)
+		sessionStorage.removeItem(usernameCacheKey)
 		authStore.setNeedsTotpPasscode(false)
 
 		redirectIfSaved()
 	} catch (e) {
-		if (e.response?.data.code === 1017 && !credentials.totpPasscode) {
+		const error = e as { response?: { data?: { code?: number } } }
+		if (error.response?.data?.code === 1017 && !credentials.totpPasscode) {
 			return
 		}
 


### PR DESCRIPTION
## Summary

Fixes the login form losing an already-entered username when the login view remounts after the browser tab loses and regains focus.

The username field intentionally remains DOM-driven so the existing browser autofill workaround is preserved. The patch adds a small session-scoped mirror of the username, restores it when the login form mounts again, and clears it after a successful login.

## Root Cause

The username field was intentionally not bound with `v-model` because some browsers do not reliably propagate autofilled values through Vue bindings. That meant the value only lived in the DOM. If the login form remounted while still on the login page, the DOM node was recreated and the typed username was lost.

## Screenshot

The UI is visually unchanged. 

<img width="1436" height="960" alt="Screenshot 2026-05-27 at 11 45 58" src="https://github.com/user-attachments/assets/abb7db66-e948-437b-adf2-ab00f0d16be6" />

## Tests

- `./node_modules/.bin/vitest --run src/views/user/Login.test.ts`
- `./node_modules/.bin/eslint src/views/user/Login.vue`
- `./node_modules/.bin/eslint --no-ignore src/views/user/Login.test.ts`

## Manual Verification

- Started the frontend dev server with `DEV_PROXY=https://try.vikunja.io`.
- Filled the username field on `/login`.
- Switched focus to another browser tab and back.
- Confirmed the username remained populated.
