### PR TITLE
docs: fix typo in autotls.enabled description

### DIFF
--- a/config-raw.json
+++ b/config-raw.json
@@ -1059,7 +1059,7 @@
                 {
                     "key": "enabled",
                     "default_value": "false",
-                    "comment": "If set to true, Vikunja will automatically request a TLS certificate from Let's Encrypt and use it to serve Vikunja over TLS. By enabling this option, you agree to Let's Encrypt's TOS.\nYou must configure a `service.publicurl` with a valid TLD where Vikunja is reachable to make this work. Furthermore, it is reccomened to set `service.interface` to `:443` if you're using this."
+                    "comment": "If set to true, Vikunja will automatically request a TLS certificate from Let's Encrypt and use it to serve Vikunja over TLS. By enabling this option, you agree to Let's Encrypt's TOS.\nYou must configure a `service.publicurl` with a valid TLD where Vikunja is reachable to make this work. Furthermore, it is recommended to set `service.interface` to `:443` if you're using this."
                 },
                 {
                     "key": "email",


### PR DESCRIPTION
Fix "reccomened" -> "recommended" in the autotls.enabled description

No code was changed.