### PR TITLE
feat: allow subscribing another user to a project or task

### DIFF
--- a/pkg/models/subscription.go
+++ b/pkg/models/subscription.go
@@ -103,8 +103,10 @@ type Subscription struct {
 	// The id of the entity to subscribe to.
 	EntityID int64 `xorm:"bigint index not null" json:"entity_id" param:"entityID" readOnly:"true" doc:"The numeric id of the subscribed entity; taken from the request path."`
 
-	// The user who made this subscription
-	UserID int64 `xorm:"bigint index not null" json:"-"`
+	// The user who made this subscription. If left empty when creating a subscription, the currently
+	// authenticated user is subscribed. To subscribe a different user, both the authenticated user and
+	// the user to subscribe need read access to the entity.
+	UserID int64 `xorm:"bigint index not null" json:"user_id,omitempty" doc:"The id of the user to subscribe. If omitted, the currently authenticated user is subscribed. To subscribe someone else, both users need access to the entity."`
 
 	// A timestamp when this subscription was created. You cannot change this value.
 	Created time.Time `xorm:"created not null" json:"created" readOnly:"true" doc:"A timestamp when this subscription was created. You cannot change this value."`
@@ -129,15 +131,18 @@ func (sb *Subscription) TableName() string {
 	return "subscriptions"
 }
 
-// Create subscribes the current user to an entity
-// @Summary Subscribes the current user to an entity.
-// @Description Subscribes the current user to an entity.
+// Create subscribes a user to an entity. If no user is specified, the currently authenticated user is
+// subscribed. To subscribe a different user, both the authenticated user and the user to subscribe need
+// read access to the entity.
+// @Summary Subscribes a user to an entity.
+// @Description Subscribes the currently authenticated user to an entity. To subscribe a different user, pass their numeric id as `user_id` in the request body - this requires the authenticated user to have write access to the entity, and the user to subscribe needs read access to it.
 // @tags subscriptions
 // @Accept json
 // @Produce json
 // @Security JWTKeyAuth
 // @Param entity path string true "The entity the user subscribes to. Can be either `project` or `task`."
 // @Param entityID path string true "The numeric id of the entity to subscribe to."
+// @Param subscription body models.Subscription true "The user to subscribe. Leave the body empty to subscribe the currently authenticated user."
 // @Success 201 {object} models.Subscription "The subscription"
 // @Failure 403 {object} web.HTTPError "The user does not have access to subscribe to this entity."
 // @Failure 412 {object} web.HTTPError "The subscription already exists."
@@ -148,9 +153,27 @@ func (sb *Subscription) Create(s *xorm.Session, auth web.Auth) (err error) {
 	// Permissions method already does the validation of the entity type, so we don't need to do that here
 
 	sb.ID = 0
-	sb.UserID = auth.GetID()
 
-	sub, err := GetSubscriptionForUser(s, sb.EntityType, sb.EntityID, auth)
+	// subscriber defaults to the currently authenticated user; CanCreate already made sure the caller
+	// is allowed to subscribe someone else if sb.UserID is set to a different user.
+	subscriber := auth
+	if sb.UserID != 0 && sb.UserID != auth.GetID() {
+		subscriber, err = user.GetUserByID(s, sb.UserID)
+		if err != nil {
+			return err
+		}
+
+		canRead, readErr := canReadSubscriptionEntity(s, sb.EntityType, sb.EntityID, subscriber)
+		if readErr != nil {
+			return readErr
+		}
+		if !canRead {
+			return ErrUserDoesNotHaveAccessToProject{ProjectID: sb.EntityID, UserID: sb.UserID}
+		}
+	}
+	sb.UserID = subscriber.GetID()
+
+	sub, err := GetSubscriptionForUser(s, sb.EntityType, sb.EntityID, subscriber)
 	if err != nil {
 		return err
 	}
@@ -163,6 +186,20 @@ func (sb *Subscription) Create(s *xorm.Session, auth web.Auth) (err error) {
 	}
 
 	_, err = s.Insert(sb)
+	return
+}
+
+func canReadSubscriptionEntity(s *xorm.Session, entityType SubscriptionEntityType, entityID int64, a web.Auth) (can bool, err error) {
+	switch entityType {
+	case SubscriptionEntityProject:
+		p := &Project{ID: entityID}
+		can, _, err = p.CanRead(s, a)
+	case SubscriptionEntityTask:
+		t := &Task{ID: entityID}
+		can, _, err = t.CanRead(s, a)
+	default:
+		return false, &ErrUnknownSubscriptionEntityType{EntityType: entityType}
+	}
 	return
 }
 

--- a/pkg/models/subscription.go
+++ b/pkg/models/subscription.go
@@ -113,6 +113,9 @@ type Subscription struct {
 
 	web.CRUDable    `xorm:"-" json:"-"`
 	web.Permissions `xorm:"-" json:"-"`
+
+	// subscriber is resolved and access-checked in CanCreate so Create doesn't need to re-query it.
+	subscriber *user.User
 }
 
 type SubscriptionWithUser struct {
@@ -149,31 +152,13 @@ func (sb *Subscription) TableName() string {
 // @Failure 412 {object} web.HTTPError "The subscription entity is invalid."
 // @Failure 500 {object} models.Message "Internal error"
 // @Router /subscriptions/{entity}/{entityID} [put]
-func (sb *Subscription) Create(s *xorm.Session, auth web.Auth) (err error) {
-	// Permissions method already does the validation of the entity type, so we don't need to do that here
+func (sb *Subscription) Create(s *xorm.Session, _ web.Auth) (err error) {
+	// CanCreate already validated the entity type and resolved+access-checked sb.subscriber.
 
 	sb.ID = 0
+	sb.UserID = sb.subscriber.GetID()
 
-	// subscriber defaults to the currently authenticated user; CanCreate already made sure the caller
-	// is allowed to subscribe someone else if sb.UserID is set to a different user.
-	subscriber := auth
-	if sb.UserID != 0 && sb.UserID != auth.GetID() {
-		subscriber, err = user.GetUserByID(s, sb.UserID)
-		if err != nil {
-			return err
-		}
-
-		canRead, readErr := canReadSubscriptionEntity(s, sb.EntityType, sb.EntityID, subscriber)
-		if readErr != nil {
-			return readErr
-		}
-		if !canRead {
-			return ErrUserDoesNotHaveAccessToProject{ProjectID: sb.EntityID, UserID: sb.UserID}
-		}
-	}
-	sb.UserID = subscriber.GetID()
-
-	sub, err := GetSubscriptionForUser(s, sb.EntityType, sb.EntityID, subscriber)
+	sub, err := GetSubscriptionForUser(s, sb.EntityType, sb.EntityID, sb.subscriber)
 	if err != nil {
 		return err
 	}

--- a/pkg/models/subscription_permissions.go
+++ b/pkg/models/subscription_permissions.go
@@ -21,7 +21,8 @@ import (
 	"xorm.io/xorm"
 )
 
-// CanCreate checks if a user can subscribe to an entity
+// CanCreate checks if a user can subscribe to an entity. Subscribing yourself only requires read access,
+// subscribing someone else requires write access to the entity.
 func (sb *Subscription) CanCreate(s *xorm.Session, a web.Auth) (can bool, err error) {
 	if _, is := a.(*LinkSharing); is {
 		return false, ErrGenericForbidden{}
@@ -29,13 +30,23 @@ func (sb *Subscription) CanCreate(s *xorm.Session, a web.Auth) (can bool, err er
 
 	sb.EntityType = getEntityTypeFromString(sb.Entity)
 
+	subscribingSomeoneElse := sb.UserID != 0 && sb.UserID != a.GetID()
+
 	switch sb.EntityType {
 	case SubscriptionEntityProject:
 		l := &Project{ID: sb.EntityID}
-		can, _, err = l.CanRead(s, a)
+		if subscribingSomeoneElse {
+			can, err = l.CanUpdate(s, a)
+		} else {
+			can, _, err = l.CanRead(s, a)
+		}
 	case SubscriptionEntityTask:
 		t := &Task{ID: sb.EntityID}
-		can, _, err = t.CanRead(s, a)
+		if subscribingSomeoneElse {
+			can, err = t.CanUpdate(s, a)
+		} else {
+			can, _, err = t.CanRead(s, a)
+		}
 	default:
 		return false, &ErrUnknownSubscriptionEntityType{EntityType: sb.EntityType}
 	}

--- a/pkg/models/subscription_permissions.go
+++ b/pkg/models/subscription_permissions.go
@@ -17,12 +17,14 @@
 package models
 
 import (
+	"code.vikunja.io/api/pkg/user"
 	"code.vikunja.io/api/pkg/web"
 	"xorm.io/xorm"
 )
 
 // CanCreate checks if a user can subscribe to an entity. Subscribing yourself only requires read access,
-// subscribing someone else requires write access to the entity.
+// subscribing someone else requires write access to the entity for the caller and read access for the
+// target user.
 func (sb *Subscription) CanCreate(s *xorm.Session, a web.Auth) (can bool, err error) {
 	if _, is := a.(*LinkSharing); is {
 		return false, ErrGenericForbidden{}
@@ -31,6 +33,14 @@ func (sb *Subscription) CanCreate(s *xorm.Session, a web.Auth) (can bool, err er
 	sb.EntityType = getEntityTypeFromString(sb.Entity)
 
 	subscribingSomeoneElse := sb.UserID != 0 && sb.UserID != a.GetID()
+
+	subscriber := a.(*user.User)
+	if subscribingSomeoneElse {
+		subscriber, err = user.GetUserByID(s, sb.UserID)
+		if err != nil {
+			return false, err
+		}
+	}
 
 	switch sb.EntityType {
 	case SubscriptionEntityProject:
@@ -50,8 +60,22 @@ func (sb *Subscription) CanCreate(s *xorm.Session, a web.Auth) (can bool, err er
 	default:
 		return false, &ErrUnknownSubscriptionEntityType{EntityType: sb.EntityType}
 	}
+	if err != nil || !can {
+		return
+	}
 
-	return
+	if subscribingSomeoneElse {
+		can, err = canReadSubscriptionEntity(s, sb.EntityType, sb.EntityID, subscriber)
+		if err != nil {
+			return false, err
+		}
+		if !can {
+			return false, ErrUserDoesNotHaveAccessToProject{ProjectID: sb.EntityID, UserID: sb.UserID}
+		}
+	}
+
+	sb.subscriber = subscriber
+	return true, nil
 }
 
 // CanDelete checks if a user can delete a subscription

--- a/pkg/models/subscription_test.go
+++ b/pkg/models/subscription_test.go
@@ -190,6 +190,118 @@ func TestSubscription_Create(t *testing.T) {
 	// TODO: Add tests to test triggering of notifications for subscribed things
 }
 
+// TestSubscription_CreateForOtherUser covers subscribing a different user than the caller.
+// Project 29 (pkg/db/fixtures/users_projects.yml) is shared to:
+//   - user1  (permission 2, admin)
+//   - user11 (permission 0, read)
+//   - user12 (permission 1, write)
+//   - user13 (permission 2, admin)
+//
+// user2 has no access to project 29 at all.
+func TestSubscription_CreateForOtherUser(t *testing.T) {
+	t.Run("caller with write access can subscribe a user with read access", func(t *testing.T) {
+		db.LoadAndAssertFixtures(t)
+		s := db.NewSession()
+		defer s.Close()
+
+		caller := &user.User{ID: 1}
+		sb := &Subscription{
+			Entity:   "project",
+			EntityID: 29,
+			UserID:   11,
+		}
+
+		can, err := sb.CanCreate(s, caller)
+		require.NoError(t, err)
+		assert.True(t, can)
+
+		err = sb.Create(s, caller)
+		require.NoError(t, err)
+		require.NoError(t, s.Commit())
+
+		assert.Equal(t, int64(11), sb.UserID)
+		db.AssertExists(t, "subscriptions", map[string]interface{}{
+			"entity_type": 2,
+			"entity_id":   29,
+			"user_id":     11,
+		}, false)
+	})
+	t.Run("explicit own id behaves like self-subscribe", func(t *testing.T) {
+		db.LoadAndAssertFixtures(t)
+		s := db.NewSession()
+		defer s.Close()
+
+		caller := &user.User{ID: 12}
+		sb := &Subscription{
+			Entity:   "project",
+			EntityID: 29,
+			UserID:   12,
+		}
+
+		can, err := sb.CanCreate(s, caller)
+		require.NoError(t, err)
+		assert.True(t, can)
+
+		err = sb.Create(s, caller)
+		require.NoError(t, err)
+	})
+	t.Run("target user without access is rejected", func(t *testing.T) {
+		db.LoadAndAssertFixtures(t)
+		s := db.NewSession()
+		defer s.Close()
+
+		caller := &user.User{ID: 1}
+		sb := &Subscription{
+			Entity:   "project",
+			EntityID: 29,
+			UserID:   2, // user2 has no access to project 29
+		}
+
+		can, err := sb.CanCreate(s, caller)
+		require.NoError(t, err)
+		assert.True(t, can, "the caller has write access, so CanCreate passes")
+
+		err = sb.Create(s, caller)
+		require.Error(t, err)
+		assert.True(t, IsErrUserDoesNotHaveAccessToProject(err))
+	})
+	t.Run("caller with read-only access cannot subscribe someone else", func(t *testing.T) {
+		db.LoadAndAssertFixtures(t)
+		s := db.NewSession()
+		defer s.Close()
+
+		caller := &user.User{ID: 11} // read-only on project 29
+		sb := &Subscription{
+			Entity:   "project",
+			EntityID: 29,
+			UserID:   12,
+		}
+
+		can, err := sb.CanCreate(s, caller)
+		require.NoError(t, err)
+		assert.False(t, can)
+	})
+	t.Run("empty user id still subscribes the caller", func(t *testing.T) {
+		db.LoadAndAssertFixtures(t)
+		s := db.NewSession()
+		defer s.Close()
+
+		caller := &user.User{ID: 11}
+		sb := &Subscription{
+			Entity:   "project",
+			EntityID: 29,
+		}
+
+		can, err := sb.CanCreate(s, caller)
+		require.NoError(t, err)
+		assert.True(t, can)
+
+		err = sb.Create(s, caller)
+		require.NoError(t, err)
+		assert.Equal(t, int64(11), sb.UserID)
+	})
+}
+
 func TestSubscription_Delete(t *testing.T) {
 	t.Run("normal", func(t *testing.T) {
 		db.LoadAndAssertFixtures(t)

--- a/pkg/models/subscription_test.go
+++ b/pkg/models/subscription_test.go
@@ -258,12 +258,9 @@ func TestSubscription_CreateForOtherUser(t *testing.T) {
 		}
 
 		can, err := sb.CanCreate(s, caller)
-		require.NoError(t, err)
-		assert.True(t, can, "the caller has write access, so CanCreate passes")
-
-		err = sb.Create(s, caller)
 		require.Error(t, err)
 		assert.True(t, IsErrUserDoesNotHaveAccessToProject(err))
+		assert.False(t, can, "the caller has write access, but the target user has no access, so CanCreate rejects")
 	})
 	t.Run("caller with read-only access cannot subscribe someone else", func(t *testing.T) {
 		db.LoadAndAssertFixtures(t)

--- a/pkg/routes/api/v2/subscriptions.go
+++ b/pkg/routes/api/v2/subscriptions.go
@@ -34,13 +34,21 @@ type subscriptionPathParams struct {
 	EntityID int64  `path:"entityID" doc:"The numeric id of the entity to (un)subscribe from."`
 }
 
+// Body is a pointer and optional: an empty request subscribes the authenticated user. Passing a
+// user_id subscribes that user instead, provided both users have access to the entity.
+type subscriptionCreateParams struct {
+	Entity   string               `path:"entity" enum:"project,task" doc:"The kind of entity to (un)subscribe from. Either project or task."`
+	EntityID int64                `path:"entityID" doc:"The numeric id of the entity to (un)subscribe from."`
+	Body     *models.Subscription `required:"false"`
+}
+
 func RegisterSubscriptionRoutes(api huma.API) {
 	tags := []string{"subscriptions"}
 
 	Register(api, huma.Operation{
 		OperationID: "subscriptions-create",
 		Summary:     "Subscribe to an entity",
-		Description: "Subscribes the authenticated user to a project or task so they receive its notifications. The user needs read access to the entity. Fails if a subscription already exists.",
+		Description: "Subscribes a user to a project or task so they receive its notifications. Leave the body empty to subscribe the authenticated user, who only needs read access. To subscribe someone else, pass their numeric id as user_id in the body - this requires the authenticated user to have write access to the entity, and the user to subscribe needs read access to it. Fails if a subscription already exists.",
 		Method:      http.MethodPost,
 		Path:        "/subscriptions/{entity}/{entityID}",
 		Tags:        tags,
@@ -58,12 +66,15 @@ func RegisterSubscriptionRoutes(api huma.API) {
 
 func init() { AddRouteRegistrar(RegisterSubscriptionRoutes) }
 
-func subscriptionsCreate(ctx context.Context, in *subscriptionPathParams) (*singleBody[models.Subscription], error) {
+func subscriptionsCreate(ctx context.Context, in *subscriptionCreateParams) (*singleBody[models.Subscription], error) {
 	a, err := authFromCtx(ctx)
 	if err != nil {
 		return nil, err
 	}
 	sb := &models.Subscription{Entity: in.Entity, EntityID: in.EntityID}
+	if in.Body != nil {
+		sb.UserID = in.Body.UserID
+	}
 	if err := handler.DoCreate(ctx, sb, a); err != nil {
 		return nil, translateDomainError(err)
 	}

--- a/pkg/webtests/huma_subscription_test.go
+++ b/pkg/webtests/huma_subscription_test.go
@@ -20,6 +20,8 @@ import (
 	"net/http"
 	"testing"
 
+	"code.vikunja.io/api/pkg/user"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -28,6 +30,8 @@ import (
 //   - user1 has read access to task 1 and project 1.
 //   - user1 is already subscribed to task 2 (subscriptions.yml id 1).
 //   - user1 cannot see task 14 or project 20.
+//   - project 29 (users_projects.yml) is shared to user1 (admin), user11 (read)
+//     and user12 (write); user2 has no access to it at all.
 func TestHumaSubscription(t *testing.T) {
 	token := func(t *testing.T) string { return humaTokenFor(t, &testuser1) }
 
@@ -83,6 +87,38 @@ func TestHumaSubscription(t *testing.T) {
 			require.NoError(t, err)
 			rec := humaRequest(t, e, http.MethodPost, "/api/v2/subscriptions/project/20", "", token(t), "")
 			assert.Equal(t, http.StatusForbidden, rec.Code, "body: %s", rec.Body.String())
+		})
+
+		// Project 29 (pkg/db/fixtures/users_projects.yml) is shared to user1 (admin),
+		// user11 (read), user12 (write) and user13 (admin). user2 has no access at all.
+		t.Run("for another user", func(t *testing.T) {
+			t.Run("caller with write access can subscribe a user with read access", func(t *testing.T) {
+				e, err := setupTestEnv()
+				require.NoError(t, err)
+				rec := humaRequest(t, e, http.MethodPost, "/api/v2/subscriptions/project/29", `{"user_id":11}`, token(t), "")
+				assert.Equal(t, http.StatusCreated, rec.Code, "body: %s", rec.Body.String())
+				assert.Contains(t, rec.Body.String(), `"user_id":11`)
+			})
+			t.Run("target user without access is rejected", func(t *testing.T) {
+				e, err := setupTestEnv()
+				require.NoError(t, err)
+				rec := humaRequest(t, e, http.MethodPost, "/api/v2/subscriptions/project/29", `{"user_id":2}`, token(t), "")
+				assert.Equal(t, http.StatusForbidden, rec.Code, "body: %s", rec.Body.String())
+			})
+			t.Run("caller with read-only access cannot subscribe someone else", func(t *testing.T) {
+				e, err := setupTestEnv()
+				require.NoError(t, err)
+				rec := humaRequest(t, e, http.MethodPost, "/api/v2/subscriptions/project/29",
+					`{"user_id":12}`, humaTokenFor(t, &user.User{ID: 11}), "")
+				assert.Equal(t, http.StatusForbidden, rec.Code, "body: %s", rec.Body.String())
+			})
+			t.Run("empty body still subscribes the caller", func(t *testing.T) {
+				e, err := setupTestEnv()
+				require.NoError(t, err)
+				rec := humaRequest(t, e, http.MethodPost, "/api/v2/subscriptions/project/29", "", token(t), "")
+				assert.Equal(t, http.StatusCreated, rec.Code, "body: %s", rec.Body.String())
+				assert.Contains(t, rec.Body.String(), `"user_id":1`)
+			})
 		})
 	})
 


### PR DESCRIPTION
Subscriptions previously only supported subscribing the currently authenticated user. PUT/POST /subscriptions/{entity}/{entityID} now accepts an optional user_id in the body to subscribe someone else, mirroring how /tasks/{id}/assignees works.

An empty body still subscribes the authenticated user (unchanged default, backwards compatibility). Subscribing another user requires the caller to have write access to the entity, and the target user needs read access to it - enforced in both Subscription.CanCreate/Create (pkg/models) and the v2 Huma route (pkg/routes/api/v2/subscriptions.go).