### PR TITLE
Improve TickTick import robustness for malformed numeric columns

### DIFF
--- a/pkg/modules/migration/ticktick/testdata_ticktick_invalid_numbers.csv
+++ b/pkg/modules/migration/ticktick/testdata_ticktick_invalid_numbers.csv
@@ -1,0 +1,9 @@
+"Date: 2026-02-27+0000"
+"Version: 7.1"
+"Status:
+0 Normal
+1 Completed
+2 Archived"
+"Folder Name","List Name","Title","Kind","Tags","Content","Is Check list","Start Date","Due Date","Reminder","Repeat","Priority","Status","Created Time","Completed Time","Order","Timezone","Is All Day","Is Floating","Column Name","Column Order","View Mode","taskId","parentId"
+"Work","Project Beta","Task with non-numeric priority","TEXT","","A task whose priority column is p1","N","","","","","p1","0","2026-02-15 09:30:00","","-1099511627776","Europe/Berlin",,"false",,,"list","1",""
+"Work","Project Beta","Task with non-numeric ids","TEXT","","A task with garbage in the id columns","N","","","","","0","0","2026-02-10 08:00:00","","0","Europe/Berlin","false","false",,,"list","abc","xyz"

--- a/pkg/modules/migration/ticktick/ticktick.go
+++ b/pkg/modules/migration/ticktick/ticktick.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"io"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -44,30 +45,82 @@ type Migrator struct {
 }
 
 type tickTickTask struct {
-	FolderName        string        `csv:"Folder Name"`
-	ProjectName       string        `csv:"List Name"`
-	Title             string        `csv:"Title"`
-	TagsList          string        `csv:"Tags"`
-	Tags              []string      `csv:"-"`
-	Content           string        `csv:"Content"`
-	IsChecklistString string        `csv:"Is Check list"`
-	IsChecklist       bool          `csv:"-"`
-	StartDate         tickTickTime  `csv:"Start Date"`
-	DueDate           tickTickTime  `csv:"Due Date"`
-	ReminderDuration  string        `csv:"Reminder"`
-	Reminder          time.Duration `csv:"-"`
-	Repeat            string        `csv:"Repeat"`
-	Priority          int           `csv:"Priority"`
-	Status            string        `csv:"Status"`
-	CreatedTime       tickTickTime  `csv:"Created Time"`
-	CompletedTime     tickTickTime  `csv:"Completed Time"`
-	Order             float64       `csv:"Order"`
-	TaskID            int64         `csv:"taskId"`
-	ParentID          int64         `csv:"parentId"`
+	FolderName        string           `csv:"Folder Name"`
+	ProjectName       string           `csv:"List Name"`
+	Title             string           `csv:"Title"`
+	TagsList          string           `csv:"Tags"`
+	Tags              []string         `csv:"-"`
+	Content           string           `csv:"Content"`
+	IsChecklistString string           `csv:"Is Check list"`
+	IsChecklist       bool             `csv:"-"`
+	StartDate         tickTickTime     `csv:"Start Date"`
+	DueDate           tickTickTime     `csv:"Due Date"`
+	ReminderDuration  string           `csv:"Reminder"`
+	Reminder          time.Duration    `csv:"-"`
+	Repeat            string           `csv:"Repeat"`
+	Priority          tickTickPriority `csv:"Priority"`
+	Status            string           `csv:"Status"`
+	CreatedTime       tickTickTime     `csv:"Created Time"`
+	CompletedTime     tickTickTime     `csv:"Completed Time"`
+	Order             float64          `csv:"Order"`
+	TaskID            tickTickNumber   `csv:"taskId"`
+	ParentID          tickTickNumber   `csv:"parentId"`
 }
 
 type tickTickTime struct {
 	time.Time
+}
+
+// tickTickNumber is an int64 that tolerates non-numeric or malformed values in
+// the numeric ID columns (taskId, parentId) of TickTick exports. Such values can
+// occur through column misalignment caused by unescaped delimiters, which would
+// otherwise make gocsv fail the entire import with an internal server error
+// (go-vikunja/vikunja#2822). Rather than aborting the import, we fall back to 0
+// for any value we cannot parse.
+type tickTickNumber int64
+
+func (n *tickTickNumber) UnmarshalCSV(csv string) error {
+	csv = strings.TrimSpace(csv)
+	if csv == "" {
+		*n = 0
+		return nil
+	}
+	parsed, err := strconv.ParseInt(csv, 10, 64)
+	if err != nil {
+		// Deliberately ignore the parse error and fall back to 0 so a single
+		// malformed value does not abort the whole import.
+		*n = 0
+		return nil //nolint:nilerr
+	}
+	*n = tickTickNumber(parsed)
+	return nil
+}
+
+// tickTickPriority parses the TickTick "Priority" column. TickTick exports the
+// priority either as a plain number (0, 1, 3, 5) or, in some exports, prefixed
+// with "p" (p1, p2, p3). We accept both forms and fall back to 0 (no priority)
+// for anything we cannot parse, so a stray value never fails the whole import
+// (go-vikunja/vikunja#2822). Vikunja's task priority is a free-form sortable
+// integer, so the parsed value is carried over as-is.
+type tickTickPriority int64
+
+func (p *tickTickPriority) UnmarshalCSV(csv string) error {
+	csv = strings.TrimSpace(csv)
+	csv = strings.TrimPrefix(csv, "p")
+	csv = strings.TrimPrefix(csv, "P")
+	if csv == "" {
+		*p = 0
+		return nil
+	}
+	parsed, err := strconv.ParseInt(csv, 10, 64)
+	if err != nil {
+		// Deliberately ignore the parse error and fall back to 0 so a single
+		// malformed value does not abort the whole import.
+		*p = 0
+		return nil //nolint:nilerr
+	}
+	*p = tickTickPriority(parsed)
+	return nil
 }
 
 func (date *tickTickTime) UnmarshalCSV(csv string) (err error) {
@@ -88,12 +141,12 @@ func (date *tickTickTime) UnmarshalCSV(csv string) (err error) {
 // appears before any of its children. Tasks without a parent come first.
 // The relative order of siblings / unrelated tasks is preserved.
 func sortParentsBeforeChildren(tasks []*tickTickTask) []*tickTickTask {
-	tasksByID := make(map[int64]*tickTickTask, len(tasks))
+	tasksByID := make(map[tickTickNumber]*tickTickTask, len(tasks))
 	for _, t := range tasks {
 		tasksByID[t.TaskID] = t
 	}
 
-	placed := make(map[int64]bool, len(tasks))
+	placed := make(map[tickTickNumber]bool, len(tasks))
 	result := make([]*tickTickTask, 0, len(tasks))
 
 	var place func(t *tickTickTask)
@@ -161,7 +214,7 @@ func convertTickTickToVikunja(tasks []*tickTickTask) (result []*models.ProjectWi
 
 		task := &models.TaskWithComments{
 			Task: models.Task{
-				ID:          t.TaskID,
+				ID:          int64(t.TaskID),
 				Title:       t.Title,
 				Description: t.Content,
 				StartDate:   t.StartDate.Time,
@@ -170,6 +223,7 @@ func convertTickTickToVikunja(tasks []*tickTickTask) (result []*models.ProjectWi
 				Done:        t.Status == "1" || t.Status == "2",
 				DoneAt:      t.CompletedTime.Time,
 				Position:    t.Order,
+				Priority:    int64(t.Priority),
 				Labels:      labels,
 			},
 		}
@@ -185,7 +239,7 @@ func convertTickTickToVikunja(tasks []*tickTickTask) (result []*models.ProjectWi
 
 		if t.ParentID != 0 {
 			task.RelatedTasks = map[models.RelationKind][]*models.Task{
-				models.RelationKindParenttask: {{ID: t.ParentID}},
+				models.RelationKindParenttask: {{ID: int64(t.ParentID)}},
 			}
 		}
 

--- a/pkg/modules/migration/ticktick/ticktick.go
+++ b/pkg/modules/migration/ticktick/ticktick.go
@@ -146,12 +146,16 @@ func sortParentsBeforeChildren(tasks []*tickTickTask) []*tickTickTask {
 		tasksByID[t.TaskID] = t
 	}
 
-	placed := make(map[tickTickNumber]bool, len(tasks))
+	// placed is keyed by the task itself rather than by TaskID: malformed
+	// exports can collapse several taskIds to 0 (see tickTickNumber), and
+	// keying by ID would treat every zero-ID task after the first as already
+	// placed and silently drop it.
+	placed := make(map[*tickTickTask]bool, len(tasks))
 	result := make([]*tickTickTask, 0, len(tasks))
 
 	var place func(t *tickTickTask)
 	place = func(t *tickTickTask) {
-		if placed[t.TaskID] {
+		if placed[t] {
 			return
 		}
 		// If this task has a parent that we know about, place the parent first.
@@ -160,7 +164,7 @@ func sortParentsBeforeChildren(tasks []*tickTickTask) []*tickTickTask {
 				place(parent)
 			}
 		}
-		placed[t.TaskID] = true
+		placed[t] = true
 		result = append(result, t)
 	}
 

--- a/pkg/modules/migration/ticktick/ticktick_test.go
+++ b/pkg/modules/migration/ticktick/ticktick_test.go
@@ -846,3 +846,26 @@ func TestNonNumericNumberColumns(t *testing.T) {
 	}
 	assert.Equal(t, int64(1), priority)
 }
+
+// TestMultipleTasksWithMalformedIDsAreNotDropped guards against a regression
+// where collapsing several unparseable taskIds to 0 caused all but the first
+// zero-ID task to be silently dropped by sortParentsBeforeChildren.
+func TestMultipleTasksWithMalformedIDsAreNotDropped(t *testing.T) {
+	tasks := []*tickTickTask{
+		{TaskID: 0, ProjectName: "Project 1", Title: "First malformed"},
+		{TaskID: 0, ProjectName: "Project 1", Title: "Second malformed"},
+		{TaskID: 0, ProjectName: "Project 1", Title: "Third malformed"},
+	}
+
+	sorted := sortParentsBeforeChildren(tasks)
+	require.Len(t, sorted, 3, "no task with a zero ID should be dropped")
+
+	vikunjaTasks := convertTickTickToVikunja(tasks)
+	titles := []string{}
+	for _, project := range vikunjaTasks {
+		for _, task := range project.Tasks {
+			titles = append(titles, task.Title)
+		}
+	}
+	assert.ElementsMatch(t, []string{"First malformed", "Second malformed", "Third malformed"}, titles)
+}

--- a/pkg/modules/migration/ticktick/ticktick_test.go
+++ b/pkg/modules/migration/ticktick/ticktick_test.go
@@ -131,7 +131,7 @@ func TestConvertTicktickTasksToVikunja(t *testing.T) {
 	assert.Equal(t, models.RelatedTaskMap{
 		models.RelationKindParenttask: []*models.Task{
 			{
-				ID: tickTickTasks[1].ParentID,
+				ID: int64(tickTickTasks[1].ParentID),
 			},
 		},
 	}, vikunjaTasks[1].Tasks[1].RelatedTasks)
@@ -769,4 +769,80 @@ func TestEmptyLabelHandlingWithRealCSV(t *testing.T) {
 
 		t.Logf("Successfully processed %d tasks with %d total labels, no empty labels created", len(tasks), totalLabels)
 	})
+}
+
+func TestTickTickPriorityParsing(t *testing.T) {
+	cases := []struct {
+		input    string
+		expected int64
+	}{
+		{"", 0},
+		{"0", 0},
+		{"1", 1},
+		{"3", 3},
+		{"5", 5},
+		{"p1", 1},
+		{"P2", 2},
+		{"p3", 3},
+		{" p5 ", 5},
+		{"garbage", 0},
+	}
+	for _, c := range cases {
+		t.Run(c.input, func(t *testing.T) {
+			var p tickTickPriority
+			require.NoError(t, p.UnmarshalCSV(c.input))
+			assert.Equal(t, tickTickPriority(c.expected), p)
+		})
+	}
+}
+
+// TestNonNumericNumberColumns ensures that exports containing non-numeric values
+// in columns Vikunja parses as integers (Priority, taskId, parentId) do not fail
+// the whole import. See go-vikunja/vikunja#2822.
+func TestNonNumericNumberColumns(t *testing.T) {
+	file, err := os.Open("testdata_ticktick_invalid_numbers.csv")
+	require.NoError(t, err)
+	defer file.Close()
+
+	stat, err := file.Stat()
+	require.NoError(t, err)
+
+	lines, err := linesToSkipBeforeHeader(file, stat.Size())
+	require.NoError(t, err)
+
+	_, err = file.Seek(0, io.SeekStart)
+	require.NoError(t, err)
+
+	dec, err := newLineSkipDecoder(file, lines)
+	require.NoError(t, err)
+	tasks := []*tickTickTask{}
+	err = gocsv.UnmarshalDecoder(dec, &tasks)
+	require.NoError(t, err, "non-numeric values in numeric columns should not fail the import")
+	require.Len(t, tasks, 2)
+
+	// "p1" in the Priority column is parsed as priority 1 instead of crashing.
+	assert.Equal(t, tickTickPriority(1), tasks[0].Priority)
+	assert.Equal(t, tickTickNumber(1), tasks[0].TaskID)
+
+	// Non-numeric taskId/parentId fall back to 0 as well.
+	assert.Equal(t, tickTickNumber(0), tasks[1].TaskID)
+	assert.Equal(t, tickTickNumber(0), tasks[1].ParentID)
+
+	// And the tasks still convert to the Vikunja structure, carrying the parsed
+	// priority over to the resulting task.
+	for _, task := range tasks {
+		task.Tags = strings.Split(task.TagsList, ", ")
+	}
+	vikunjaTasks := convertTickTickToVikunja(tasks)
+	require.Greater(t, len(vikunjaTasks), 0)
+
+	var priority int64
+	for _, project := range vikunjaTasks {
+		for _, task := range project.Tasks {
+			if task.Title == "Task with non-numeric priority" {
+				priority = task.Priority
+			}
+		}
+	}
+	assert.Equal(t, int64(1), priority)
 }


### PR DESCRIPTION
Resolves https://github.com/go-vikunja/vikunja/issues/2822

## Summary
Enhance the TickTick migration importer to gracefully handle malformed or non-numeric values in numeric columns (Priority, taskId, parentId), preventing import failures due to column misalignment or data corruption.

## Changes
- **New custom CSV unmarshalers:**
  - `tickTickNumber`: Parses taskId and parentId columns, falling back to 0 for non-numeric values instead of aborting the import
  - `tickTickPriority`: Parses Priority column supporting both plain numbers (0, 1, 3, 5) and prefixed formats (p1, p2, p3), with graceful fallback to 0

- **Type updates:**
  - Changed `Priority` field from `int` to `tickTickPriority` type
  - Changed `TaskID` and `ParentID` fields from `int64` to `tickTickNumber` type
  - Updated type conversions in `convertTickTickToVikunja()` to cast custom types back to `int64` where needed

- **Priority mapping:**
  - Added `Priority` field population in task conversion (previously ignored)

- **Test coverage:**
  - Added `TestTickTickPriorityParsing()` covering empty strings, plain numbers, prefixed formats, whitespace, and invalid input
  - Added `TestNonNumericNumberColumns()` with test CSV file demonstrating real-world malformed data handling
  - Updated existing test assertions to account for type changes

## Implementation Details
The custom unmarshalers deliberately ignore parse errors and return `nil` (with `//nolint:nilerr` suppression) rather than propagating errors. This ensures a single malformed value in a numeric column does not abort the entire import, addressing issue go-vikunja/vikunja#2822 where unescaped delimiters cause column misalignment.

https://claude.ai/code/session_01Et6z8WserfVvzKBwX19YJv