### PR TITLE
feat(filters): filter tasks by their relations (closes #2183)

### DIFF
--- a/frontend/src/components/input/filter/FilterInputDocs.vue
+++ b/frontend/src/components/input/filter/FilterInputDocs.vue
@@ -33,6 +33,8 @@ const showDocs = ref(false)
 			<li><code>reminders</code>: {{ $t('filters.query.help.fields.reminders') }}</li>
 			<li><code>created</code>: {{ $t('filters.query.help.fields.created') }}</li>
 			<li><code>updated</code>: {{ $t('filters.query.help.fields.updated') }}</li>
+			<li><code>relations</code>: {{ $t('filters.query.help.fields.relations') }}</li>
+			<li><code>openRelations</code>: {{ $t('filters.query.help.fields.openRelations') }}</li>
 		</ul>
 		<p>{{ $t('filters.query.help.canUseDatemath') }}</p>
 		<p>{{ $t('filters.query.help.operators.intro') }}</p>
@@ -65,6 +67,11 @@ const showDocs = ref(false)
 			<li>
 				<code>(priority = 1 || priority = 2) &amp;&amp; dueDate &lt;= now</code>:
 				{{ $t('filters.query.help.examples.priorityOneOrTwoPastDue') }}
+			</li>
+			<li><code>relations = subtask</code>: {{ $t('filters.query.help.examples.hasSubtasks') }}</li>
+			<li>
+				<code>done = false &amp;&amp; openRelations != blocked</code>:
+				{{ $t('filters.query.help.examples.doableNow') }}
 			</li>
 		</ul>
 	</Expandable>

--- a/frontend/src/helpers/filters.test.ts
+++ b/frontend/src/helpers/filters.test.ts
@@ -16,6 +16,8 @@ describe('Filter Transformation', () => {
 		'reminders': 'reminders',
 		'assignees': 'assignees',
 		'labels': 'labels',
+		'relations': 'relations',
+		'openRelations': 'open_relations',
 	}
 
 	describe('For API', () => {

--- a/frontend/src/helpers/filters.ts
+++ b/frontend/src/helpers/filters.ts
@@ -47,6 +47,8 @@ export const AVAILABLE_FILTER_FIELDS = [
 	'done',
 	'priority',
 	'percentDone',
+	'relations',
+	'openRelations',
 ]
 
 export const FILTER_OPERATORS = [

--- a/frontend/src/i18n/lang/en.json
+++ b/frontend/src/i18n/lang/en.json
@@ -621,7 +621,9 @@
           "project": "The project the task belongs to (only available for saved filters, not on a project level)",
           "reminders": "The reminders of the task as a date field, will return all tasks with at least one reminder matching the query",
           "created": "The time and date when the task was created",
-          "updated": "The time and date when the task was last changed"
+          "updated": "The time and date when the task was last changed",
+          "relations": "The kinds of relations the task has to other tasks (subtask, parenttask, related, duplicateof, duplicates, blocking, blocked, precedes, follows, copiedfrom, copiedto), matches all tasks with at least one relation of that kind",
+          "openRelations": "Same as relations, but only counts relations where the other task is not done yet"
         },
         "operators": {
           "intro": "The available operators for filtering include:",
@@ -647,7 +649,9 @@
           "dueDatePast": "Matches tasks with a due date in the past",
           "undoneHighPriority": "Matches undone tasks with priority level 3 or higher",
           "assigneesIn": "Matches tasks assigned to either \"user1\" or \"user2\"",
-          "priorityOneOrTwoPastDue": "Matches tasks with priority level 1 or 2 and a due date in the past"
+          "priorityOneOrTwoPastDue": "Matches tasks with priority level 1 or 2 and a due date in the past",
+          "hasSubtasks": "Matches tasks which have at least one subtask",
+          "doableNow": "Matches undone tasks which are not blocked by another undone task"
         }
       }
     }

--- a/pkg/db/fixtures/task_relations.yml
+++ b/pkg/db/fixtures/task_relations.yml
@@ -97,3 +97,42 @@
   relation_kind: 'parenttask'
   created_by_id: 6
   created: 2018-12-01 15:13:12
+# Blocked/blocking pairs for relation filter tests:
+# task 10 is blocked by task 11 (open), task 4 is blocked by task 2 (done),
+# task 12 is blocking task 2 (done)
+- id: 17
+  task_id: 10
+  other_task_id: 11
+  relation_kind: 'blocked'
+  created_by_id: 1
+  created: 2018-12-01 15:13:12
+- id: 18
+  task_id: 11
+  other_task_id: 10
+  relation_kind: 'blocking'
+  created_by_id: 1
+  created: 2018-12-01 15:13:12
+- id: 19
+  task_id: 4
+  other_task_id: 2
+  relation_kind: 'blocked'
+  created_by_id: 1
+  created: 2018-12-01 15:13:12
+- id: 20
+  task_id: 2
+  other_task_id: 4
+  relation_kind: 'blocking'
+  created_by_id: 1
+  created: 2018-12-01 15:13:12
+- id: 21
+  task_id: 12
+  other_task_id: 2
+  relation_kind: 'blocking'
+  created_by_id: 1
+  created: 2018-12-01 15:13:12
+- id: 22
+  task_id: 2
+  other_task_id: 12
+  relation_kind: 'blocked'
+  created_by_id: 1
+  created: 2018-12-01 15:13:12

--- a/pkg/db/fixtures/task_relations.yml
+++ b/pkg/db/fixtures/task_relations.yml
@@ -136,3 +136,16 @@
   relation_kind: 'blocked'
   created_by_id: 1
   created: 2018-12-01 15:13:12
+# Relation to the soft-deleted task 51: must not count for relation filters
+- id: 23
+  task_id: 33
+  other_task_id: 51
+  relation_kind: 'blocked'
+  created_by_id: 1
+  created: 2018-12-01 15:13:12
+- id: 24
+  task_id: 51
+  other_task_id: 33
+  relation_kind: 'blocking'
+  created_by_id: 1
+  created: 2018-12-01 15:13:12

--- a/pkg/models/task_collection.go
+++ b/pkg/models/task_collection.go
@@ -105,7 +105,9 @@ func validateTaskField(fieldName string) error {
 	case
 		taskPropertyAssignees,
 		taskPropertyLabels,
-		taskPropertyReminders:
+		taskPropertyReminders,
+		taskPropertyRelations,
+		taskPropertyOpenRelations:
 		return nil
 	}
 

--- a/pkg/models/task_collection_filter.go
+++ b/pkg/models/task_collection_filter.go
@@ -160,6 +160,13 @@ func parseFilterFromExpression(f fexpr.ExprGroup, loc *time.Location) (filter *t
 		return nil, err
 	}
 
+	// Relation filters check for the existence of a relation kind, so only
+	// equality-style comparators make sense for them.
+	if (filter.field == taskPropertyRelations || filter.field == taskPropertyOpenRelations) &&
+		!strictComparators[filter.comparator] {
+		return nil, ErrInvalidTaskFilterComparator{Comparator: filter.comparator}
+	}
+
 	reflectValue, filter.value, err = getNativeValueForTaskField(filter.field, filter.comparator, value, loc)
 	if err != nil {
 		return nil, ErrInvalidTaskFilterValue{
@@ -370,6 +377,19 @@ func getNativeValueForTaskField(fieldName string, comparator taskFilterComparato
 	if realFieldName == "Assignees" {
 		vals := strings.Split(value, ",")
 		valueSlice := append([]string{}, vals...)
+		return nil, valueSlice, nil
+	}
+
+	if fieldName == taskPropertyRelations || fieldName == taskPropertyOpenRelations {
+		kinds := strings.Split(value, ",")
+		valueSlice := make([]string, 0, len(kinds))
+		for _, kind := range kinds {
+			relationKind := RelationKind(strings.ToLower(strings.TrimSpace(kind)))
+			if !relationKind.isValid() {
+				return nil, nil, ErrInvalidTaskFilterValue{Field: fieldName, Value: kind}
+			}
+			valueSlice = append(valueSlice, string(relationKind))
+		}
 		return nil, valueSlice, nil
 	}
 

--- a/pkg/models/task_collection_filter_test.go
+++ b/pkg/models/task_collection_filter_test.go
@@ -343,6 +343,58 @@ func TestParseFilter(t *testing.T) {
 		_, err := getTaskFiltersFromFilterString("due_date = no", "UTC")
 		require.Error(t, err)
 	})
+	t.Run("relations", func(t *testing.T) {
+		result, err := getTaskFiltersFromFilterString("relations = blocked", "UTC")
+
+		require.NoError(t, err)
+		require.Len(t, result, 1)
+		assert.Equal(t, "relations", result[0].field)
+		assert.Equal(t, taskFilterComparatorEquals, result[0].comparator)
+		assert.Equal(t, []string{"blocked"}, result[0].value)
+	})
+	t.Run("relations in multiple kinds", func(t *testing.T) {
+		result, err := getTaskFiltersFromFilterString("relations in 'subtask, parenttask'", "UTC")
+
+		require.NoError(t, err)
+		require.Len(t, result, 1)
+		assert.Equal(t, "relations", result[0].field)
+		assert.Equal(t, taskFilterComparatorIn, result[0].comparator)
+		assert.Equal(t, []string{"subtask", "parenttask"}, result[0].value)
+	})
+	t.Run("open_relations", func(t *testing.T) {
+		result, err := getTaskFiltersFromFilterString("open_relations != 'blocked'", "UTC")
+
+		require.NoError(t, err)
+		require.Len(t, result, 1)
+		assert.Equal(t, "open_relations", result[0].field)
+		assert.Equal(t, taskFilterComparatorNotEquals, result[0].comparator)
+		assert.Equal(t, []string{"blocked"}, result[0].value)
+	})
+	t.Run("relations kind is case insensitive", func(t *testing.T) {
+		result, err := getTaskFiltersFromFilterString("relations = Blocked", "UTC")
+
+		require.NoError(t, err)
+		require.Len(t, result, 1)
+		assert.Equal(t, []string{"blocked"}, result[0].value)
+	})
+	t.Run("relations with invalid kind", func(t *testing.T) {
+		_, err := getTaskFiltersFromFilterString("relations = befriended", "UTC")
+
+		require.Error(t, err)
+		assert.True(t, IsErrInvalidTaskFilterValue(err))
+	})
+	t.Run("relations with invalid comparator", func(t *testing.T) {
+		_, err := getTaskFiltersFromFilterString("relations > blocked", "UTC")
+
+		require.Error(t, err)
+		assert.True(t, IsErrInvalidTaskFilterComparator(err))
+	})
+	t.Run("open_relations with like comparator", func(t *testing.T) {
+		_, err := getTaskFiltersFromFilterString("open_relations like blocked", "UTC")
+
+		require.Error(t, err)
+		assert.True(t, IsErrInvalidTaskFilterComparator(err))
+	})
 }
 
 // Date filter boundaries must be emitted in UTC — the driver drops a bound

--- a/pkg/models/task_collection_sort.go
+++ b/pkg/models/task_collection_sort.go
@@ -51,6 +51,9 @@ const (
 	taskPropertyAssignees     string = "assignees"
 	taskPropertyLabels        string = "labels"
 	taskPropertyReminders     string = "reminders"
+	// Not task columns: match against the task_relations table, filterable only.
+	taskPropertyRelations     string = "relations"
+	taskPropertyOpenRelations string = "open_relations"
 	// Not a task column: sorts by search relevance on ParadeDB. Valid for
 	// sorting only, silently skipped when the database or query cannot score.
 	taskPropertyRelevance string = "relevance"

--- a/pkg/models/task_collection_test.go
+++ b/pkg/models/task_collection_test.go
@@ -177,7 +177,31 @@ func TestTaskCollection_ReadAll(t *testing.T) {
 		Labels: []*Label{
 			label4,
 		},
-		RelatedTasks: map[RelationKind][]*Task{},
+		RelatedTasks: map[RelationKind][]*Task{
+			RelationKindBlocking: {
+				{
+					ID:          4,
+					Title:       "task #4 low prio",
+					Index:       4,
+					CreatedByID: 1,
+					ProjectID:   1,
+					Priority:    1,
+					Created:     time.Unix(1543626724, 0).In(loc),
+					Updated:     time.Unix(1543626724, 0).In(loc),
+				},
+			},
+			RelationKindBlocked: {
+				{
+					ID:          12,
+					Title:       "task #12 basic",
+					Index:       12,
+					CreatedByID: 1,
+					ProjectID:   1,
+					Created:     time.Unix(1543626724, 0).In(loc),
+					Updated:     time.Unix(1543626724, 0).In(loc),
+				},
+			},
+		},
 		Reminders: []*TaskReminder{
 			{
 				ID:       3,
@@ -209,17 +233,30 @@ func TestTaskCollection_ReadAll(t *testing.T) {
 		Priority:     100,
 	}
 	task4 := &Task{
-		ID:           4,
-		Title:        "task #4 low prio",
-		Identifier:   "TEST1-4",
-		Index:        4,
-		CreatedByID:  1,
-		CreatedBy:    user1,
-		ProjectID:    1,
-		RelatedTasks: map[RelationKind][]*Task{},
-		Created:      time.Unix(1543626724, 0).In(loc),
-		Updated:      time.Unix(1543626724, 0).In(loc),
-		Priority:     1,
+		ID:          4,
+		Title:       "task #4 low prio",
+		Identifier:  "TEST1-4",
+		Index:       4,
+		CreatedByID: 1,
+		CreatedBy:   user1,
+		ProjectID:   1,
+		RelatedTasks: map[RelationKind][]*Task{
+			RelationKindBlocked: {
+				{
+					ID:          2,
+					Title:       "task #2 done",
+					Done:        true,
+					Index:       2,
+					CreatedByID: 1,
+					ProjectID:   1,
+					Created:     time.Unix(1543626724, 0).In(loc),
+					Updated:     time.Unix(1543626724, 0).In(loc),
+				},
+			},
+		},
+		Created:  time.Unix(1543626724, 0).In(loc),
+		Updated:  time.Unix(1543626724, 0).In(loc),
+		Priority: 1,
 	}
 	task5 := &Task{
 		ID:           5,
@@ -289,40 +326,77 @@ func TestTaskCollection_ReadAll(t *testing.T) {
 		EndDate:      time.Unix(1544700000, 0).In(loc),
 	}
 	task10 := &Task{
-		ID:           10,
-		Title:        "task #10 basic",
-		Identifier:   "TEST1-10",
-		Index:        10,
-		CreatedByID:  1,
-		CreatedBy:    user1,
-		ProjectID:    1,
-		RelatedTasks: map[RelationKind][]*Task{},
-		Created:      time.Unix(1543626724, 0).In(loc),
-		Updated:      time.Unix(1543626724, 0).In(loc),
+		ID:          10,
+		Title:       "task #10 basic",
+		Identifier:  "TEST1-10",
+		Index:       10,
+		CreatedByID: 1,
+		CreatedBy:   user1,
+		ProjectID:   1,
+		RelatedTasks: map[RelationKind][]*Task{
+			RelationKindBlocked: {
+				{
+					ID:          11,
+					Title:       "task #11 basic",
+					Index:       11,
+					CreatedByID: 1,
+					ProjectID:   1,
+					Created:     time.Unix(1543626724, 0).In(loc),
+					Updated:     time.Unix(1543626724, 0).In(loc),
+				},
+			},
+		},
+		Created: time.Unix(1543626724, 0).In(loc),
+		Updated: time.Unix(1543626724, 0).In(loc),
 	}
 	task11 := &Task{
-		ID:           11,
-		Title:        "task #11 basic",
-		Identifier:   "TEST1-11",
-		Index:        11,
-		CreatedByID:  1,
-		CreatedBy:    user1,
-		ProjectID:    1,
-		RelatedTasks: map[RelationKind][]*Task{},
-		Created:      time.Unix(1543626724, 0).In(loc),
-		Updated:      time.Unix(1543626724, 0).In(loc),
+		ID:          11,
+		Title:       "task #11 basic",
+		Identifier:  "TEST1-11",
+		Index:       11,
+		CreatedByID: 1,
+		CreatedBy:   user1,
+		ProjectID:   1,
+		RelatedTasks: map[RelationKind][]*Task{
+			RelationKindBlocking: {
+				{
+					ID:          10,
+					Title:       "task #10 basic",
+					Index:       10,
+					CreatedByID: 1,
+					ProjectID:   1,
+					Created:     time.Unix(1543626724, 0).In(loc),
+					Updated:     time.Unix(1543626724, 0).In(loc),
+				},
+			},
+		},
+		Created: time.Unix(1543626724, 0).In(loc),
+		Updated: time.Unix(1543626724, 0).In(loc),
 	}
 	task12 := &Task{
-		ID:           12,
-		Title:        "task #12 basic",
-		Identifier:   "TEST1-12",
-		Index:        12,
-		CreatedByID:  1,
-		CreatedBy:    user1,
-		ProjectID:    1,
-		RelatedTasks: map[RelationKind][]*Task{},
-		Created:      time.Unix(1543626724, 0).In(loc),
-		Updated:      time.Unix(1543626724, 0).In(loc),
+		ID:          12,
+		Title:       "task #12 basic",
+		Identifier:  "TEST1-12",
+		Index:       12,
+		CreatedByID: 1,
+		CreatedBy:   user1,
+		ProjectID:   1,
+		RelatedTasks: map[RelationKind][]*Task{
+			RelationKindBlocking: {
+				{
+					ID:          2,
+					Title:       "task #2 done",
+					Done:        true,
+					Index:       2,
+					CreatedByID: 1,
+					ProjectID:   1,
+					Created:     time.Unix(1543626724, 0).In(loc),
+					Updated:     time.Unix(1543626724, 0).In(loc),
+				},
+			},
+		},
+		Created: time.Unix(1543626724, 0).In(loc),
+		Updated: time.Unix(1543626724, 0).In(loc),
 	}
 	task15 := &Task{
 		ID:           15,
@@ -1572,6 +1646,148 @@ func TestTaskCollection_ReadAll(t *testing.T) {
 				task5,
 			},
 			wantErr: false,
+		},
+		{
+			name: "filter relations blocked",
+			fields: fields{
+				Filter: "relations = 'blocked'",
+			},
+			args: defaultArgs,
+			want: []*Task{
+				task2,
+				task4,
+				task10,
+			},
+			wantErr: false,
+		},
+		{
+			name: "filter relations blocking",
+			fields: fields{
+				Filter: "relations = 'blocking'",
+			},
+			args: defaultArgs,
+			want: []*Task{
+				task2,
+				task11,
+				task12,
+			},
+			wantErr: false,
+		},
+		{
+			name: "filter relations in multiple kinds",
+			fields: fields{
+				Filter: "relations in 'blocked, blocking'",
+			},
+			args: defaultArgs,
+			want: []*Task{
+				task2,
+				task4,
+				task10,
+				task11,
+				task12,
+			},
+			wantErr: false,
+		},
+		{
+			name: "filter relations subtask",
+			fields: fields{
+				ProjectID: 1,
+				Filter:    "relations = 'subtask'",
+			},
+			args: defaultArgs,
+			want: []*Task{
+				task1,
+			},
+			wantErr: false,
+		},
+		{
+			name: "filter relations parenttask",
+			fields: fields{
+				ProjectID: 1,
+				Filter:    "relations = 'parenttask'",
+			},
+			args: defaultArgs,
+			want: []*Task{
+				task29,
+			},
+			wantErr: false,
+		},
+		{
+			// Only matches when the blocking task is not done yet: task 4 is
+			// blocked by the done task 2, so it does not show up here.
+			name: "filter open_relations blocked",
+			fields: fields{
+				Filter: "open_relations = 'blocked'",
+			},
+			args: defaultArgs,
+			want: []*Task{
+				task2,
+				task10,
+			},
+			wantErr: false,
+		},
+		{
+			// Task 12 blocks only the done task 2, so it does not show up here.
+			name: "filter open_relations blocking",
+			fields: fields{
+				Filter: "open_relations = 'blocking'",
+			},
+			args: defaultArgs,
+			want: []*Task{
+				task2,
+				task11,
+			},
+			wantErr: false,
+		},
+		{
+			// The "doable now" view of #2183: open tasks which are not blocked
+			// by another open task. Task 10 is blocked by the open task 11 and
+			// disappears, task 4 is blocked by the done task 2 and stays.
+			name: "filter not blocked by an open task",
+			fields: fields{
+				ProjectID: 1,
+				Filter:    "done = false && open_relations != 'blocked'",
+			},
+			args: defaultArgs,
+			want: []*Task{
+				task1,
+				task3,
+				task4,
+				task5,
+				task6,
+				task7,
+				task8,
+				task9,
+				task11,
+				task12,
+				task27,
+				task28,
+				task29,
+				task30,
+				task31,
+				task33,
+				task47,
+				task48,
+			},
+			wantErr: false,
+		},
+		{
+			name: "filter relations with invalid kind",
+			fields: fields{
+				Filter: "relations = 'befriended'",
+			},
+			args:    defaultArgs,
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "filter relations with invalid comparator",
+			fields: fields{
+				Filter: "relations > 'blocked'",
+			},
+			args:    defaultArgs,
+			want:    nil,
+			wantErr: true,
 		},
 		{
 			name: "order by position",

--- a/pkg/models/task_collection_test.go
+++ b/pkg/models/task_collection_test.go
@@ -1648,6 +1648,8 @@ func TestTaskCollection_ReadAll(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			// Task 33 is blocked as well, but only by the soft-deleted task 51,
+			// which must not count.
 			name: "filter relations blocked",
 			fields: fields{
 				Filter: "relations = 'blocked'",
@@ -1742,7 +1744,8 @@ func TestTaskCollection_ReadAll(t *testing.T) {
 		{
 			// The "doable now" view of #2183: open tasks which are not blocked
 			// by another open task. Task 10 is blocked by the open task 11 and
-			// disappears, task 4 is blocked by the done task 2 and stays.
+			// disappears, task 4 is blocked by the done task 2 and stays, and
+			// task 33 stays because its only blocker is soft-deleted.
 			name: "filter not blocked by an open task",
 			fields: fields{
 				ProjectID: 1,
@@ -2122,6 +2125,39 @@ func TestTaskSearchWithExpandSubtasks(t *testing.T) {
 	tasks, _, _, err := getRawTasksForProjects(s, []*Project{project}, &user.User{ID: 15}, opts)
 	require.NoError(t, err)
 	require.NotEmpty(t, tasks)
+}
+
+func TestTaskSearchExpandSubtasksWithRelationFilter(t *testing.T) {
+	db.LoadAndAssertFixtures(t)
+	s := db.NewSession()
+	defer s.Close()
+
+	// The subtask expansion evaluates the filter against the parent_tasks
+	// alias as well, which must work for the relation sub-table filters too.
+	filters, err := getTaskFiltersFromFilterString("done = false && open_relations != 'blocked'", "UTC")
+	require.NoError(t, err)
+
+	project, err := GetProjectSimpleByID(s, 1)
+	require.NoError(t, err)
+
+	opts := &taskSearchOptions{
+		parsedFilters: filters,
+		expand:        []TaskCollectionExpandable{TaskCollectionExpandSubtasks},
+	}
+
+	tasks, _, _, err := getRawTasksForProjects(s, []*Project{project}, &user.User{ID: 1}, opts)
+	require.NoError(t, err)
+	require.NotEmpty(t, tasks)
+
+	ids := make([]int64, 0, len(tasks))
+	for _, task := range tasks {
+		ids = append(ids, task.ID)
+	}
+	// Task 10 is blocked by the open task 11 and must not appear, task 4 is
+	// blocked by the done task 2 and stays.
+	assert.NotContains(t, ids, int64(10))
+	assert.Contains(t, ids, int64(4))
+	assert.Contains(t, ids, int64(29), "task 29 is a subtask of task 1 and must be pulled in via expand")
 }
 
 func TestTaskCollection_SubtaskWithMultipleParentsNoDuplicates(t *testing.T) {

--- a/pkg/models/task_search.go
+++ b/pkg/models/task_search.go
@@ -68,11 +68,15 @@ var subTableFilters = SubTableFilters{
 		JoinTable:       "users",
 		JoinCond:        "users.id = user_id",
 	},
+	// A relation to a soft-deleted task no longer counts, same as in
+	// buildSubtaskRootCondition.
 	taskPropertyRelations: {
 		Table:           "task_relations",
 		BaseFilter:      "tasks.id = task_id",
 		FilterableField: "relation_kind",
 		AllowNullCheck:  true,
+		JoinTable:       "tasks related_task",
+		JoinCond:        "related_task.id = task_relations.other_task_id AND related_task.deleted_at IS NULL",
 	},
 	// Like "relations", but only matches when the related task is not done yet.
 	taskPropertyOpenRelations: {
@@ -81,7 +85,7 @@ var subTableFilters = SubTableFilters{
 		FilterableField: "relation_kind",
 		AllowNullCheck:  true,
 		JoinTable:       "tasks related_task",
-		JoinCond:        "related_task.id = task_relations.other_task_id AND related_task.done = false",
+		JoinCond:        "related_task.id = task_relations.other_task_id AND related_task.deleted_at IS NULL AND related_task.done = false",
 	},
 	"parent_project": {
 		Table:           "projects",
@@ -239,7 +243,9 @@ func convertFiltersToDBFilterCondWithAlias(rawFilters []*taskFilter, includeNull
 				for i+1 < len(rawFilters) {
 					next := rawFilters[i+1]
 					nextSubTable, nextOk := subTableFilters[next.field]
-					if !nextOk || nextSubTable.Table != subTableFilterParams.Table || next.join != filterConcatAnd {
+					// Compare the whole sub-table config, not just the table name:
+					// relations and open_relations share a table but join differently.
+					if !nextOk || nextSubTable != subTableFilterParams || next.join != filterConcatAnd {
 						break
 					}
 					if !isRangeComparator(next.comparator) {

--- a/pkg/models/task_search.go
+++ b/pkg/models/task_search.go
@@ -33,6 +33,10 @@ type SubTableFilter struct {
 	BaseFilter      string
 	FilterableField string
 	AllowNullCheck  bool
+	// JoinTable/JoinCond add an INNER JOIN to the EXISTS subquery, for filters
+	// which need columns from a table beyond the sub-table itself.
+	JoinTable string
+	JoinCond  string
 }
 
 type SubTableFilters map[string]SubTableFilter
@@ -61,6 +65,23 @@ var subTableFilters = SubTableFilters{
 		BaseFilter:      "tasks.id = task_id",
 		FilterableField: "username",
 		AllowNullCheck:  true,
+		JoinTable:       "users",
+		JoinCond:        "users.id = user_id",
+	},
+	taskPropertyRelations: {
+		Table:           "task_relations",
+		BaseFilter:      "tasks.id = task_id",
+		FilterableField: "relation_kind",
+		AllowNullCheck:  true,
+	},
+	// Like "relations", but only matches when the related task is not done yet.
+	taskPropertyOpenRelations: {
+		Table:           "task_relations",
+		BaseFilter:      "tasks.id = task_id",
+		FilterableField: "relation_kind",
+		AllowNullCheck:  true,
+		JoinTable:       "tasks related_task",
+		JoinCond:        "related_task.id = task_relations.other_task_id AND related_task.done = false",
 	},
 	"parent_project": {
 		Table:           "projects",
@@ -114,9 +135,8 @@ func (sf *SubTableFilter) ToBaseSubQuery(taskAlias string) *builder.Builder {
 		From(sf.Table).
 		Where(builder.Expr(baseFilter))
 
-	// little hack to add users table for assignees filter
-	if sf.Table == "task_assignees" {
-		cond.Join("INNER", "users", "users.id = user_id")
+	if sf.JoinTable != "" {
+		cond.Join("INNER", sf.JoinTable, sf.JoinCond)
 	}
 
 	return cond

--- a/pkg/webtests/huma_task_collection_test.go
+++ b/pkg/webtests/huma_task_collection_test.go
@@ -99,14 +99,21 @@ func TestHumaTaskCollection(t *testing.T) {
 		t.Run("filter by open relations", func(t *testing.T) {
 			// open_relations = 'blocked' matches only tasks blocked by a task
 			// which is not done yet: task 10 (blocked by open task 11) and task 2
-			// (blocked by open task 12), but not task 4 (blocked by done task 2).
+			// (blocked by open task 12), but not task 4 (blocked by done task 2)
+			// and not task 33 (blocked by the soft-deleted task 51). Substring
+			// checks would not do here since excluded tasks can still show up
+			// as related task copies inside the matched ones.
 			rec := get("/api/v2/projects/1/tasks?filter=open_relations%20%3D%20%27blocked%27")
 			require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
-			body := rec.Body.String()
-			assert.Contains(t, body, `task #10`)
-			assert.Contains(t, body, `task #2 `)
-			assert.NotContains(t, body, `task #5 `)
-			assert.NotContains(t, body, `task #6 `)
+			ids := make([]int64, 0, 2)
+			for _, raw := range decodePaginatedTaskItems(t, rec) {
+				var task struct {
+					ID int64 `json:"id"`
+				}
+				require.NoError(t, json.Unmarshal(raw, &task))
+				ids = append(ids, task.ID)
+			}
+			assert.ElementsMatch(t, []int64{2, 10}, ids)
 		})
 		t.Run("invalid relation kind in filter", func(t *testing.T) {
 			rec := get("/api/v2/projects/1/tasks?filter=relations%20%3D%20%27bogus%27")

--- a/pkg/webtests/huma_task_collection_test.go
+++ b/pkg/webtests/huma_task_collection_test.go
@@ -96,6 +96,22 @@ func TestHumaTaskCollection(t *testing.T) {
 			rec := get("/api/v2/projects/1/tasks?filter=due_date%20%3E%20invalid")
 			assert.Equal(t, http.StatusBadRequest, rec.Code, "body: %s", rec.Body.String())
 		})
+		t.Run("filter by open relations", func(t *testing.T) {
+			// open_relations = 'blocked' matches only tasks blocked by a task
+			// which is not done yet: task 10 (blocked by open task 11) and task 2
+			// (blocked by open task 12), but not task 4 (blocked by done task 2).
+			rec := get("/api/v2/projects/1/tasks?filter=open_relations%20%3D%20%27blocked%27")
+			require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+			body := rec.Body.String()
+			assert.Contains(t, body, `task #10`)
+			assert.Contains(t, body, `task #2 `)
+			assert.NotContains(t, body, `task #5 `)
+			assert.NotContains(t, body, `task #6 `)
+		})
+		t.Run("invalid relation kind in filter", func(t *testing.T) {
+			rec := get("/api/v2/projects/1/tasks?filter=relations%20%3D%20%27bogus%27")
+			assert.Equal(t, http.StatusBadRequest, rec.Code, "body: %s", rec.Body.String())
+		})
 	})
 
 	t.Run("search via q", func(t *testing.T) {


### PR DESCRIPTION
Adds two filter fields so tasks can be filtered by their relations. Closes #2183.

```
done = false && open_relations != blocked   # open tasks, minus anything blocked by an unfinished task
```

`relations` matches a task with at least one relation of the given kind (`subtask`, `blocked`, `related`, ...). `open_relations` only counts a relation when the task on the other end isn't done, so a task comes back as soon as its blocker is completed. Operators: `=`, `!=`, `in`, `not in`. Works anywhere `filter=` does.

Additive — no new routes, no `/api/v1` changes. Implemented as an `EXISTS` subquery on the existing sub-table filter mechanism in `pkg/models/task_search.go`, plus the frontend field list and filter help.

Tests added in `pkg/models` and `pkg/webtests`; `mage test:web` and the filter tests pass. Also tested by hand through the API and UI (every kind, cross-project, toggling a blocker done/undone).

AI-assisted: written with Claude, reviewed and tested by me. I'm not a Go dev, so the join in `task_search.go` is worth a close look.

<details>
<summary>Details</summary>

**Valid kinds:** `subtask`, `parenttask`, `blocked`, `blocking`, `related`, `duplicateof`, `duplicates`, `precedes`, `follows`, `copiedfrom`, `copiedto`. The web UI uses `openRelations` and converts to snake_case like other multi-word fields.

**Where the code is:**
- `task_collection_sort.go` / `task_collection.go` — property constants, valid-field set.
- `task_collection_filter.go` — parses values as `RelationKind`s, restricts to equality operators.
- `task_search.go` — `EXISTS` against `task_relations` with an inner join to the related task, so soft-deleted relations are ignored and `open_relations` can check the done state. `SubTableFilter` gained optional join fields, which also replace the hard-coded users join for assignees.
- Frontend: `filters.ts`, `FilterInputDocs.vue`, `en.json`. `pkg/swagger/` untouched (CI regenerates it).

**Two pre-existing quirks you'll hit while reviewing:**
- In a **List** view, `relations = subtask` looks doubled — the view always requests `expand=subtasks`. Table/Kanban/Gantt show the exact result.
- `subtask`/`parenttask` are keyed from the holder's side (a task that *has* subtasks carries `subtask`), opposite to `blocked`/`blocking`. Matches the existing `related_tasks` map; happy to rename.
</details>