### PR TITLE
fix: use correct label for imported tasks 'project'

### DIFF
--- a/frontend/src/views/migrate/MigrationCSV.vue
+++ b/frontend/src/views/migrate/MigrationCSV.vue
@@ -267,7 +267,7 @@ function getAttributeLabel(attribute: string): string {
 		priority: 'task.attributes.priority',
 		labels: 'task.attributes.labels',
 		reminder: 'task.attributes.reminders',
-		project: 'project.title',
+		project: 'task.attributes.project',
 		ignore: 'migrate.csv.ignore',
 	}
 	return t(attributeMap[attribute] || attribute)


### PR DESCRIPTION
Changes the label in the dropdown menu for column mapping CSV task imports from "Title" to "Project"