### PR TITLE
docs(swagger): fix @Success 200 -> 201 on 5 PUT/Create endpoints

### DIFF
--- a/pkg/models/api_tokens.go
+++ b/pkg/models/api_tokens.go
@@ -84,7 +84,7 @@ func GetAPITokenByID(s *xorm.Session, id int64) (token *APIToken, err error) {
 // @Produce json
 // @Security JWTKeyAuth
 // @Param token body models.APIToken true "The token object with required fields"
-// @Success 200 {object} models.APIToken "The created token."
+// @Success 201 {object} models.APIToken "The created token."
 // @Failure 400 {object} web.HTTPError "Invalid token object provided."
 // @Failure 500 {object} models.Message "Internal error"
 // @Router /tokens [put]

--- a/pkg/models/kanban.go
+++ b/pkg/models/kanban.go
@@ -306,7 +306,7 @@ func GetTasksInBucketsForView(s *xorm.Session, view *ProjectView, projects []*Pr
 // @Param id path int true "Project Id"
 // @Param view path int true "Project view ID"
 // @Param bucket body models.Bucket true "The bucket object"
-// @Success 200 {object} models.Bucket "The created bucket object."
+// @Success 201 {object} models.Bucket "The created bucket object."
 // @Failure 400 {object} web.HTTPError "Invalid bucket object provided."
 // @Failure 404 {object} web.HTTPError "The project does not exist."
 // @Failure 500 {object} models.Message "Internal error"

--- a/pkg/models/project_view.go
+++ b/pkg/models/project_view.go
@@ -301,7 +301,7 @@ func (pv *ProjectView) Delete(s *xorm.Session, _ web.Auth) (err error) {
 // @Security JWTKeyAuth
 // @Param project path int true "Project ID"
 // @Param view body models.ProjectView true "The project view you want to create."
-// @Success 200 {object} models.ProjectView "The created project view"
+// @Success 201 {object} models.ProjectView "The created project view"
 // @Failure 403 {object} web.HTTPError "The user does not have access to create a project view"
 // @Failure 500 {object} models.Message "Internal error"
 // @Router /projects/{project}/views [put]

--- a/pkg/models/reaction.go
+++ b/pkg/models/reaction.go
@@ -169,7 +169,7 @@ func (r *Reaction) Delete(s *xorm.Session, a web.Auth) (err error) {
 // @Param id path int true "Entity ID"
 // @Param kind path int true "The kind of the entity. Can be either `tasks` or `comments` for task comments"
 // @Param project body models.Reaction true "The reaction you want to add to the entity."
-// @Success 200 {object} models.Reaction "The created reaction"
+// @Success 201 {object} models.Reaction "The created reaction"
 // @Failure 403 {object} web.HTTPError "The user does not have access to the entity"
 // @Failure 500 {object} models.Message "Internal error"
 // @Router /{kind}/{id}/reactions [put]

--- a/pkg/models/webhooks.go
+++ b/pkg/models/webhooks.go
@@ -159,7 +159,7 @@ func GetUserDirectedWebhookEvents() []string {
 // @Security JWTKeyAuth
 // @Param id path int true "Project ID"
 // @Param webhook body models.Webhook true "The webhook target object with required fields"
-// @Success 200 {object} models.Webhook "The created webhook target."
+// @Success 201 {object} models.Webhook "The created webhook target."
 // @Failure 400 {object} web.HTTPError "Invalid webhook object provided."
 // @Failure 500 {object} models.Message "Internal error"
 // @Router /projects/{id}/webhooks [put]

--- a/pkg/swagger/docs.go
+++ b/pkg/swagger/docs.go
@@ -3073,7 +3073,7 @@ const docTemplate = `{
                     }
                 ],
                 "responses": {
-                    "200": {
+                    "201": {
                         "description": "The created bucket object.",
                         "schema": {
                             "$ref": "#/definitions/models.Bucket"
@@ -3300,7 +3300,7 @@ const docTemplate = `{
                     }
                 ],
                 "responses": {
-                    "200": {
+                    "201": {
                         "description": "The created webhook target.",
                         "schema": {
                             "$ref": "#/definitions/models.Webhook"
@@ -4299,7 +4299,7 @@ const docTemplate = `{
                     }
                 ],
                 "responses": {
-                    "200": {
+                    "201": {
                         "description": "The created project view",
                         "schema": {
                             "$ref": "#/definitions/models.ProjectView"
@@ -7030,7 +7030,7 @@ const docTemplate = `{
                     }
                 ],
                 "responses": {
-                    "200": {
+                    "201": {
                         "description": "The created token.",
                         "schema": {
                             "$ref": "#/definitions/models.APIToken"
@@ -8749,7 +8749,7 @@ const docTemplate = `{
                     }
                 ],
                 "responses": {
-                    "200": {
+                    "201": {
                         "description": "The created reaction",
                         "schema": {
                             "$ref": "#/definitions/models.Reaction"

--- a/pkg/swagger/swagger.json
+++ b/pkg/swagger/swagger.json
@@ -3065,7 +3065,7 @@
                     }
                 ],
                 "responses": {
-                    "200": {
+                    "201": {
                         "description": "The created bucket object.",
                         "schema": {
                             "$ref": "#/definitions/models.Bucket"
@@ -3292,7 +3292,7 @@
                     }
                 ],
                 "responses": {
-                    "200": {
+                    "201": {
                         "description": "The created webhook target.",
                         "schema": {
                             "$ref": "#/definitions/models.Webhook"
@@ -4291,7 +4291,7 @@
                     }
                 ],
                 "responses": {
-                    "200": {
+                    "201": {
                         "description": "The created project view",
                         "schema": {
                             "$ref": "#/definitions/models.ProjectView"
@@ -7022,7 +7022,7 @@
                     }
                 ],
                 "responses": {
-                    "200": {
+                    "201": {
                         "description": "The created token.",
                         "schema": {
                             "$ref": "#/definitions/models.APIToken"
@@ -8741,7 +8741,7 @@
                     }
                 ],
                 "responses": {
-                    "200": {
+                    "201": {
                         "description": "The created reaction",
                         "schema": {
                             "$ref": "#/definitions/models.Reaction"

--- a/pkg/swagger/swagger.yaml
+++ b/pkg/swagger/swagger.yaml
@@ -1928,7 +1928,7 @@ paths:
       produces:
       - application/json
       responses:
-        "200":
+        "201":
           description: The created reaction
           schema:
             $ref: '#/definitions/models.Reaction'
@@ -4017,7 +4017,7 @@ paths:
       produces:
       - application/json
       responses:
-        "200":
+        "201":
           description: The created bucket object.
           schema:
             $ref: '#/definitions/models.Bucket'
@@ -4189,7 +4189,7 @@ paths:
       produces:
       - application/json
       responses:
-        "200":
+        "201":
           description: The created webhook target.
           schema:
             $ref: '#/definitions/models.Webhook'
@@ -4552,7 +4552,7 @@ paths:
       produces:
       - application/json
       responses:
-        "200":
+        "201":
           description: The created project view
           schema:
             $ref: '#/definitions/models.ProjectView'
@@ -6690,7 +6690,7 @@ paths:
       produces:
       - application/json
       responses:
-        "200":
+        "201":
           description: The created token.
           schema:
             $ref: '#/definitions/models.APIToken'


### PR DESCRIPTION
## What / why

Five `PUT`-routed "create" endpoints document `@Success 200`, but they all dispatch through the shared `CreateWeb` handler (`pkg/web/handler/create.go`), which always responds `201 Created` regardless of the model's own swagger comment. Every other `CreateWeb`-routed endpoint (labels, teams, filters, task relations/comments/assignees/duplicate, task-labels) already correctly documents `201` — these five are stragglers with the same stale annotation, confirmed by checking the generated `pkg/swagger/swagger.json` itself, not just the source comments.

Found while verifying API behavior against the source for an unrelated investigation.

## Endpoints fixed

- `PUT /tokens` (`pkg/models/api_tokens.go`)
- `PUT /projects/{id}/views/{view}/buckets` (`pkg/models/kanban.go`)
- `PUT /projects/{id}/webhooks` (`pkg/models/webhooks.go`)
- `PUT /{kind}/{id}/reactions` (`pkg/models/reaction.go`)
- `PUT /projects/{project}/views` (`pkg/models/project_view.go`)

## Scope

Docs only — no behavior change. The 5 annotation edits plus a regenerated `pkg/swagger/{docs.go,swagger.json,swagger.yaml}` via:

```
swag init -g ./pkg/routes/routes.go --parseDependency -d . -o ./pkg/swagger
```

(the same command `mage generate:swagger-docs` runs), so `mage check:gotswag` should pass and the generated files match the annotations rather than needing CI to regenerate them.
