### PR TITLE
fix: blur quick add input on escape

### DIFF
--- a/frontend/src/components/tasks/AddTask.vue
+++ b/frontend/src/components/tasks/AddTask.vue
@@ -25,6 +25,7 @@
 					rows="1"
 					@keydown="resetEmptyTitleError"
 					@keydown.enter="handleEnter"
+					@keydown.esc="blurTaskInput"
 				/>
 				<QuickAddMagic
 					:highlight-hint-icon="taskAddHovered"
@@ -280,6 +281,10 @@ function handleEnter(e: KeyboardEvent) {
 
 function focusTaskInput() {
 	newTaskInput.value?.focus()
+}
+
+function blurTaskInput() {
+	newTaskInput.value?.blur()
 }
 
 defineExpose({


### PR DESCRIPTION
When the quick add input is focused, pressing Esc key now unfocuses the input. This frees up keyboard shortcuts without having to reach for mouse.