### PR TITLE
fix: ensure new tasks appear at the top in saved filter views

### DIFF
--- a/pkg/models/saved_filter_positions_test.go
+++ b/pkg/models/saved_filter_positions_test.go
@@ -313,3 +313,61 @@ func TestIssue724_SortingOnFilteredViews(t *testing.T) {
 	assert.Zero(t, zeroCount,
 		"No position=0 records should exist in database for view %d", view.ID)
 }
+
+// A task that starts matching a saved filter has no position row in that filter's
+// view yet. The fetch-time safety net creates one at the top, but it runs after the
+// query has already ordered the page. With NULLS LAST this made the new task appear
+// last on the first load and jump to the top only after a refresh. It must instead
+// stay at the top on the very first fetch and not move on subsequent fetches.
+func TestSavedFilterNewTaskStaysAtTopAcrossFetches(t *testing.T) {
+	db.LoadAndAssertFixtures(t)
+	s := db.NewSession()
+	defer s.Close()
+
+	u := &user.User{ID: 1}
+
+	sf := &SavedFilter{
+		Title:   "open-tasks-position",
+		Filters: &TaskCollection{Filter: "done = false"},
+	}
+	require.NoError(t, sf.Create(s, u))
+
+	listView := &ProjectView{}
+	exists, err := s.Where("project_id = ? AND view_kind = ?",
+		getProjectIDFromSavedFilterID(sf.ID), ProjectViewKindList).Get(listView)
+	require.NoError(t, err)
+	require.True(t, exists)
+
+	// Give every currently-matching task a position so the new task below is the
+	// only one without one (this is the state after the cron / a previous fetch).
+	require.NoError(t, RecalculateTaskPositions(s, listView, u))
+
+	newTask := &Task{Title: "freshly created open task", ProjectID: 1}
+	require.NoError(t, newTask.Create(s, u))
+
+	indexOfNewTask := func() int {
+		tc := &TaskCollection{
+			ProjectID:     getProjectIDFromSavedFilterID(sf.ID),
+			ProjectViewID: listView.ID,
+			SortBy:        []string{"position"},
+			OrderBy:       []string{"asc"},
+		}
+		result, _, _, err := tc.ReadAll(s, u, "", 1, 1000)
+		require.NoError(t, err)
+		tasks, ok := result.([]*Task)
+		require.True(t, ok)
+		for i, task := range tasks {
+			if task.ID == newTask.ID {
+				return i
+			}
+		}
+		t.Fatalf("new task %d not found in filter results", newTask.ID)
+		return -1
+	}
+
+	first := indexOfNewTask()
+	second := indexOfNewTask()
+
+	assert.Equal(t, 0, first, "newly matching task must appear at the top on the first fetch, not only after a refresh")
+	assert.Equal(t, first, second, "task order must be stable across fetches")
+}

--- a/pkg/models/task_search.go
+++ b/pkg/models/task_search.go
@@ -137,11 +137,17 @@ func getOrderByDBStatement(opts *taskSearchOptions) (orderby string, err error) 
 			prefix = "tasks."
 		}
 
+		nullsFirst := opts.isSavedFilter && param.sortBy == taskPropertyPosition
+
 		// Mysql sorts columns with null values before ones without null value.
 		// Because it does not have support for NULLS FIRST or NULLS LAST we work around this by
 		// first sorting for null (or not null) values and then the order we actually want to.
 		if db.Type() == schemas.MYSQL {
-			orderby += prefix + "`" + param.sortBy + "` IS NULL, "
+			nullSort := ""
+			if nullsFirst {
+				nullSort = " DESC"
+			}
+			orderby += prefix + "`" + param.sortBy + "` IS NULL" + nullSort + ", "
 		}
 
 		orderby += prefix + "`" + param.sortBy + "` " + param.orderBy.String()
@@ -149,7 +155,11 @@ func getOrderByDBStatement(opts *taskSearchOptions) (orderby string, err error) 
 		// Postgres and sqlite allow us to control how columns with null values are sorted.
 		// To make that consistent with the sort order we have and other dbms, we're adding a separate clause here.
 		if db.Type() == schemas.POSTGRES || db.Type() == schemas.SQLITE {
-			orderby += " NULLS LAST"
+			if nullsFirst {
+				orderby += " NULLS FIRST"
+			} else {
+				orderby += " NULLS LAST"
+			}
 		}
 
 		if (i + 1) < len(opts.sortby) {

--- a/pkg/models/tasks.go
+++ b/pkg/models/tasks.go
@@ -720,6 +720,10 @@ func addMoreInfoToTasks(s *xorm.Session, taskMap map[int64]*Task, a web.Auth, vi
 				}
 			}
 
