### PR TITLE
fix(filter): accept non-zero-padded dates in task filters

### DIFF
--- a/pkg/models/task_collection_filter.go
+++ b/pkg/models/task_collection_filter.go
@@ -91,15 +91,18 @@ func parseTimeFromUserInput(timeString string, loc *time.Location) (value time.T
 		if len(parts) < 3 {
 			return
 		}
-		year, err := strconv.Atoi(parts[0])
+		// Assign to the named err return (not :=) so a successful manual parse
+		// clears the error from the failed layout attempts above.
+		var year, month, day int
+		year, err = strconv.Atoi(parts[0])
 		if err != nil {
 			return value, err
 		}
-		month, err := strconv.Atoi(parts[1])
+		month, err = strconv.Atoi(parts[1])
 		if err != nil {
 			return value, err
 		}
-		day, err := strconv.Atoi(parts[2])
+		day, err = strconv.Atoi(parts[2])
 		if err != nil {
 			return value, err
 		}

--- a/pkg/models/task_collection_filter_test.go
+++ b/pkg/models/task_collection_filter_test.go
@@ -250,6 +250,29 @@ func TestParseFilter(t *testing.T) {
 		resultTime := result[0].value.(time.Time)
 		assert.Equal(t, expectedDate.Format(time.RFC3339), resultTime.Format(time.RFC3339))
 	})
+	t.Run("date field with non-zero-padded date", func(t *testing.T) {
+		result, err := getTaskFiltersFromFilterString("start_date = 2023-6-5", "UTC")
+
+		require.NoError(t, err)
+		require.Len(t, result, 1)
+		assert.Equal(t, "start_date", result[0].field)
+		assert.Equal(t, taskFilterComparatorEquals, result[0].comparator)
+		expectedDate, err := time.ParseInLocation("2006-01-02", "2023-06-05", time.UTC)
+		require.NoError(t, err)
+		resultTime := result[0].value.(time.Time)
+		assert.Equal(t, expectedDate.Format(time.RFC3339), resultTime.Format(time.RFC3339))
+	})
+	t.Run("date field with non-zero-padded day", func(t *testing.T) {
+		result, err := getTaskFiltersFromFilterString("due_date = 2022-11-1", "UTC")
+
+		require.NoError(t, err)
+		require.Len(t, result, 1)
+		assert.Equal(t, "due_date", result[0].field)
+		expectedDate, err := time.ParseInLocation("2006-01-02", "2022-11-01", time.UTC)
+		require.NoError(t, err)
+		resultTime := result[0].value.(time.Time)
+		assert.Equal(t, expectedDate.Format(time.RFC3339), resultTime.Format(time.RFC3339))
+	})
 	t.Run("in query with multiple values", func(t *testing.T) {
 		result, err := getTaskFiltersFromFilterString("priority in 1,3,5", "UTC")
 


### PR DESCRIPTION
Filtering by a date written without zero-padding — e.g. `due_date = 2022-11-1` or `start_date = 2023-6-5` — fails with "Task filter value is invalid", even though `parseTimeFromUserInput` has a manual fallback added specifically to accept such dates.

**Cause:** in that fallback, `year, err := strconv.Atoi(parts[0])` shadows the named `err` return (`:=` introduces a new local because `year` is new). A successful manual parse then returns the correct `time.Time` alongside the stale error left over from the earlier failed `2006-01-02` layout attempt, so the caller discards the value as invalid.

**Fix:** declare `year, month, day` with `var` and assign to the named `err` return with `=`, so a successful manual parse clears the error.

Added regression subtests for a non-zero-padded day and month in `TestParseFilter`.

Verified with `go test ./pkg/models/` (the new subtests fail before this change, pass after); `gofmt`/`go vet` clean.

_Disclosure: this change was prepared with AI assistance (Claude). I reviewed and tested every line and stand behind it._
