### PR TITLE
Extract golangci-lint setup into reusable action

### DIFF
--- a/.github/actions/golangci-lint/action.yml
+++ b/.github/actions/golangci-lint/action.yml
@@ -1,0 +1,37 @@
+name: golangci-lint
+description: |
+  Set up Go and run golangci-lint on a Go module.
+  Caches the analysis dir explicitly instead of using the lint action's
+  built-in cache: that cache's key omits the Go version, so with
+  go-version: stable a toolchain bump restores facts cached under the
+  previous Go release, which yields staticcheck false positives
+  (e.g. SA5011 on t.Fatal nil-guards) on every PR until the key rotates.
+inputs:
+  version:
+    description: 'golangci-lint version to run'
+    required: false
+    default: 'v2.12.2'
+  working-directory:
+    description: 'Module directory to lint, relative to the repo root'
+    required: false
+    default: '.'
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+      id: go
+      with:
+        go-version: stable
+        cache-dependency-path: ${{ inputs.working-directory }}/go.sum
+    - name: Cache golangci-lint analysis
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ~/.cache/golangci-lint
+        key: golangci-lint-${{ inputs.working-directory }}-${{ inputs.version }}-${{ steps.go.outputs.go-version }}-${{ hashFiles(format('{0}/go.sum', inputs.working-directory)) }}
+        restore-keys: |
+          golangci-lint-${{ inputs.working-directory }}-${{ inputs.version }}-${{ steps.go.outputs.go-version }}-
+    - uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
+      with:
+        version: ${{ inputs.version }}
+        working-directory: ${{ inputs.working-directory }}
+        skip-cache: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,9 +3,6 @@ name: Test
 on:
   workflow_call:
 
-env:
-  GOLANGCI_LINT_VERSION: v2.12.2
-
 jobs:
   mage:
     runs-on: ubuntu-latest
@@ -65,58 +62,23 @@ jobs:
           name: vikunja_bin
           path: ./vikunja
 
-  # Both lint jobs cache the golangci-lint analysis dir themselves instead
-  # of using the action's built-in cache: the action's key does not include
-  # the Go version, so with go-version: stable a toolchain bump restores
-  # facts cached under the previous Go release, which yields staticcheck
-  # false positives (SA5011 on t.Fatal nil-guards) on every PR until the
-  # key rotates.
   api-lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
-        id: go
-        with:
-          go-version: stable
       - name: prepare frontend files
         run: |
           mkdir -p frontend/dist
           touch frontend/dist/index.html
-      - name: Cache golangci-lint analysis
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.cache/golangci-lint
-          key: golangci-lint-api-${{ env.GOLANGCI_LINT_VERSION }}-${{ steps.go.outputs.go-version }}-${{ hashFiles('go.sum') }}
-          restore-keys: |
-            golangci-lint-api-${{ env.GOLANGCI_LINT_VERSION }}-${{ steps.go.outputs.go-version }}-
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
-        with:
-          version: ${{ env.GOLANGCI_LINT_VERSION }}
-          skip-cache: true
+      - uses: ./.github/actions/golangci-lint
 
   veans-lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
-        id: go
+      - uses: ./.github/actions/golangci-lint
         with:
-          go-version: stable
-      - name: Cache golangci-lint analysis
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.cache/golangci-lint
-          key: golangci-lint-veans-${{ env.GOLANGCI_LINT_VERSION }}-${{ steps.go.outputs.go-version }}-${{ hashFiles('veans/go.sum') }}
-          restore-keys: |
-            golangci-lint-veans-${{ env.GOLANGCI_LINT_VERSION }}-${{ steps.go.outputs.go-version }}-
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
-        with:
-          version: ${{ env.GOLANGCI_LINT_VERSION }}
           working-directory: veans
-          skip-cache: true
 
   veans-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,9 @@ name: Test
 on:
   workflow_call:
 
+env:
+  GOLANGCI_LINT_VERSION: v2.12.2
+
 jobs:
   mage:
     runs-on: ubuntu-latest
@@ -84,13 +87,13 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/golangci-lint
-          key: golangci-lint-api-${{ steps.go.outputs.go-version }}-${{ hashFiles('go.sum') }}
+          key: golangci-lint-api-${{ env.GOLANGCI_LINT_VERSION }}-${{ steps.go.outputs.go-version }}-${{ hashFiles('go.sum') }}
           restore-keys: |
-            golangci-lint-api-${{ steps.go.outputs.go-version }}-
+            golangci-lint-api-${{ env.GOLANGCI_LINT_VERSION }}-${{ steps.go.outputs.go-version }}-
       - name: golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