+			sort.Slice(tasksNeedingPositions, func(i, j int) bool {
+				return tasksNeedingPositions[i].ID < tasksNeedingPositions[j].ID
+			})
+
 			if len(tasksNeedingPositions) > 0 {
 				// Create positions for tasks that don't have them
 				if err = createPositionsForTasksInView(s, tasksNeedingPositions, view, a); err != nil {


### PR DESCRIPTION
## Problem

In a **saved filter** viewed as a List and sorted **Manually** (i.e. by `position` ascending), a task that newly matches the filter — e.g. one you just created that satisfies `done = false && (assignees = me || creator = me)` — shows up at the **bottom** of the list on first load, then **jumps to the top** after a page refresh.

## Root cause

A pure ordering issue in the task query, specific to saved filters:

- Tasks only get a `task_positions` row for the views of their *own* project at creation time (`setTaskInBucketInViews`). A saved filter is a pseudo-project, so a newly matching task has **no position row** in the filter's view.
- The list query orders by `task_positions.position` through a `LEFT JOIN`, so that task's position is `NULL`:

```sql
SELECT tasks.*
FROM tasks
LEFT JOIN task_positions
       ON task_positions.task_id = tasks.id
      AND task_positions.project_view_id = ?
ORDER BY task_positions.position ASC NULLS LAST, tasks.id ASC
```

  `getOrderByDBStatement` sorted `NULL`s **last** on every engine → the task goes to the bottom.
- The order (and pagination) of the returned slice is fixed by that query. `addMoreInfoToTasks` then runs the saved-filter "safety net" (`createPositionsForTasksInView`), which lazily creates a position row **at the top** — but *after* the query already ordered the page, so it doesn't affect that response. The next fetch sees the new row and renders the task at the top → the bottom→top jump.

## Fix

### 1. Sort `NULL` positions first for saved filters (`getOrderByDBStatement`)

An unpositioned task in a saved filter logically belongs exactly where the safety net will place it — the top. Sorting position `NULL`s **first** makes the first load match the persisted state, and also ensures the task lands on page 1 where the page-scoped safety net actually creates its position.

```go
nullsFirst := opts.isSavedFilter && param.sortBy == taskPropertyPosition

// MySQL has no NULLS FIRST/LAST syntax; emulate it with `col IS NULL`.
if db.Type() == schemas.MYSQL {
    nullSort := ""
    if nullsFirst {
        nullSort = " DESC" // IS NULL = 1 for nulls; DESC ranks them first
    }
    orderby += prefix + "`" + param.sortBy + "` IS NULL" + nullSort + ", "
}

orderby += prefix + "`" + param.sortBy + "` " + param.orderBy.String()

if db.Type() == schemas.POSTGRES || db.Type() == schemas.SQLITE {
    if nullsFirst {
        orderby += " NULLS FIRST"
    } else {
        orderby += " NULLS LAST"
    }
}
```

### 2. Assign positions in a stable order (`addMoreInfoToTasks`)

`taskMap` iteration order is nondeterministic, so when several tasks newly match at once they would otherwise receive position values in random order and reshuffle between refreshes. Sorting by `ID` matches the query's secondary sort (`id ASC`), keeping multi-task order stable.

```go
sort.Slice(tasksNeedingPositions, func(i, j int) bool {
    return tasksNeedingPositions[i].ID < tasksNeedingPositions[j].ID
})
```

## Scope / compatibility

- Behavior changes **only** for saved-filter views sorted by `position`. Regular project views and all other sort columns keep the previous `NULLS LAST` behavior (and regular-project tasks always have a position row anyway, so there is no regression).
- Verified equivalent `NULL` ordering across Postgres, SQLite, and MySQL.

## Testing

New regression test `TestSavedFilterNewTaskStaysAtTopAcrossFetches`: a task that newly matches a position-sorted saved filter stays at index `0` on the first fetch and does not move on subsequent fetches. It fails before the fix (the task lands last, then jumps to the top).

```go
first := indexOfNewTask()
second := indexOfNewTask()

assert.Equal(t, 0, first, "newly matching task must appear at the top on the first fetch")
assert.Equal(t, first, second, "task order must be stable across fetches")
```

Full `pkg/models` suite passes, including the existing regular-view `order by position` test that asserts `NULLS LAST`.

## Known limitation

The safety net only positions tasks present in the current page's result set. If the number of still-unpositioned matching tasks exceeds one page, tasks on later pages stay `NULL` and can still reorder relative to the just-positioned ones until the periodic position cron runs. This is a pre-existing limitation of the lazy safety net, not introduced here; the common single-task case is fully fixed.

---