### PR TITLE
improve systemd service security with hardening directives

### DIFF
--- a/vikunja.service
+++ b/vikunja.service
@@ -14,6 +14,34 @@ Type=simple
 WorkingDirectory=/opt/vikunja
 ExecStart=/usr/local/bin/vikunja
 Restart=always
+
+# Hardening
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectHome=yes
+ProtectProc=invisible
+ProcSubset=pid
+UMask=0077
+
+CapabilityBoundingSet=
+AmbientCapabilities=
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectKernelLogs=yes
+ProtectControlGroups=yes
+ProtectClock=yes
+ProtectHostname=yes
+PrivateDevices=yes
+RestrictNamespaces=yes
+RestrictSUIDSGID=yes
+RestrictRealtime=yes
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX AF_NETLINK
+SystemCallArchitectures=native
+SystemCallFilter=@system-service
+SystemCallFilter=~@privileged @resources
+
 # If you want to bind Vikunja to a port below 1024 uncomment
 # the two values below
 ###


### PR DESCRIPTION
the shipped vikunja.service runs as `root` with no isolation. it has full root access, unrestricted filesystem access and the service can use any syscall. for a network service, the surface could be tightened down. also, `systemd-analyze security` gives the original unit a score of 9.8 (UNSAFE).

this PR adds a set of systemd security directives that should be safe for any configuration (no user, path or database changes needed): it does namespace isolation (tmp, home, proc), kernel protection, device restriction and capability clearing.

i've tested it on vikunja 2.3.0 with sqlite, uploads (profile pic) and remote clients (tasks.org).  a dedicated `vikunja` unix user on its own `/var/lib/vikunja` home would further reduce any potential attack surface, but it would require packaging changes and introduce the need for users to manually move their install into another folder, which is beyond the scope of this PR.
