### PR TITLE
fix(docker): make /tmp world-writable so exports work under any UID

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ WORKDIR /app/vikunja
 ENTRYPOINT [ "/app/vikunja/vikunja" ]
 EXPOSE 3456
 
-COPY --from=apibuilder --chown=1000:1000 /tmp /tmp
+COPY --from=apibuilder --chown=1000:1000 --chmod=1777 /tmp /tmp
 
 USER 1000
 


### PR DESCRIPTION
The scratch image shipped `/tmp` owned by `1000:1000` and writable only by UID 1000, so containers run under a different user (Unraid's `99:100`, OpenShift random UIDs, or any `user:` override) failed data exports with `error creating temp file: open /tmp/vikunja-export-*.zip: permission denied`.

The builder-stage `chmod 1777 /tmp` did not survive into the final image — #2316 had to add `--chown` to make it writable for UID 1000, which proves the world-writable intent was lost through the `COPY`. This forces the mode at copy time with BuildKit's `--chmod=1777`, restoring a normal sticky, world-writable `/tmp` that works for every UID.

Fixes #2755

## Test plan
- Build the image and run it with a non-1000 user (e.g. `docker run --user 99:100 ...`), then trigger a data export from Settings — it should produce the export instead of a `permission denied` error.