### PR TITLE
fix(caldav): parse ISO 8601 week durations in reminder triggers

### DIFF
--- a/pkg/utils/duration.go
+++ b/pkg/utils/duration.go
@@ -32,12 +32,13 @@ func ParseISO8601Duration(str string) time.Duration {
 
 	years := parseDurationPart(matches[2], time.Hour*24*365)
 	months := parseDurationPart(matches[3], time.Hour*24*30)
-	days := parseDurationPart(matches[4], time.Hour*24)
-	hours := parseDurationPart(matches[5], time.Hour)
-	minutes := parseDurationPart(matches[6], time.Second*60)
-	seconds := parseDurationPart(matches[7], time.Second)
+	weeks := parseDurationPart(matches[4], time.Hour*24*7)
+	days := parseDurationPart(matches[5], time.Hour*24)
+	hours := parseDurationPart(matches[6], time.Hour)
+	minutes := parseDurationPart(matches[7], time.Second*60)
+	seconds := parseDurationPart(matches[8], time.Second)
 
-	duration := years + months + days + hours + minutes + seconds
+	duration := years + months + weeks + days + hours + minutes + seconds
 
 	if matches[1] == "-" {
 		return -duration
@@ -45,7 +46,7 @@ func ParseISO8601Duration(str string) time.Duration {
 	return duration
 }
 
-var durationRegex = regexp.MustCompile(`([-+])?P([\d\.]+Y)?([\d\.]+M)?([\d\.]+D)?T?([\d\.]+H)?([\d\.]+M)?([\d\.]+?S)?`)
+var durationRegex = regexp.MustCompile(`([-+])?P([\d\.]+Y)?([\d\.]+M)?([\d\.]+W)?([\d\.]+D)?T?([\d\.]+H)?([\d\.]+M)?([\d\.]+?S)?`)
 
 func parseDurationPart(value string, unit time.Duration) time.Duration {
 	if len(value) != 0 {

--- a/pkg/utils/duration_test.go
+++ b/pkg/utils/duration_test.go
@@ -36,4 +36,16 @@ func TestParseISO8601Duration(t *testing.T) {
 
 		assert.Equal(t, expected, dur)
 	})
+	t.Run("weeks", func(t *testing.T) {
+		dur := ParseISO8601Duration("P1W")
+		expected, _ := time.ParseDuration("168h")
+
+		assert.Equal(t, expected, dur)
+	})
+	t.Run("negative weeks", func(t *testing.T) {
+		dur := ParseISO8601Duration("-P2W")
+		expected, _ := time.ParseDuration("-336h")
+
+		assert.Equal(t, expected, dur)
+	})
 }

--- a/pkg/utils/duration_test.go
+++ b/pkg/utils/duration_test.go
@@ -48,4 +48,16 @@ func TestParseISO8601Duration(t *testing.T) {
 
 		assert.Equal(t, expected, dur)
 	})
+	t.Run("weeks combined with days", func(t *testing.T) {
+		dur := ParseISO8601Duration("P1W2D")
+		expected, _ := time.ParseDuration("216h")
+
+		assert.Equal(t, expected, dur)
+	})
+	t.Run("weeks combined with other units", func(t *testing.T) {
+		dur := ParseISO8601Duration("P1W2DT3H4M5S")
+		expected, _ := time.ParseDuration("219h4m5s")
+
+		assert.Equal(t, expected, dur)
+	})
 }


### PR DESCRIPTION
`ParseISO8601Duration` ignored the week designator: `P1W` (and `-P2W`) matched only the bare `P` and returned `0`. Per RFC 5545, `dur-week` is a valid VALARM `TRIGGER` (e.g. `TRIGGER:-P1W` for one week before), so importing such an alarm silently produced a zero-offset reminder. The same parser also backs the TickTick migration importer, which was affected too.

Fix: add a week group to the duration regex and fold it into the total. Added regression tests for `P1W` / `-P2W`. Month-vs-minute disambiguation is unchanged (`P1M` = 1 month, `PT1M` = 1 minute).

Verified with `go test ./pkg/utils/ ./pkg/caldav/` (the new week cases fail before / pass after); gofmt/vet clean.

_Prepared with Claude Code assistance (see `Co-Authored-By` trailer)._