-          version: v2.12.2
+          version: ${{ env.GOLANGCI_LINT_VERSION }}
           skip-cache: true
 
   veans-lint:
@@ -105,13 +108,13 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/golangci-lint
-          key: golangci-lint-veans-${{ steps.go.outputs.go-version }}-${{ hashFiles('veans/go.sum') }}
+          key: golangci-lint-veans-${{ env.GOLANGCI_LINT_VERSION }}-${{ steps.go.outputs.go-version }}-${{ hashFiles('veans/go.sum') }}
           restore-keys: |
-            golangci-lint-veans-${{ steps.go.outputs.go-version }}-
+            golangci-lint-veans-${{ env.GOLANGCI_LINT_VERSION }}-${{ steps.go.outputs.go-version }}-
       - name: golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
-          version: v2.12.2
+          version: ${{ env.GOLANGCI_LINT_VERSION }}
           working-directory: veans
           skip-cache: true
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,6 +90,12 @@ jobs:
         with:
           version: v2.12.2
           working-directory: veans
+          # The restored analysis cache goes stale when the Go toolchain
+          # bumps underneath it (go-version: stable) while veans/go.mod —
+          # part of the cache key — stays unchanged, yielding staticcheck
+          # SA5011 false positives on every PR. The module lints in ~15s,
+          # so the cache buys nothing anyway.
+          skip-cache: true
 
   veans-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,39 +62,57 @@ jobs:
           name: vikunja_bin
           path: ./vikunja
 
+  # Both lint jobs cache the golangci-lint analysis dir themselves instead
+  # of using the action's built-in cache: the action's key does not include
+  # the Go version, so with go-version: stable a toolchain bump restores
+  # facts cached under the previous Go release, which yields staticcheck
+  # false positives (SA5011 on t.Fatal nil-guards) on every PR until the
+  # key rotates.
   api-lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        id: go
         with:
           go-version: stable
       - name: prepare frontend files
         run: |
           mkdir -p frontend/dist
           touch frontend/dist/index.html
+      - name: Cache golangci-lint analysis
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/golangci-lint
+          key: golangci-lint-api-${{ steps.go.outputs.go-version }}-${{ hashFiles('go.sum') }}
+          restore-keys: |
+            golangci-lint-api-${{ steps.go.outputs.go-version }}-
       - name: golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
           version: v2.12.2
+          skip-cache: true
 
   veans-lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        id: go
         with:
           go-version: stable
+      - name: Cache golangci-lint analysis
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/golangci-lint
+          key: golangci-lint-veans-${{ steps.go.outputs.go-version }}-${{ hashFiles('veans/go.sum') }}
+          restore-keys: |
+            golangci-lint-veans-${{ steps.go.outputs.go-version }}-
       - name: golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
           version: v2.12.2
           working-directory: veans
-          # The restored analysis cache goes stale when the Go toolchain
-          # bumps underneath it (go-version: stable) while veans/go.mod —
-          # part of the cache key — stays unchanged, yielding staticcheck
-          # SA5011 false positives on every PR. The module lints in ~15s,
-          # so the cache buys nothing anyway.
           skip-cache: true
 
   veans-test:


### PR DESCRIPTION
## Summary
Refactors the golangci-lint setup across CI workflows into a reusable composite GitHub Action to reduce duplication and improve maintainability.

## Key Changes
- **New composite action** (`.github/actions/golangci-lint/action.yml`):
  - Encapsulates Go setup, golangci-lint analysis caching, and linting execution
  - Accepts `version` and `working-directory` inputs with sensible defaults
  - Implements explicit cache management for `~/.cache/golangci-lint` keyed by Go version, golangci-lint version, and `go.sum` hash
  - Skips the built-in golangci-lint-action cache to avoid false positives from stale staticcheck facts when Go versions change

- **Updated test workflow** (`.github/workflows/test.yml`):
  - Replaced inline golangci-lint setup in `lint` job with call to new action
  - Replaced inline golangci-lint setup in `veans-lint` job with call to new action, passing `working-directory: veans`
  - Removed redundant `actions/setup-go` steps (now handled by the action)

## Implementation Details
The custom cache strategy addresses a known issue where the golangci-lint action's built-in cache omits the Go version from its key. With `go-version: stable`, a toolchain bump would restore analysis facts cached under the previous Go release, causing staticcheck false positives (e.g., SA5011 on `t.Fatal` nil-guards) until the cache key rotates. The new action includes `go-version` in the cache key to prevent this.

https://claude.ai/code/session_01RtdryWLAueBrxuFDf1YBvN