### PR TITLE
fix(tasks): prevent position race conditions with atomic upserts and locking

### DIFF
--- a/pkg/models/listeners.go
+++ b/pkg/models/listeners.go
@@ -905,7 +905,7 @@ func (l *UpdateTaskInSavedFilterViews) Handle(msg *message.Message) (err error) 
 		// A request healing the same filter view can insert a position row for
 		// this task between the delete above and this insert, so skip rows
 		// which exist by now instead of failing on the unique index.
-		err = insertTaskPositionsIgnoringExisting(s, taskPositions)
+		err = bulkInsertTaskPositions(s, taskPositions, false)
 		if err != nil {
 			return
 		}

--- a/pkg/models/listeners.go
+++ b/pkg/models/listeners.go
@@ -902,7 +902,10 @@ func (l *UpdateTaskInSavedFilterViews) Handle(msg *message.Message) (err error) 
 		if err != nil {
 			return
 		}
-		_, err = s.Insert(taskPositions)
+		// A request healing the same filter view can insert a position row for
+		// this task between the delete above and this insert, so skip rows
+		// which exist by now instead of failing on the unique index.
+		err = insertTaskPositionsIgnoringExisting(s, taskPositions)
 		if err != nil {
 			return
 		}

--- a/pkg/models/task_position.go
+++ b/pkg/models/task_position.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"math"
 	"sort"
+	"strings"
 
 	"xorm.io/builder"
 	"xorm.io/xorm"
@@ -72,29 +73,92 @@ func (tp *TaskPosition) refresh(s *xorm.Session) (err error) {
 	return nil
 }
 
