### PR TITLE
feat(tasks): show the task identifier in the list view 🤖🤖🤖

### DIFF
--- a/frontend/src/components/tasks/partials/SingleTaskInProject.vue
+++ b/frontend/src/components/tasks/partials/SingleTaskInProject.vue
@@ -59,6 +59,7 @@
 						class="pis-2 mie-1"
 					/>
 
+					<span class="task-id">{{ getTaskIdentifier(task) }}</span>
 					<TaskGlanceTooltip :task="task">
 						<RouterLink
 							ref="taskLinkRef"
@@ -200,7 +201,7 @@
 import {ref, watch, shallowReactive, onMounted, computed} from 'vue'
 import {useI18n} from 'vue-i18n'
 
-import TaskModel, {getHexColor} from '@/models/task'
+import TaskModel, {getHexColor, getTaskIdentifier} from '@/models/task'
 import type {ITask} from '@/modelTypes/ITask'
 
 import PriorityLabel from '@/components/tasks/partials/PriorityLabel.vue'
@@ -616,5 +617,11 @@ defineExpose({
 		padding: 1rem;
 		border: 1px solid var(--grey-200);
 	}
+}
+.task-id {
+	color: var(--grey-400);
+	margin-inline-end: .25rem;
+	font-size: .9em;
+	white-space: nowrap;
 }
 </style>


### PR DESCRIPTION
Renders each task's identifier before the title in the List view, reusing the existing `getTaskIdentifier()` helper so the format matches the task detail heading (and honours a project identifier when one is set).

Scope: only `SingleTaskInProject.vue` — one template line, one import, and a small `.task-id` style reusing the existing `--grey-400` token. No new dependencies or logic changes.

`pnpm lint` and `pnpm lint:styles` pass.