### PR TITLE
fix(caldav): compute VTODO DURATION components correctly

### DIFF
--- a/pkg/caldav/caldav.go
+++ b/pkg/caldav/caldav.go
@@ -119,12 +119,14 @@ COLOR:` + color
 }
 
 func formatDuration(duration time.Duration) string {
-	seconds := duration.Seconds() - duration.Minutes()*60
-	minutes := duration.Minutes() - duration.Hours()*60
+	seconds := int64(duration.Seconds())
+	hours := seconds / 3600
+	minutes := (seconds % 3600) / 60
+	seconds %= 60
 
-	return strconv.FormatFloat(duration.Hours(), 'f', 0, 64) + `H` +
-		strconv.FormatFloat(minutes, 'f', 0, 64) + `M` +
-		strconv.FormatFloat(seconds, 'f', 0, 64) + `S`
+	return strconv.FormatInt(hours, 10) + `H` +
+		strconv.FormatInt(minutes, 10) + `M` +
+		strconv.FormatInt(seconds, 10) + `S`
 }
 
 func getRruleFromInterval(interval int64) (freq string, newInterval int64) {

--- a/pkg/caldav/caldav_test.go
+++ b/pkg/caldav/caldav_test.go
@@ -526,6 +526,26 @@ func TestGetCaldavColor(t *testing.T) {
 	}
 }
 
+func Test_formatDuration(t *testing.T) {
+	tests := []struct {
+		name string
+		in   time.Duration
+		want string
+	}{
+		{"whole hours", time.Hour, "1H0M0S"},
+		{"hours and minutes", time.Hour + 30*time.Minute, "1H30M0S"},
+		{"minutes only", 30 * time.Minute, "0H30M0S"},
+		{"minutes only, not a round hour", 45 * time.Minute, "0H45M0S"},
+		{"hours, minutes and seconds", 2*time.Hour + 15*time.Minute + 30*time.Second, "2H15M30S"},
+		{"seconds only", 30 * time.Second, "0H0M30S"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, formatDuration(tt.in))
+		})
+	}
+}
+
 func TestEscapeICalText(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
`formatDuration` derived its minute/second components with `duration.Minutes() - duration.Hours()*60` and `duration.Seconds() - duration.Minutes()*60`. Because `Minutes()` is exactly `Hours()*60` (and likewise for seconds), both were always 0, and `FormatFloat(..., 'f', 0, ...)` additionally rounded the total hours. So the DURATION emitted for a VTODO was wrong for any non-whole-hour value:

- 1h30m -> PT2H0M0S  (should be PT1H30M0S)
- 30m   -> PT0H0M0S  (dropped entirely; should be PT0H30M0S)
- 45m   -> PT1H0M0S  (should be PT0H45M0S)

Switched to integer arithmetic to derive the hour/minute/second remainders, and added a `Test_formatDuration` table test covering these cases (it fails on current `main` and passes with this change). `go test ./pkg/caldav/`, `go vet`, and `gofmt` are clean.

AI disclosure: written with AI assistance (Claude). I reviewed every line, reproduced the bug, and verified the fix with `go test ./pkg/caldav/`.