+// upsertTaskPosition atomically inserts or updates the position row for the
+// given task and view. A separate exists-check followed by an insert races
+// with concurrent requests doing the same and violates the unique index on
+// (task_id, project_view_id).
+func upsertTaskPosition(s *xorm.Session, tp *TaskPosition) (err error) {
+	if db.GetDialect() == builder.MYSQL {
+		_, err = s.Exec(
+			"INSERT INTO task_positions (task_id, project_view_id, position) VALUES (?, ?, ?) ON DUPLICATE KEY UPDATE position = VALUES(position)",
+			tp.TaskID, tp.ProjectViewID, tp.Position)
+		return
+	}
+
+	_, err = s.Exec(
+		"INSERT INTO task_positions (task_id, project_view_id, position) VALUES (?, ?, ?) ON CONFLICT (task_id, project_view_id) DO UPDATE SET position = excluded.position",
+		tp.TaskID, tp.ProjectViewID, tp.Position)
+	return
+}
+
+// insertTaskPositionsIgnoringExisting bulk-inserts position rows, skipping rows
+// whose (task_id, project_view_id) pair already exists. Used on paths where a
+// concurrent transaction may have created some of the rows in the meantime.
+func insertTaskPositionsIgnoringExisting(s *xorm.Session, positions []*TaskPosition) (err error) {
+	// Keep statements well below the parameter limits of all supported databases.
+	const batchSize = 100
+
+	for start := 0; start < len(positions); start += batchSize {
+		batch := positions[start:min(start+batchSize, len(positions))]
+
+		placeholders := make([]string, 0, len(batch))
+		args := make([]interface{}, 1, len(batch)*3+1)
+		for _, p := range batch {
+			placeholders = append(placeholders, "(?, ?, ?)")
+			args = append(args, p.TaskID, p.ProjectViewID, p.Position)
+		}
+
+		query := "INSERT INTO task_positions (task_id, project_view_id, position) VALUES " + strings.Join(placeholders, ", ")
+		if db.GetDialect() == builder.MYSQL {
+			// A no-op update only ignores duplicate keys, unlike INSERT IGNORE
+			// which would swallow unrelated errors as well.
+			query += " ON DUPLICATE KEY UPDATE position = task_positions.position"
+		} else {
+			query += " ON CONFLICT (task_id, project_view_id) DO NOTHING"
+		}
+		args[0] = query
+
+		_, err = s.Exec(args...)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// lockPositionsForViewUpdate takes a row lock on the view, serializing
+// concurrent transactions which rewrite the positions of the same view.
+// Without it, two transactions can both delete the old position rows and then
+// insert overlapping new ones, violating the unique index on
+// (task_id, project_view_id). SQLite allows only a single writer at a time and
+// does not support FOR UPDATE, so no explicit lock is needed there.
+func lockPositionsForViewUpdate(s *xorm.Session, viewID int64) (err error) {
+	if db.GetDialect() == builder.SQLITE {
+		return nil
+	}
+
+	_, err = s.Exec("SELECT id FROM project_views WHERE id = ? FOR UPDATE", viewID)
+	return
+}
+
 // updateTaskPosition is the internal function that performs the task position update logic
 // without dispatching events. This is used by moveTaskToDoneBuckets to avoid duplicate events.
 func updateTaskPosition(s *xorm.Session, a web.Auth, tp *TaskPosition) (err error) {
-	exists, err := s.
-		Where("task_id = ? AND project_view_id = ?", tp.TaskID, tp.ProjectViewID).
-		Exist(&TaskPosition{})
-	if err != nil {
-		return err
+	if tp.Position < MinPositionSpacing {
+		// The recalculation below will need the view lock anyway. Taking it
+		// before the upsert keeps the lock order consistent with concurrent
+		// recalculations (view lock first, then position rows), avoiding a
+		// lock-order deadlock.
+		err = lockPositionsForViewUpdate(s, tp.ProjectViewID)
+		if err != nil {
+			return err
+		}
 	}
 
-	if !exists {
-		_, err = s.Insert(tp)
-		if err != nil {
-			return
-		}
-	} else {
-		_, err = s.
-			Where("task_id = ? AND project_view_id = ?", tp.TaskID, tp.ProjectViewID).
-			Cols("project_view_id", "position").
-			Update(tp)
-		if err != nil {
-			return
-		}
+	err = upsertTaskPosition(s, tp)
+	if err != nil {
+		return err
 	}
 
 	if tp.Position < MinPositionSpacing {
@@ -153,6 +217,11 @@ func (tp *TaskPosition) Update(s *xorm.Session, a web.Auth) (err error) {
 func RecalculateTaskPositions(s *xorm.Session, view *ProjectView, a web.Auth) (err error) {
 
 	log.Debugf("Recalculating task positions for view %d", view.ID)
+
+	err = lockPositionsForViewUpdate(s, view.ID)
+	if err != nil {
+		return err
+	}
 
 	opts := &taskSearchOptions{
 		projectViewID: view.ID,
@@ -214,8 +283,15 @@ func RecalculateTaskPositions(s *xorm.Session, view *ProjectView, a web.Auth) (e
 
 	maxPosition := math.Pow(2, 32)
 	newPositions := make([]*TaskPosition, 0, len(allTasks))
+	seenTasks := make(map[int64]bool, len(allTasks))
 
 	for i, task := range allTasks {
+		// The search can return a task more than once, but the unique index
+		// on (task_id, project_view_id) allows only one row per task and view.
+		if seenTasks[task.ID] {
+			continue
+		}
+		seenTasks[task.ID] = true
 
 		currentPosition := maxPosition / float64(len(allTasks)) * (float64(i + 1))
 
@@ -261,9 +337,14 @@ func getPositionsForView(s *xorm.Session, view *ProjectView) (positions []*TaskP
 func recalculateTaskPositionsForRepair(s *xorm.Session, view *ProjectView) error {
 	log.Debugf("Recalculating task positions for view %d (repair mode)", view.ID)
 
+	err := lockPositionsForViewUpdate(s, view.ID)
+	if err != nil {
+		return err
+	}
+
 	// Get all existing positions for this view, ordered by current position then task ID
 	var existingPositions []*TaskPosition
-	err := s.Where("project_view_id = ?", view.ID).
+	err = s.Where("project_view_id = ?", view.ID).
 		OrderBy("position ASC, task_id ASC").
 		Find(&existingPositions)
 	if err != nil {
@@ -442,8 +523,9 @@ func createPositionsForTasksInView(s *xorm.Session, tasks []*Task, view *Project
 		})
 	}
 
-	_, err = s.Insert(&newPositions)
-	return err
+	// A concurrent request may have healed some of the same tasks already,
+	// so skip rows which exist by now instead of failing on the unique index.
+	return insertTaskPositionsIgnoringExisting(s, newPositions)
 }
 
 // ensureTaskPositionsForSavedFilterView creates position rows for all tasks matching a saved
@@ -496,12 +578,7 @@ func ensureTaskPositionsForSavedFilterView(s *xorm.Session, a web.Auth, projects
 		return fmt.Errorf("could not fetch unpositioned tasks, error was '%w', sql: '%v', values: %v", err, sql, vals)
 	}
 
-	err = createPositionsForTasksInView(s, tasks, view, a)
-	if err != nil && db.IsUniqueConstraintError(err, "task_positions") {
-		// A concurrent request healed the same tasks first — the rows exist, which is all we need.
-		return nil
-	}
-	return err
+	return createPositionsForTasksInView(s, tasks, view, a)
 }
 
 // findPositionConflicts returns all task positions that share the same position value

--- a/pkg/models/task_position.go
+++ b/pkg/models/task_position.go
@@ -24,6 +24,7 @@ import (
 
 	"xorm.io/builder"
 	"xorm.io/xorm"
+	"xorm.io/xorm/schemas"
 
 	"code.vikunja.io/api/pkg/db"
 	"code.vikunja.io/api/pkg/events"
@@ -78,25 +79,45 @@ func (tp *TaskPosition) refresh(s *xorm.Session) (err error) {
 // with concurrent requests doing the same and violates the unique index on
 // (task_id, project_view_id).
 func upsertTaskPosition(s *xorm.Session, tp *TaskPosition) (err error) {
-	if db.GetDialect() == builder.MYSQL {
-		_, err = s.Exec(
-			"INSERT INTO task_positions (task_id, project_view_id, position) VALUES (?, ?, ?) ON DUPLICATE KEY UPDATE position = VALUES(position)",
-			tp.TaskID, tp.ProjectViewID, tp.Position)
-		return
+	onConflict := "ON CONFLICT (task_id, project_view_id) DO UPDATE SET position = excluded.position"
+	if db.Type() == schemas.MYSQL {
+		onConflict = "ON DUPLICATE KEY UPDATE position = VALUES(position)"
 	}
 
+	// Raw SQL bypasses xorm's bean-based table-name handling, so qualify the
+	// table ourselves to honor a configured postgres schema (database.schema).
+	table := s.Engine().TableName(tp, true)
 	_, err = s.Exec(
-		"INSERT INTO task_positions (task_id, project_view_id, position) VALUES (?, ?, ?) ON CONFLICT (task_id, project_view_id) DO UPDATE SET position = excluded.position",
+		"INSERT INTO "+table+" (task_id, project_view_id, position) VALUES (?, ?, ?) "+onConflict,
 		tp.TaskID, tp.ProjectViewID, tp.Position)
 	return
 }
 
-// insertTaskPositionsIgnoringExisting bulk-inserts position rows, skipping rows
-// whose (task_id, project_view_id) pair already exists. Used on paths where a
+// bulkInsertTaskPositions inserts position rows in batches. Rows whose
+// (task_id, project_view_id) pair already exists are updated to the given
+// position when overwrite is set and skipped otherwise. Used on paths where a
 // concurrent transaction may have created some of the rows in the meantime.
-func insertTaskPositionsIgnoringExisting(s *xorm.Session, positions []*TaskPosition) (err error) {
+func bulkInsertTaskPositions(s *xorm.Session, positions []*TaskPosition, overwrite bool) (err error) {
 	// Keep statements well below the parameter limits of all supported databases.
 	const batchSize = 100
+
+	var onConflict string
+	switch {
+	case db.Type() == schemas.MYSQL && overwrite:
+		onConflict = "ON DUPLICATE KEY UPDATE position = VALUES(position)"
+	case db.Type() == schemas.MYSQL:
+		// The self-assignment is a no-op update which only ignores duplicate
+		// keys, unlike INSERT IGNORE which would swallow unrelated errors too.
+		onConflict = "ON DUPLICATE KEY UPDATE position = position"
+	case overwrite:
+		onConflict = "ON CONFLICT (task_id, project_view_id) DO UPDATE SET position = excluded.position"
+	default:
+		onConflict = "ON CONFLICT (task_id, project_view_id) DO NOTHING"
+	}
+
+	// Raw SQL bypasses xorm's bean-based table-name handling, so qualify the
+	// table ourselves to honor a configured postgres schema (database.schema).
+	table := s.Engine().TableName(&TaskPosition{}, true)
 
 	for start := 0; start < len(positions); start += batchSize {
 		batch := positions[start:min(start+batchSize, len(positions))]
@@ -108,15 +129,7 @@ func insertTaskPositionsIgnoringExisting(s *xorm.Session, positions []*TaskPosit
 			args = append(args, p.TaskID, p.ProjectViewID, p.Position)
 		}
 
-		query := "INSERT INTO task_positions (task_id, project_view_id, position) VALUES " + strings.Join(placeholders, ", ")
-		if db.GetDialect() == builder.MYSQL {
-			// A no-op update only ignores duplicate keys, unlike INSERT IGNORE
-			// which would swallow unrelated errors as well.
-			query += " ON DUPLICATE KEY UPDATE position = task_positions.position"
-		} else {
-			query += " ON CONFLICT (task_id, project_view_id) DO NOTHING"
-		}
-		args[0] = query
+		args[0] = "INSERT INTO " + table + " (task_id, project_view_id, position) VALUES " + strings.Join(placeholders, ", ") + " " + onConflict
 
 		_, err = s.Exec(args...)
 		if err != nil {
@@ -134,11 +147,12 @@ func insertTaskPositionsIgnoringExisting(s *xorm.Session, positions []*TaskPosit
 // (task_id, project_view_id). SQLite allows only a single writer at a time and
 // does not support FOR UPDATE, so no explicit lock is needed there.
 func lockPositionsForViewUpdate(s *xorm.Session, viewID int64) (err error) {
-	if db.GetDialect() == builder.SQLITE {
+	if db.Type() == schemas.SQLITE {
 		return nil
 	}
 
-	_, err = s.Exec("SELECT id FROM project_views WHERE id = ? FOR UPDATE", viewID)
+	table := s.Engine().TableName(&ProjectView{}, true)
+	_, err = s.Exec("SELECT id FROM "+table+" WHERE id = ? FOR UPDATE", viewID)
 	return
 }
 
@@ -309,12 +323,15 @@ func RecalculateTaskPositions(s *xorm.Session, view *ProjectView, a web.Auth) (e
 		return
 	}
 
-	count, err := s.Insert(newPositions)
+	// Writers which don't take the view lock (they only ever add missing rows)
+	// can slip a row in between the delete above and this insert. The
+	// recalculated values are authoritative, so overwrite instead of failing.
+	err = bulkInsertTaskPositions(s, newPositions, true)
 	if err != nil {
 		return
 	}
 
-	log.Debugf("Inserted %d new positions for %d total tasks in view %d", count, len(allTasks), view.ID)
+	log.Debugf("Inserted %d new positions for %d total tasks in view %d", len(newPositions), len(allTasks), view.ID)
 
 	events.DispatchOnCommit(s, &TaskPositionsRecalculatedEvent{
 		NewTaskPositions: newPositions,
@@ -374,12 +391,13 @@ func recalculateTaskPositionsForRepair(s *xorm.Session, view *ProjectView) error
 		})
 	}
 
-	count, err := s.Insert(newPositions)
+	// Overwrite for the same reason as in RecalculateTaskPositions.
+	err = bulkInsertTaskPositions(s, newPositions, true)
 	if err != nil {
 		return err
 	}
 
-	log.Debugf("Repair: inserted %d new positions for view %d", count, view.ID)
+	log.Debugf("Repair: inserted %d new positions for view %d", len(newPositions), view.ID)
 
 	events.DispatchOnCommit(s, &TaskPositionsRecalculatedEvent{
 		NewTaskPositions: newPositions,
@@ -525,7 +543,7 @@ func createPositionsForTasksInView(s *xorm.Session, tasks []*Task, view *Project
 
 	// A concurrent request may have healed some of the same tasks already,
 	// so skip rows which exist by now instead of failing on the unique index.
-	return insertTaskPositionsIgnoringExisting(s, newPositions)
+	return bulkInsertTaskPositions(s, newPositions, false)
 }
 
 // ensureTaskPositionsForSavedFilterView creates position rows for all tasks matching a saved

--- a/pkg/models/task_position.go
+++ b/pkg/models/task_position.go
@@ -93,10 +93,23 @@ func upsertTaskPosition(s *xorm.Session, tp *TaskPosition) (err error) {
 	return
 }
 
-// bulkInsertTaskPositions inserts position rows in batches. Rows whose
-// (task_id, project_view_id) pair already exists are updated to the given
-// position when overwrite is set and skipped otherwise. Used on paths where a
-// concurrent transaction may have created some of the rows in the meantime.
+// bulkInsertTaskPositions inserts position rows in batches, tolerating rows
+// whose (task_id, project_view_id) pair already exists because a concurrent
+// transaction created them in the meantime. The overwrite flag decides who
+// wins such a conflict:
+//
+// Callers which only add rows for tasks that had none (saved filter healing,
+// the task-created listener) pass false: if another transaction beat them to
+// it, the existing row is the correct state — e.g. a position the user set
+// via drag & drop in between — and the caller's value is stale, so the row is
+// kept as is.
+//
+// The recalculation paths pass true: they rewrite every position in the view,
+// so their values are authoritative. They hold the view lock, but writers of
+// the first kind deliberately don't take it and can slip a row in between the
+// recalculation's delete and reinsert (invisible to the delete's snapshot
+// under READ COMMITTED). A plain insert would then fail on the unique index;
+// overwriting resolves the race with the recalculated value instead.
 func bulkInsertTaskPositions(s *xorm.Session, positions []*TaskPosition, overwrite bool) (err error) {
 	// Keep statements well below the parameter limits of all supported databases.
 	const batchSize = 100
@@ -323,9 +336,6 @@ func RecalculateTaskPositions(s *xorm.Session, view *ProjectView, a web.Auth) (e
 		return
 	}
 
-	// Writers which don't take the view lock (they only ever add missing rows)
-	// can slip a row in between the delete above and this insert. The
-	// recalculated values are authoritative, so overwrite instead of failing.
 	err = bulkInsertTaskPositions(s, newPositions, true)
 	if err != nil {
 		return
@@ -391,7 +401,6 @@ func recalculateTaskPositionsForRepair(s *xorm.Session, view *ProjectView) error
 		})
 	}
 
-	// Overwrite for the same reason as in RecalculateTaskPositions.
 	err = bulkInsertTaskPositions(s, newPositions, true)
 	if err != nil {
 		return err
@@ -541,8 +550,6 @@ func createPositionsForTasksInView(s *xorm.Session, tasks []*Task, view *Project
 		})
 	}
 
-	// A concurrent request may have healed some of the same tasks already,
-	// so skip rows which exist by now instead of failing on the unique index.
 	return bulkInsertTaskPositions(s, newPositions, false)
 }
 

--- a/pkg/models/task_position_test.go
+++ b/pkg/models/task_position_test.go
@@ -633,7 +633,7 @@ func TestUpsertTaskPosition(t *testing.T) {
 	})
 }
 
-func TestInsertTaskPositionsIgnoringExisting(t *testing.T) {
+func TestBulkInsertTaskPositions(t *testing.T) {
 	t.Run("skips rows which already exist", func(t *testing.T) {
 		db.LoadAndAssertFixtures(t)
 		s := db.NewSession()
@@ -642,10 +642,10 @@ func TestInsertTaskPositionsIgnoringExisting(t *testing.T) {
 		_, err := s.Insert(&TaskPosition{TaskID: 100, ProjectViewID: 1, Position: 50})
 		require.NoError(t, err)
 
-		err = insertTaskPositionsIgnoringExisting(s, []*TaskPosition{
+		err = bulkInsertTaskPositions(s, []*TaskPosition{
 			{TaskID: 100, ProjectViewID: 1, Position: 60},
 			{TaskID: 101, ProjectViewID: 1, Position: 70},
-		})
+		}, false)
 		require.NoError(t, err)
 		require.NoError(t, s.Commit())
 
@@ -655,6 +655,34 @@ func TestInsertTaskPositionsIgnoringExisting(t *testing.T) {
 			"project_view_id": 1,
 			"position":        50,
 		}, false)
+		db.AssertExists(t, "task_positions", map[string]interface{}{
+			"task_id":         101,
+			"project_view_id": 1,
+			"position":        70,
+		}, false)
+	})
+
+	t.Run("overwrites rows which already exist", func(t *testing.T) {
+		db.LoadAndAssertFixtures(t)
+		s := db.NewSession()
+		defer s.Close()
+
+		_, err := s.Insert(&TaskPosition{TaskID: 100, ProjectViewID: 1, Position: 50})
+		require.NoError(t, err)
+
+		err = bulkInsertTaskPositions(s, []*TaskPosition{
+			{TaskID: 100, ProjectViewID: 1, Position: 60},
+			{TaskID: 101, ProjectViewID: 1, Position: 70},
+		}, true)
+		require.NoError(t, err)
+		require.NoError(t, s.Commit())
+
+		db.AssertExists(t, "task_positions", map[string]interface{}{
+			"task_id":         100,
+			"project_view_id": 1,
+			"position":        60,
+		}, false)
+		db.AssertCount(t, "task_positions", builder.Eq{"task_id": 100, "project_view_id": 1}, 1)
 		db.AssertExists(t, "task_positions", map[string]interface{}{
 			"task_id":         101,
 			"project_view_id": 1,
@@ -676,7 +704,7 @@ func TestInsertTaskPositionsIgnoringExisting(t *testing.T) {
 			})
 		}
 
-		err := insertTaskPositionsIgnoringExisting(s, positions)
+		err := bulkInsertTaskPositions(s, positions, false)
 		require.NoError(t, err)
 		require.NoError(t, s.Commit())
 

--- a/pkg/models/task_position_test.go
+++ b/pkg/models/task_position_test.go
@@ -593,3 +593,89 @@ func TestResolvePositionConflictsAfterInsertFallsBackToRecalculation(t *testing.
 		seen[p.Position] = true
 	}
 }
+
+func TestUpsertTaskPosition(t *testing.T) {
+	t.Run("inserts a new row", func(t *testing.T) {
+		db.LoadAndAssertFixtures(t)
+		s := db.NewSession()
+		defer s.Close()
+
+		err := upsertTaskPosition(s, &TaskPosition{TaskID: 100, ProjectViewID: 1, Position: 42})
+		require.NoError(t, err)
+
+		pos := &TaskPosition{}
+		has, err := s.Where("task_id = ? AND project_view_id = ?", 100, 1).Get(pos)
+		require.NoError(t, err)
+		require.True(t, has)
+		assert.InDelta(t, 42.0, pos.Position, 0.001)
+	})
+
+	t.Run("updates an existing row instead of failing on the unique index", func(t *testing.T) {
+		db.LoadAndAssertFixtures(t)
+		s := db.NewSession()
+		defer s.Close()
+
+		_, err := s.Insert(&TaskPosition{TaskID: 100, ProjectViewID: 1, Position: 42})
+		require.NoError(t, err)
+
+		err = upsertTaskPosition(s, &TaskPosition{TaskID: 100, ProjectViewID: 1, Position: 555})
+		require.NoError(t, err)
+
+		positions := []*TaskPosition{}
+		err = s.Where("task_id = ? AND project_view_id = ?", 100, 1).Find(&positions)
+		require.NoError(t, err)
+		require.Len(t, positions, 1)
+		assert.InDelta(t, 555.0, positions[0].Position, 0.001)
+	})
+}
+
+func TestInsertTaskPositionsIgnoringExisting(t *testing.T) {
+	t.Run("skips rows which already exist", func(t *testing.T) {
+		db.LoadAndAssertFixtures(t)
+		s := db.NewSession()
+		defer s.Close()
+
+		_, err := s.Insert(&TaskPosition{TaskID: 100, ProjectViewID: 1, Position: 50})
+		require.NoError(t, err)
+
+		err = insertTaskPositionsIgnoringExisting(s, []*TaskPosition{
+			{TaskID: 100, ProjectViewID: 1, Position: 60},
+			{TaskID: 101, ProjectViewID: 1, Position: 70},
+		})
+		require.NoError(t, err)
+
+		existing := &TaskPosition{}
+		has, err := s.Where("task_id = ? AND project_view_id = ?", 100, 1).Get(existing)
+		require.NoError(t, err)
+		require.True(t, has)
+		assert.InDelta(t, 50.0, existing.Position, 0.001, "existing row must not be overwritten")
+
+		inserted := &TaskPosition{}
+		has, err = s.Where("task_id = ? AND project_view_id = ?", 101, 1).Get(inserted)
+		require.NoError(t, err)
+		require.True(t, has)
+		assert.InDelta(t, 70.0, inserted.Position, 0.001)
+	})
+
+	t.Run("inserts more rows than a single batch", func(t *testing.T) {
+		db.LoadAndAssertFixtures(t)
+		s := db.NewSession()
+		defer s.Close()
+
+		positions := make([]*TaskPosition, 0, 150)
+		for i := 0; i < 150; i++ {
+			positions = append(positions, &TaskPosition{
+				TaskID:        int64(10000 + i),
+				ProjectViewID: 1,
+				Position:      float64(i + 1),
+			})
+		}
+
+		err := insertTaskPositionsIgnoringExisting(s, positions)
+		require.NoError(t, err)
+
+		count, err := s.Where("project_view_id = ? AND task_id >= 10000", 1).Count(&TaskPosition{})
+		require.NoError(t, err)
+		assert.Equal(t, int64(150), count)
+	})
+}

--- a/pkg/models/task_position_test.go
+++ b/pkg/models/task_position_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"xorm.io/builder"
 )
 
 func TestFindPositionConflicts(t *testing.T) {
@@ -602,12 +603,13 @@ func TestUpsertTaskPosition(t *testing.T) {
 
 		err := upsertTaskPosition(s, &TaskPosition{TaskID: 100, ProjectViewID: 1, Position: 42})
 		require.NoError(t, err)
+		require.NoError(t, s.Commit())
 
-		pos := &TaskPosition{}
-		has, err := s.Where("task_id = ? AND project_view_id = ?", 100, 1).Get(pos)
-		require.NoError(t, err)
-		require.True(t, has)
-		assert.InDelta(t, 42.0, pos.Position, 0.001)
+		db.AssertExists(t, "task_positions", map[string]interface{}{
+			"task_id":         100,
+			"project_view_id": 1,
+			"position":        42,
+		}, false)
 	})
 
 	t.Run("updates an existing row instead of failing on the unique index", func(t *testing.T) {
@@ -620,12 +622,14 @@ func TestUpsertTaskPosition(t *testing.T) {
 
 		err = upsertTaskPosition(s, &TaskPosition{TaskID: 100, ProjectViewID: 1, Position: 555})
 		require.NoError(t, err)
+		require.NoError(t, s.Commit())
 
-		positions := []*TaskPosition{}
-		err = s.Where("task_id = ? AND project_view_id = ?", 100, 1).Find(&positions)
-		require.NoError(t, err)
-		require.Len(t, positions, 1)
-		assert.InDelta(t, 555.0, positions[0].Position, 0.001)
+		db.AssertExists(t, "task_positions", map[string]interface{}{
+			"task_id":         100,
+			"project_view_id": 1,
+			"position":        555,
+		}, false)
+		db.AssertCount(t, "task_positions", builder.Eq{"task_id": 100, "project_view_id": 1}, 1)
 	})
 }
 
@@ -643,18 +647,19 @@ func TestInsertTaskPositionsIgnoringExisting(t *testing.T) {
 			{TaskID: 101, ProjectViewID: 1, Position: 70},
 		})
 		require.NoError(t, err)
+		require.NoError(t, s.Commit())
 
-		existing := &TaskPosition{}
-		has, err := s.Where("task_id = ? AND project_view_id = ?", 100, 1).Get(existing)
-		require.NoError(t, err)
-		require.True(t, has)
-		assert.InDelta(t, 50.0, existing.Position, 0.001, "existing row must not be overwritten")
-
-		inserted := &TaskPosition{}
-		has, err = s.Where("task_id = ? AND project_view_id = ?", 101, 1).Get(inserted)
-		require.NoError(t, err)
-		require.True(t, has)
-		assert.InDelta(t, 70.0, inserted.Position, 0.001)
+		// The existing row must not be overwritten.
+		db.AssertExists(t, "task_positions", map[string]interface{}{
+			"task_id":         100,
+			"project_view_id": 1,
+			"position":        50,
+		}, false)
+		db.AssertExists(t, "task_positions", map[string]interface{}{
+			"task_id":         101,
+			"project_view_id": 1,
+			"position":        70,
+		}, false)
 	})
 
 	t.Run("inserts more rows than a single batch", func(t *testing.T) {
@@ -673,9 +678,11 @@ func TestInsertTaskPositionsIgnoringExisting(t *testing.T) {
 
 		err := insertTaskPositionsIgnoringExisting(s, positions)
 		require.NoError(t, err)
+		require.NoError(t, s.Commit())
 
-		count, err := s.Where("project_view_id = ? AND task_id >= 10000", 1).Count(&TaskPosition{})
-		require.NoError(t, err)
-		assert.Equal(t, int64(150), count)
+		db.AssertCount(t, "task_positions", builder.And(
+			builder.Eq{"project_view_id": 1},
+			builder.Gte{"task_id": 10000},
+		), 150)
 	})
 }


### PR DESCRIPTION
## Summary
Fixes race conditions in task position management that could violate the unique index on `(task_id, project_view_id)` when concurrent requests modify positions simultaneously. Introduces atomic upsert operations and explicit row locking to serialize concurrent position updates.

Fixes https://github.com/go-vikunja/vikunja/issues/3089

## Key Changes

- **New `upsertTaskPosition()` function**: Atomically inserts or updates a position row using database-native upsert syntax (`ON DUPLICATE KEY UPDATE` for MySQL, `ON CONFLICT DO UPDATE` for PostgreSQL). Replaces the separate exists-check + insert/update pattern that raced with concurrent requests.

- **New `insertTaskPositionsIgnoringExisting()` function**: Bulk-inserts position rows while gracefully skipping rows that already exist (using `ON DUPLICATE KEY UPDATE` or `ON CONFLICT DO NOTHING`). Batches inserts in groups of 100 to stay within database parameter limits. Used in paths where concurrent transactions may have created some rows in the meantime.

- **New `lockPositionsForViewUpdate()` function**: Takes an explicit row lock on the project view (via `SELECT ... FOR UPDATE`) to serialize concurrent transactions that rewrite positions for the same view. SQLite is excluded since it allows only a single writer at a time. This prevents two transactions from both deleting old position rows and then inserting overlapping new ones.

- **Updated `updateTaskPosition()`**: Now calls `lockPositionsForViewUpdate()` before upserting when position recalculation is needed, ensuring consistent lock ordering (view lock first, then position rows) to avoid deadlocks.

- **Updated `RecalculateTaskPositions()`**: Acquires the view lock at the start and deduplicates tasks in the result set (since the search can return a task more than once, but the unique index allows only one row per task/view pair).

- **Updated `recalculateTaskPositionsForRepair()`**: Acquires the view lock before repairing positions.

- **Updated `createPositionsForTasksInView()`**: Uses `insertTaskPositionsIgnoringExisting()` instead of a plain insert, allowing it to handle concurrent healing of the same tasks.

- **Updated `ensureTaskPositionsForSavedFilterView()`**: Removes the try-catch for unique constraint errors since `createPositionsForTasksInView()` now handles them internally.

- **Updated `UpdateTaskInSavedFilterViews` listener**: Uses `insertTaskPositionsIgnoringExisting()` to skip rows that may have been inserted concurrently.

## Tests
Added comprehensive test coverage for the new upsert and bulk-insert functions, including edge cases like updating existing rows and batching across multiple inserts.

https://claude.ai/code/session_01Rvn2MowBBaoxTVjAR9AV8K