### PR TITLE
fix: assign bot-created projects to the bot's owner

### DIFF
--- a/pkg/models/project.go
+++ b/pkg/models/project.go
@@ -1046,8 +1046,17 @@ func CreateProject(s *xorm.Session, project *Project, auth web.Auth, createBackl
 	}
 
 	project.ID = 0
-	project.OwnerID = doer.ID
-	project.Owner = doer
+	if doer.IsBot() {
+		project.OwnerID = doer.BotOwnerID
+		owner, err := user.GetUserByID(s, doer.BotOwnerID)
+		if err != nil {
+			return err
+		}
+		project.Owner = owner
+	} else {
+		project.OwnerID = doer.ID
+		project.Owner = doer
+	}
 
 	err = checkProjectBeforeUpdateOrDelete(s, project)
 	if err != nil {
@@ -1059,6 +1068,18 @@ func CreateProject(s *xorm.Session, project *Project, auth web.Auth, createBackl
 	_, err = s.Insert(project)
 	if err != nil {
 		return
+	}
+
+	// Give the bot continued access to the project it created.
+	if doer.IsBot() {
+		pu := &ProjectUser{
+			ProjectID:  project.ID,
+			Username:   doer.Username,
+			Permission: PermissionAdmin,
+		}
+		if err = pu.Create(s, auth); err != nil {
+			return err
+		}
 	}
 
 	project.Position = calculateDefaultPosition(project.ID, project.Position)

--- a/pkg/models/project_test.go
+++ b/pkg/models/project_test.go
@@ -79,6 +79,29 @@ func TestProject_CreateOrUpdate(t *testing.T) {
 				"project_view_id": kanbanView.ID,
 			}, false)
 		})
+		t.Run("bot project owned by bot owner", func(t *testing.T) {
+			db.LoadAndAssertFixtures(t)
+			s := db.NewSession()
+			defer s.Close()
+
+			bot := &user.User{ID: 23, Username: "bot-owner-a-assistant", BotOwnerID: 21}
+			project := Project{Title: "bot-created"}
+			err := project.Create(s, bot)
+			require.NoError(t, err)
+			require.NoError(t, s.Commit())
+
+			// The bot's owner should own the project.
+			db.AssertExists(t, "projects", map[string]interface{}{
+				"id":       project.ID,
+				"owner_id": 21,
+			}, false)
+			// The bot should retain access via a share.
+			db.AssertExists(t, "users_projects", map[string]interface{}{
+				"user_id":    23,
+				"project_id": project.ID,
+				"permission": PermissionAdmin,
+			}, false)
+		})
 		t.Run("kanban view creates To-Do, doing, done buckets", func(t *testing.T) {
 			db.LoadAndAssertFixtures(t)
 			s := db.NewSession()


### PR DESCRIPTION
Problem: A bot account on my account created a project by API, but I cannot see the project.

Solution: Assign Project ownership to the bot owner, then share admin access with the bot.

I considered sharing the Project with the bot owner instead of assigning ownership, but this makes more sense. Either solution works for me though.

_AI Generated Below_
<hr/>
When a bot user creates a project, the bot's owner (the human who created the bot) now owns the project instead of the bot itself. The bot retains admin access via an explicit project share. This ensures the human can always see and manage projects their bots create.