### PR TITLE
fix(auth): filter empty strings in API token route group name

### DIFF
--- a/pkg/models/api_routes.go
+++ b/pkg/models/api_routes.go
@@ -78,7 +78,7 @@ func getRouteGroupName(path string) (finalName string, filteredParts []string) {
 	parts := strings.Split(stripAPIVersion(path), "/")
 	filteredParts = []string{}
 	for _, part := range parts {
-		if strings.HasPrefix(part, ":") {
+		if part == "" || strings.HasPrefix(part, ":") {
 			continue
 		}
 

--- a/pkg/models/api_routes_test.go
+++ b/pkg/models/api_routes_test.go
@@ -91,6 +91,37 @@ func TestStripAPIVersion(t *testing.T) {
 	}
 }
 
+func TestGetRouteGroupName(t *testing.T) {
+	cases := []struct {
+		path     string
+		wantName string
+	}{
+		{"/api/v1/tasks/:projecttask/labels", "tasks_labels"},
+		{"/api/v1/tasks/:projecttask/labels/:label", "tasks_labels"},
+		{"/api/v1/tasks/:projecttask/labels/bulk", "tasks_labels_bulk"},
+		{"/api/v1/tasks/:projecttask/assignees", "tasks_assignees"},
+		{"/api/v1/tasks/:projecttask/comments", "tasks_comments"},
+		{"/api/v1/tasks/:projecttask/relations", "tasks_relations"},
+		{"/api/v1/tasks/:projecttask/attachments", "tasks_attachments"},
+		{"/api/v1/projects/:project/views", "projects_views"},
+		{"/api/v1/projects/:project/teams", "projects_teams"},
+		{"/api/v1/projects/:project/users", "projects_users"},
+		{"/api/v1/teams/:team/members", "teams_members"},
+		{"/api/v1/labels", "labels"},
+		{"/api/v1/labels/:label", "labels"},
+		{"/api/v1/projects/:project/tasks", "tasks"},
+		{"/api/v1/tasks/all", "tasks"},
+		{"/api/v2/labels", "labels"},
+		{"/api/v2/tasks/:id/labels", "tasks_labels"},
+	}
+	for _, c := range cases {
+		t.Run(c.path, func(t *testing.T) {
+			name, _ := getRouteGroupName(c.path)
+			assert.Equal(t, c.wantName, name)
+		})
+	}
+}
+
 // TestCollectRoutesV2 verifies that /api/v2 routes are stored in the v2
 // shadow table under the same (group, permission) keys their v1 counterparts
 // would use. This is what lets a token scoped on `labels.read_one` authorise


### PR DESCRIPTION
## Summary

`getRouteGroupName` splits the version-stripped path on `"/"` but does not filter the empty string produced by the leading slash. This causes all nested resource paths to get a leading underscore in their group name:

| Path | Before (bug) | After (fix) |
|------|-------------|-------------|
| `/tasks/:id/labels` | `_tasks_labels` | `tasks_labels` |
| `/tasks/:id/assignees` | `_tasks_assignees` | `tasks_assignees` |
| `/projects/:id/views` | `_projects_views` | `projects_views` |
| `/teams/:id/members` | `_teams_members` | `teams_members` |

Since `isStandardCRUDRoute`'s `crudResources` map lists these without the underscore (e.g. `"tasks_labels": true`), the lookup always misses. The routes are then registered under the wrong key in `apiTokenRoutes`, making them inaccessible to scoped API tokens — even when the token has full permissions on the relevant groups.

**Impact:** Any scoped API token attempting to assign labels to tasks, manage assignees, add comments, or perform any other nested resource operation gets a 401, regardless of token permissions.

## Fix

One-line change: add `part == ""` to the existing filter predicate in `getRouteGroupName`, so empty parts from the leading slash are skipped alongside path parameters.

## Test plan

- [x] Added `TestGetRouteGroupName` covering all nested resource paths (v1 and v2)
- [x] Existing `TestCanDoAPIRoute_BulkLabelTask` now passes (it was asserting the correct behavior but the code didn't match)

🤖 Generated with [Claude Code](https://claude.com/claude-code)