### PR TITLE
docs: add Zenith Hosting deploy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Docker Pulls](https://img.shields.io/docker/pulls/vikunja/vikunja.svg)](https://hub.docker.com/r/vikunja/vikunja/)
 [![Swagger Docs](https://img.shields.io/badge/swagger-docs-brightgreen.svg)](https://try.vikunja.io/api/v1/docs)
 [![Go Report Card](https://goreportcard.com/badge/code.vikunja.io/api)](https://goreportcard.com/report/code.vikunja.io/api)
+[![Deploy with Zenith](https://cdn.zenith.hosting/buttons/deploy-with-zenith.svg)](https://zenith.hosting/host/vikunja)
 
 # Vikunja
 


### PR DESCRIPTION
hey, i work on Zenith Hosting, a startup doing one-click hosting for open source apps. we added Vikunja to our marketplace, so this PR adds a small "Deploy with Zenith" link under the badge row at the top of the readme (links to https://zenith.hosting/host/vikunja).

we share a cut of revenue with the projects we host. happy to explain if you're curious: hello@zenith.hosting

disclosure: this PR was prepared with AI assistance.