### PR TITLE
fix: move allowIconChanges config to API info endpoint so that it works on desktop

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -23,7 +23,6 @@
 	// It has to be the full url, including the last /api/v1 part and port.
 	// You can change this if your api is not reachable on the same port as the frontend.
 	window.API_URL = '/api/v1'
-	window.ALLOW_ICON_CHANGES = true
 </script>
 </body>
 </html>

--- a/frontend/src/components/home/Logo.vue
+++ b/frontend/src/components/home/Logo.vue
@@ -2,6 +2,7 @@
 import { computed } from 'vue'
 import { useNow } from '@vueuse/core'
 import { useAuthStore } from '@/stores/auth'
+import { useConfigStore } from '@/stores/config'
 import { useColorScheme } from '@/composables/useColorScheme'
 
 import LogoFull from '@/assets/logo-full.svg?component'
@@ -13,9 +14,10 @@ const now = useNow({
 })
 
 const authStore = useAuthStore()
+const configStore = useConfigStore()
 const { isDark } = useColorScheme()
 
-const Logo = computed(() => window.ALLOW_ICON_CHANGES
+const Logo = computed(() => configStore.allowIconChanges
 	&& authStore.settings.frontendSettings.allowIconChanges
 	&& now.value.getMonth() === 5
 	? LogoFullPride

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -19,7 +19,6 @@ declare global {
 		API_URL: string;
 		SENTRY_ENABLED?: boolean;
 		SENTRY_DSN?: string;
-		ALLOW_ICON_CHANGES: boolean;
 		CUSTOM_LOGO_URL?: string;
 		CUSTOM_LOGO_URL_DARK?: string;
 	}

--- a/frontend/src/stores/config.ts
+++ b/frontend/src/stores/config.ts
@@ -44,6 +44,7 @@ export interface ConfigState {
 		},
 	},
 	publicTeamsEnabled: boolean,
+	allowIconChanges: boolean,
 	enabledProFeatures: string[],
 }
 
@@ -84,6 +85,7 @@ export const useConfigStore = defineStore('config', () => {
 			},
 		},
 		publicTeamsEnabled: false,
+		allowIconChanges: true,
 		enabledProFeatures: [],
 	})
 

--- a/pkg/routes/api/v1/info.go
+++ b/pkg/routes/api/v1/info.go
@@ -55,6 +55,7 @@ type vikunjaInfos struct {
 	DemoModeEnabled            bool              `json:"demo_mode_enabled"`
 	WebhooksEnabled            bool              `json:"webhooks_enabled"`
 	PublicTeamsEnabled         bool              `json:"public_teams_enabled"`
+	AllowIconChanges           bool              `json:"allow_icon_changes"`
 	EnabledProFeatures         []license.Feature `json:"enabled_pro_features"`
 }
 
@@ -107,6 +108,7 @@ func Info(c *echo.Context) error {
 		DemoModeEnabled:        config.ServiceDemoMode.GetBool(),
 		WebhooksEnabled:        config.WebhooksEnabled.GetBool(),
 		PublicTeamsEnabled:     config.ServiceEnablePublicTeams.GetBool(),
+		AllowIconChanges:       config.ServiceAllowIconChanges.GetBool(),
 		EnabledProFeatures:     license.EnabledProFeatures(),
 		AvailableMigrators: []string{
 			(&vikunja_file.FileMigrator{}).Name(),

--- a/pkg/routes/static.go
+++ b/pkg/routes/static.go
@@ -48,7 +48,6 @@ const (
 <script>
 	window.SENTRY_ENABLED = {{ .SENTRY_ENABLED }}
 	window.SENTRY_DSN = '{{ .SENTRY_DSN }}'
-	window.ALLOW_ICON_CHANGES = {{ .ALLOW_ICON_CHANGES }}
 	window.CUSTOM_LOGO_URL = '{{ .CUSTOM_LOGO_URL }}'
 	window.CUSTOM_LOGO_URL_DARK = '{{ .CUSTOM_LOGO_URL_DARK }}'
 </script>`
@@ -92,10 +91,6 @@ func serveIndexFile(c *echo.Context, assetFs http.FileSystem) (err error) {
 			data["SENTRY_ENABLED"] = "true"
 		}
 		data["SENTRY_DSN"] = config.SentryFrontendDsn.GetString()
-		data["ALLOW_ICON_CHANGES"] = "false"
-		if config.ServiceAllowIconChanges.GetBool() {
-			data["ALLOW_ICON_CHANGES"] = "true"
-		}
 		data["CUSTOM_LOGO_URL"] = config.ServiceCustomLogoURL.GetString()
 		data["CUSTOM_LOGO_URL_DARK"] = config.ServiceCustomLogoURLDark.GetString()
 


### PR DESCRIPTION
Resolves https://github.com/go-vikunja/vikunja/issues/2821

## Summary
Migrate the `allowIconChanges` configuration from a server-rendered window variable to a dynamic API response, enabling runtime configuration changes without requiring frontend rebuilds.

## Key Changes
- **Backend**: Added `AllowIconChanges` field to the `/api/v1/info` endpoint response to expose the configuration value dynamically
- **Frontend Config Store**: Added `allowIconChanges` state to the config store with a default value of `true`, allowing the frontend to manage this setting centrally
- **Logo Component**: Updated to read `allowIconChanges` from the config store instead of the global `window.ALLOW_ICON_CHANGES` variable
- **Removed**: Eliminated server-side template rendering of `ALLOW_ICON_CHANGES` in `static.go`, the hardcoded default in `index.html`, and the TypeScript window interface declaration

## Implementation Details
- The config store now serves as the single source of truth for the `allowIconChanges` setting on the frontend
- The API info endpoint provides the backend configuration value, which can be consumed by the frontend to populate the config store
- This change maintains backward compatibility while enabling more flexible configuration management

https://claude.ai/code/session_01HAXTJNsDcfsB4hwDNKTECb