### PR TITLE
fix: GCS signing issue

### DIFF
--- a/pkg/files/filehandling.go
+++ b/pkg/files/filehandling.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"testing"
 	"time"
@@ -43,6 +44,16 @@ var storage FileStorage
 
 func setDefaultLocalConfig() {
 	config.FilesBasePath.Set(config.ResolvePath(config.FilesBasePath.GetString()))
+}
+
+// Wrap Signer to remove header
+type gcsHttpSigner struct {
+	wrapped s3.HTTPSignerV4
+}
+
+func (s *gcsHttpSigner) SignHTTP(ctx context.Context, credentials aws.Credentials, req *http.Request, payloadHash string, service string, region string, signingTime time.Time, optFns ...func(*v4.SignerOptions)) error {
+	req.Header.Del("Accept-Encoding")
+	return s.wrapped.SignHTTP(ctx, credentials, req, payloadHash, service, region, signingTime, optFns...)
 }
 
 // initS3FileHandler initializes the S3 file backend
@@ -80,6 +91,10 @@ func initS3FileHandler() error {
 	client := s3.NewFromConfig(cfg, func(o *s3.Options) {
 		o.BaseEndpoint = aws.String(endpoint)
 		o.UsePathStyle = config.FilesS3UsePathStyle.GetBool()
+		if endpoint == "https://storage.googleapis.com" {
+			o.HTTPSignerV4 = &gcsHttpSigner{wrapped: o.HTTPSignerV4}
+			cfg.RequestChecksumCalculation = aws.RequestChecksumCalculationWhenRequired
+		}
 		if config.FilesS3DisableSigning.GetBool() {
 			o.APIOptions = append(o.APIOptions, v4.SwapComputePayloadSHA256ForUnsignedPayloadMiddleware)
 		}

--- a/pkg/files/filehandling.go
+++ b/pkg/files/filehandling.go
@@ -47,11 +47,11 @@ func setDefaultLocalConfig() {
 }
 
 // Wrap Signer to remove header
-type gcsHttpSigner struct {
+type gcsHTTPSigner struct {
 	wrapped s3.HTTPSignerV4
 }
 
-func (s *gcsHttpSigner) SignHTTP(ctx context.Context, credentials aws.Credentials, req *http.Request, payloadHash string, service string, region string, signingTime time.Time, optFns ...func(*v4.SignerOptions)) error {
+func (s *gcsHTTPSigner) SignHTTP(ctx context.Context, credentials aws.Credentials, req *http.Request, payloadHash string, service string, region string, signingTime time.Time, optFns ...func(*v4.SignerOptions)) error {
 	req.Header.Del("Accept-Encoding")
 	return s.wrapped.SignHTTP(ctx, credentials, req, payloadHash, service, region, signingTime, optFns...)
 }
@@ -92,7 +92,7 @@ func initS3FileHandler() error {
 		o.BaseEndpoint = aws.String(endpoint)
 		o.UsePathStyle = config.FilesS3UsePathStyle.GetBool()
 		if endpoint == "https://storage.googleapis.com" {
-			o.HTTPSignerV4 = &gcsHttpSigner{wrapped: o.HTTPSignerV4}
+			o.HTTPSignerV4 = &gcsHTTPSigner{wrapped: o.HTTPSignerV4}
 			cfg.RequestChecksumCalculation = aws.RequestChecksumCalculationWhenRequired
 		}
 		if config.FilesS3DisableSigning.GetBool() {


### PR DESCRIPTION
There are signing issues when using Google Cloud Storage as an S3 backend.
For whatever reason, GCS modifies `Accept-Encoding` header.
This causes Vikunja to fail even with `files.s3.disablesigning: true`

The maintainers of aws-sdk-go refuse to address this, hence this PR.

More details can be found here: https://github.com/aws/aws-sdk-go-v2/issues/1816#issuecomment-4526752227