### PR TITLE
fix(notifications): strip Markdown escapes from plain-text mail part 🤖🤖🤖

### DIFF
--- a/pkg/notifications/mail_render.go
+++ b/pkg/notifications/mail_render.go
@@ -295,7 +295,9 @@ func convertLinesToPlain(lines []*mailLine) []*mailLine {
 	plain := make([]*mailLine, 0, len(lines))
 	for _, line := range lines {
 		if !line.isHTML {
-			plain = append(plain, line)
+			// Drop the CommonMark escapes added for the HTML part (see EscapeMarkdown);
+			// in plain text they would otherwise show up verbatim, e.g. `Test \- 1\|2`.
+			plain = append(plain, &mailLine{Text: UnescapeMarkdown(line.Text)})
 			continue
 		}
 
@@ -352,20 +354,18 @@ func RenderMail(m *Mail, lang string) (mailOpts *mail.Opts, err error) {
 	data := make(map[string]interface{})
 
 	data["Greeting"] = m.greeting
-	if m.conversational {
-		data["IntroLines"] = convertLinesToPlain(m.introLines)
-		data["OutroLines"] = convertLinesToPlain(m.outroLines)
-		if m.headerLine != nil {
-			plainHeaders := convertLinesToPlain([]*mailLine{m.headerLine})
-			if len(plainHeaders) > 0 {
-				data["HeaderLinePlain"] = plainHeaders[0].Text
-			}
+	// The plain-text part always goes through convertLinesToPlain so the Markdown
+	// escapes added for the HTML part (EscapeMarkdown) are stripped back out and do
+	// not leak into the text part verbatim (#3179).
+	data["IntroLines"] = convertLinesToPlain(m.introLines)
+	data["OutroLines"] = convertLinesToPlain(m.outroLines)
+	if m.conversational && m.headerLine != nil {
+		plainHeaders := convertLinesToPlain([]*mailLine{m.headerLine})
+		if len(plainHeaders) > 0 {
+			data["HeaderLinePlain"] = plainHeaders[0].Text
 		}
-	} else {
-		data["IntroLines"] = m.introLines
-		data["OutroLines"] = m.outroLines
 	}
-	data["FooterLines"] = m.footerLines
+	data["FooterLines"] = convertLinesToPlain(m.footerLines)
 	data["ActionText"] = m.actionText
 	data["ActionURL"] = m.actionURL
 	data["Boundary"] = boundary

--- a/pkg/notifications/mail_test.go
+++ b/pkg/notifications/mail_test.go
@@ -314,6 +314,29 @@ This is a footer line
 		// &#34; is the correct HTML entity for the quote character and will render as " in the browser
 		assert.Contains(t, mailopts.HTMLMessage, `&#34;Fix structured data Value in property &#34;reviewCount&#34; must be positive&#34;`)
 	})
+	t.Run("markdown escapes are stripped from the plain text part", func(t *testing.T) {
+		// Regression test for #3179: EscapeMarkdown (added for the HTML part to prevent
+		// Markdown injection) must not leak backslash escapes into the plain text part.
+		title := EscapeMarkdown(`Test - xyz - 123|456@789!`)
+		mail := NewMail().
+			From("test@example.com").
+			To("test@otherdomain.com").
+			Subject("Testmail").
+			Greeting("Hi there,").
+			Line(`This is a friendly reminder of the task "` + title + `".`)
+
+		mailopts, err := RenderMail(mail, "en")
+		require.NoError(t, err)
+
+		// Plain text must show the original title without any CommonMark backslash escapes.
+		assert.Contains(t, mailopts.Message, `Test - xyz - 123|456@789!`)
+		assert.NotContains(t, mailopts.Message, `\-`)
+		assert.NotContains(t, mailopts.Message, `\|`)
+		assert.NotContains(t, mailopts.Message, `\!`)
+
+		// The HTML part must still render the literal title (escapes consumed by Markdown).
+		assert.Contains(t, mailopts.HTMLMessage, `Test - xyz - 123|456@789!`)
+	})
 	t.Run("with pre-escaped HTML entities", func(t *testing.T) {
 		// This tests the fix for issue #1664 where HTML entities were being double-escaped
 		mail := NewMail().

--- a/pkg/notifications/markdown_escape.go
+++ b/pkg/notifications/markdown_escape.go
@@ -39,3 +39,32 @@ func EscapeMarkdown(s string) string {
 	}
 	return b.String()
 }
+
+// UnescapeMarkdown reverses EscapeMarkdown: it drops a backslash whenever it escapes
+// a character that EscapeMarkdown would have escaped (a CommonMark special char or a
+// literal backslash). Backslashes in front of any other character are left untouched,
+// so it is a precise inverse and never mangles unrelated text.
+//
+// It is used for the plain-text MIME part of notification mails: the escapes are
+// required for the Markdown-rendered HTML part, but without unescaping they leak into
+// the text part verbatim (e.g. `Test \- 1\|2` instead of `Test - 1|2`). See #3179.
+func UnescapeMarkdown(s string) string {
+	if !strings.Contains(s, `\`) {
+		return s
+	}
+	runes := []rune(s)
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(runes); i++ {
+		if runes[i] == '\\' && i+1 < len(runes) {
+			next := runes[i+1]
+			if next == '\\' || (next < 128 && strings.ContainsRune(markdownSpecialChars, next)) {
+				b.WriteRune(next)
+				i++
+				continue
+			}
+		}
+		b.WriteRune(runes[i])
+	}
+	return b.String()
+}

--- a/pkg/notifications/markdown_escape_test.go
+++ b/pkg/notifications/markdown_escape_test.go
@@ -99,3 +99,44 @@ func TestEscapeMarkdown_RoundTripThroughGoldmark(t *testing.T) {
 		})
 	}
 }
+
+func TestUnescapeMarkdown(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"no backslash", "Hello World", "Hello World"},
+		{"escaped dash", `a\-b`, "a-b"},
+		{"escaped pipe", `a\|b`, "a|b"},
+		{"escaped bang", `a\!b`, "a!b"},
+		{"escaped backslash", `a\\b`, `a\b`},
+		{"reporter example", `Test \- xyz \- 123\|456@789\!`, "Test - xyz - 123|456@789!"},
+		// A backslash in front of a non-special char is not something EscapeMarkdown
+		// produces, so it is left untouched.
+		{"backslash before letter kept", `a\zb`, `a\zb`},
+		{"trailing lone backslash kept", `abc\`, `abc\`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, UnescapeMarkdown(tt.in))
+		})
+	}
+}
+
+// TestUnescapeMarkdown_InvertsEscape verifies UnescapeMarkdown is a precise inverse
+// of EscapeMarkdown for arbitrary input, which is what lets the plain-text mail part
+// recover the original user text from the escaped canonical line.
+func TestUnescapeMarkdown_InvertsEscape(t *testing.T) {
+	inputs := []string{
+		"", "plain title", `Test - xyz - 123|456@789!`, `a\b`, "`code`", "*bold*",
+		"test](https://evil.com) [Click to verify", "![](https://evil.com/track.png)",
+		"<https://evil.com>", `mixed \ and - and | and !`, "#+.{}()[]<>~_",
+	}
+	for _, in := range inputs {
+		t.Run(in, func(t *testing.T) {
+			assert.Equal(t, in, UnescapeMarkdown(EscapeMarkdown(in)))
+		})
+	}
+}


### PR DESCRIPTION
## What

Fixes #3179. Since v2.3.0 the plain-text part of notification e-mails shows CommonMark backslash escapes: a task titled `Test - xyz - 123|456@789!` renders as `Test \- xyz \- 123\|456@789\!` in text-only clients.

## Root cause

`EscapeMarkdown` (added for GHSA-45q4-x4r9-8fqj to neutralize Markdown injection in the HTML part) is applied to user-controlled values at line-construction time in `pkg/models/notifications.go`, so the escapes become part of the canonical `line.Text`. The HTML part needs them — the text is fed through goldmark — but the plain-text template renders `{{ .Text }}` verbatim, so the backslashes end up in the `text/plain` MIME part. Every notification mail (reminder, assigned, overdue, …) is affected.

## Fix

The plain-text template data now always goes through `convertLinesToPlain`, which drops the escapes via a new `UnescapeMarkdown` — the precise inverse of `EscapeMarkdown`. It removes a backslash only in front of a character `EscapeMarkdown` would have escaped, so unrelated text stays untouched. The HTML part is unchanged and stays escaped.

## Tests

- `TestUnescapeMarkdown` and `TestUnescapeMarkdown_InvertsEscape` cover the round-trip identity `Unescape(Escape(x)) == x`.
- `TestRenderMail/markdown escapes are stripped from the plain text part` reproduces #3179: it fails on the current code and passes with the fix. The full `pkg/notifications` suite stays green.
