### PR TITLE
docs: Add guidance on translation management

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -262,6 +262,8 @@ In the frontend, all translation strings live in `frontend/src/i18n/lang`. For t
 You only need to adjust the `en.json` file with the source string. The actual translation happens elsewhere.
 After adjusting the source string, you need to call the respective translation library with the key. Both are similar, check the existing code to figure it out.
 
+**Do not add a new language from scratch or translate strings into other languages yourself.** Translations are managed through a dedicated workflow. If you are asked to add a new language, translate existing strings, or update translations for non-English locales, point the user to the translation guide instead: https://vikunja.io/docs/translations/
+
 ## Key Files and Conventions
 
 **Configuration:**


### PR DESCRIPTION
## Summary
Added documentation guidance to clarify that translations should not be managed manually by contributors. This prevents contributors from attempting to add new languages or translate strings themselves, directing them to the proper translation workflow instead.

## Changes
- Added a note to the AGENTS.md translation section explicitly prohibiting manual translation work
- Directs users to the official translation guide at https://vikunja.io/docs/translations/ when they encounter translation-related requests
- Clarifies that only the `en.json` source file should be modified by contributors, with actual translations handled through a dedicated workflow

## Details
This documentation update helps maintain consistency in the translation process by establishing a clear policy that translations are managed through a centralized workflow rather than ad-hoc contributor submissions. This prevents duplicate work, ensures quality control, and maintains a single source of truth for translations.

https://claude.ai/code/session_01PjzEjHqjFF2jPGb4sBZcUK