### PR TITLE
feat: add 16-eyes Claude Code skill for security audits (opt-in)

### DIFF
--- a/.claude/skills/16-eyes/SKILL.md
+++ b/.claude/skills/16-eyes/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: 16-eyes
+description: >-
+  Security audits with four subcommands — `/16-eyes init` (configure: detect
+  quality gates, exclude patterns, output location, and design the repo's
+  tailored investigation lenses — auto-runs non-interactively if skipped),
+  `/16-eyes audit` (run every persisted lens across the WHOLE repo, verify
+  every finding skeptically, adversarially re-check high-impact ones, produce
+  a classified safe/risky report), `/16-eyes audit-diff` (the identical
+  engine, scoped to a diff/PR instead of the whole repo — for reviewing a
+  change before merge), `/16-eyes fix` (apply the findings — safe ones
+  directly, risky ones with your confirmation, never commits or pushes).
+  `audit` is the deliberate, occasional deep sweep (dozens of subagent calls,
+  several minutes) that diff-scoped tools miss — a vulnerability sitting
+  untouched in the codebase for months is invisible to them. `audit-diff` is
+  the fast, per-PR counterpart, built on the same persisted-lens + skeptical
+  verify + adversarial multi-vote pipeline (unlike Claude Code's built-in
+  `/security-review` or most CI-wired scanners, which do a single pass).
+  Trigger on: full security audit, complete security review of a repo, scan
+  the whole codebase for vulnerabilities, review this PR/diff for security
+  issues, "16-eyes init/audit/audit-diff/fix"; "auditoria de segurança
+  completa do repositório", "varredura de segurança full-repo", "audita esse
+  repo inteiro por vulnerabilidades", "revisão de segurança deste PR/diff";
+  "auditoría de seguridad completa del repositorio", "escanea todo el código
+  en busca de vulnerabilidades", "revisa este PR/diff en busca de problemas
+  de seguridad".
+---
+
+# 16 Eyes — security audits, full-repo or diff-scoped
+
+Sixteen independent eyes look at every finding before it reaches you: the
+lens that found it, a skeptical verifier that re-reads the real code, and —
+for high-impact findings — several adversarial reviewers actively trying to
+disprove it. Nothing reaches the report on one agent's word alone. The same
+rigor applies whether you're running a full-repo sweep or reviewing a single
+diff — see `/16-eyes audit` vs `/16-eyes audit-diff` below.
+
+## Why this is different from `/security-review` and CI scanners
+
+Diff-scoped tools (Claude Code's built-in `/security-review`, most CI-wired
+scanners) do a single pass over what changed and only see the current
+PR/branch. `/16-eyes audit-diff` is also diff-scoped, but runs the repo's own
+tailored investigation lenses, verifies every finding skeptically against
+the real code, and adversarially re-checks high-impact ones with multiple
+independent reviewers before anything reaches the report — a heavier, more
+skeptical pipeline than a single-pass reviewer. `/16-eyes audit` goes further
+still: it scans the **whole repository**, regardless of recent changes — a
+vulnerability that's been sitting untouched in the codebase for months is
+invisible to any diff-scoped tool, `audit-diff` included. Use `audit-diff`
+for "does this PR introduce a problem?"; use `audit` for "does this codebase,
+as a whole, have problems?" `audit` is expensive (dozens of subagent calls,
+several minutes) — a deliberate, occasional deep sweep, not a per-commit
+check.
+
+## When the user runs `/16-eyes init`
+
+Read `references/init-flow.md` and follow it end to end. Detects the repo's
+quality-gate commands (test/lint/typecheck/build, across ecosystems, not just
+Node), interviews briefly about exclude patterns / output location / audit
+depth / language / whether to gitignore reports / whether to scaffold a CI
+template, then **profiles the repo and designs its investigation lenses**,
+persisting both to `.16-eyes/config.json` and `.16-eyes/lenses.json`. If
+skipped, `/16-eyes audit` and `/16-eyes audit-diff` both auto-bootstrap this
+non-interactively (sane defaults, no questions asked — safe to run headlessly
+in CI) the first time they need lenses that don't exist yet. Running it
+explicitly first just lets you customize things before that happens.
+
+## When the user runs `/16-eyes audit`
+
+Read-only — never edits code. Read `references/audit-flow.md` and follow it
+end to end: load the repo's persisted investigation lenses (bootstrapping
+them via `init` first if none exist), run them across the whole repo via the
+`Workflow` tool, verify every finding, adversarially re-check high-impact
+ones, and write a classified markdown + JSON report.
+
+## When the user runs `/16-eyes audit-diff`
+
+Read-only — never edits code. Read `references/audit-diff-flow.md` and
+follow it end to end: same persisted lenses and same verify/adversarial
+pipeline as `audit`, but each lens investigates only a diff's changed hunks
+(default: against the repo's default branch, or an explicit PR/base ref the
+user named). Use this to review a PR before merge, including as a CI check
+(see `references/ci-flow.md`).
+
+## When the user runs `/16-eyes fix`
+
+Read `references/fix-flow.md` and follow it end to end. Applies the most
+recent `/16-eyes audit` or `/16-eyes audit-diff` findings (from this
+conversation if fresh, otherwise the last saved report of either kind) —
+`safe` findings directly, `risky` ones with your explicit confirmation one at
+a time. **Never runs any git write command** (no commit, no push) — changes
+are always left in the working tree for you to review.

--- a/.claude/skills/16-eyes/assets/ci/nightly-full-audit.yml
+++ b/.claude/skills/16-eyes/assets/ci/nightly-full-audit.yml
@@ -1,0 +1,38 @@
+name: 16 Eyes — full audit (scheduled)
+
+# Optional companion to pr-audit-diff.yml — the deep, full-repo sweep,
+# decoupled from per-PR cost. Adjust the cron schedule to taste; the default
+# is weekly, since /16-eyes audit is a "deliberate, occasional" sweep, not a
+# per-commit check.
+#
+# Required secret: ANTHROPIC_API_KEY (repo or org secret).
+
+on:
+  schedule:
+    - cron: "0 6 * * 1" # every Monday at 06:00 UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  full-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run /16-eyes audit
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: "/16-eyes audit"
+          claude_args: "--permission-mode dontAsk"
+
+      - name: Upload report as a workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: 16-eyes-full-audit-${{ github.run_id }}
+          path: |
+            **/SECURITY_AUDIT_20*.md
+            **/SECURITY_AUDIT_20*.json
+          if-no-files-found: warn

--- a/.claude/skills/16-eyes/assets/ci/pr-audit-diff.yml
+++ b/.claude/skills/16-eyes/assets/ci/pr-audit-diff.yml
@@ -1,0 +1,94 @@
+name: 16 Eyes — audit diff
+
+# Prerequisite: this repo must have `.claude/skills/16-eyes/` committed
+# (`npx 16-eyes install --project`) so this job needs no install step and has
+# no npm-registry dependency or version drift at review time.
+#
+# Required secret: ANTHROPIC_API_KEY (repo or org secret).
+#
+# By default this only comments on the PR — it never blocks merge. To make it
+# a required, merge-blocking check, set `ci.failOn` to "risky" or "any" in
+# `.16-eyes/config.json` AND mark this job as a required status check in your
+# branch protection rules. See docs/ci.md for details.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: 16-eyes-audit-diff-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  audit-diff:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # audit-diff needs `git merge-base` against the base branch, which
+          # needs real history, not a 1-commit shallow clone.
+          fetch-depth: 0
+
+      - name: Run /16-eyes audit-diff
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: "/16-eyes audit-diff"
+          claude_args: "--permission-mode dontAsk"
+
+      - name: Post report + apply CI gate
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          CONFIG=".16-eyes/config.json"
+          OUTPUT_DIR="docs"
+          FAIL_ON="none"
+          COMMENT_ON_PR="true"
+          if [ -f "$CONFIG" ]; then
+            OUTPUT_DIR=$(jq -r '.output.dir // "docs"' "$CONFIG")
+            FAIL_ON=$(jq -r '.ci.failOn // "none"' "$CONFIG")
+            COMMENT_ON_PR=$(jq -r '(.ci.commentOnPr // true)' "$CONFIG")
+          fi
+
+          REPORT_JSON=$(ls -t "$OUTPUT_DIR"/SECURITY_AUDIT_DIFF_*.json 2>/dev/null | head -n1 || true)
+          REPORT_MD=$(ls -t "$OUTPUT_DIR"/SECURITY_AUDIT_DIFF_*.md 2>/dev/null | head -n1 || true)
+
+          if [ -z "$REPORT_JSON" ]; then
+            echo "No SECURITY_AUDIT_DIFF_*.json found under $OUTPUT_DIR — skipping comment/gate."
+            exit 0
+          fi
+
+          if [ "$COMMENT_ON_PR" = "true" ] && [ -n "$REPORT_MD" ]; then
+            gh pr comment "$PR_NUMBER" --body-file "$REPORT_MD" --edit-last --create-if-none
+          fi
+
+          SAFE=$(jq -r '.stats.safe' "$REPORT_JSON")
+          RISKY=$(jq -r '.stats.risky' "$REPORT_JSON")
+          REAL=$(jq -r '.stats.real' "$REPORT_JSON")
+          echo "16 Eyes results — safe: $SAFE, risky: $RISKY, real: $REAL, ci.failOn: $FAIL_ON"
+
+          case "$FAIL_ON" in
+            risky)
+              if [ "$RISKY" -gt 0 ]; then
+                echo "::error::$RISKY risky finding(s) survived review — failing per ci.failOn=risky"
+                exit 1
+              fi
+              ;;
+            any)
+              if [ "$REAL" -gt 0 ]; then
+                echo "::error::$REAL confirmed finding(s) — failing per ci.failOn=any"
+                exit 1
+              fi
+              ;;
+            *)
+              echo "ci.failOn=none (default) — comment only, this job never fails."
+              ;;
+          esac

--- a/.claude/skills/16-eyes/assets/ci/settings.json
+++ b/.claude/skills/16-eyes/assets/ci/settings.json
@@ -1,0 +1,18 @@
+{
+  "permissions": {
+    "defaultMode": "dontAsk",
+    "allow": [
+      "Bash(git diff *)",
+      "Bash(git diff)",
+      "Bash(git merge-base *)",
+      "Bash(git symbolic-ref *)",
+      "Bash(git log *)",
+      "Bash(gh pr diff *)",
+      "Bash(gh pr view *)",
+      "Read(**)",
+      "Write(.16-eyes/**)",
+      "Write(**/SECURITY_AUDIT*.md)",
+      "Write(**/SECURITY_AUDIT*.json)"
+    ]
+  }
+}

--- a/.claude/skills/16-eyes/assets/config.schema.json
+++ b/.claude/skills/16-eyes/assets/config.schema.json
@@ -1,0 +1,106 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "16-eyes config",
+  "description": "Configuration written by /16-eyes init and read by /16-eyes audit and /16-eyes fix. Not required — audit/fix work with sane defaults if this file is absent.",
+  "type": "object",
+  "required": ["version"],
+  "properties": {
+    "version": {
+      "type": "integer",
+      "const": 1
+    },
+    "depth": {
+      "type": "string",
+      "enum": ["quick", "thorough"],
+      "default": "thorough",
+      "description": "quick = fewer lenses, 1 adversarial vote per high-impact finding. thorough = more lenses, full adversarial review."
+    },
+    "language": {
+      "type": "string",
+      "enum": ["en", "pt", "es"],
+      "default": "en",
+      "description": "Default language for the audit report and narration. Can be overridden per-invocation."
+    },
+    "excludePatterns": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Glob patterns excluded from lens investigation (vendored/generated/fixture paths)."
+    },
+    "output": {
+      "type": "object",
+      "properties": {
+        "dir": { "type": "string", "description": "Directory reports are written to, relative to repo root." },
+        "markdownPattern": { "type": "string", "description": "Filename pattern for the human-readable report. {date} is replaced with YYYY-MM-DD." },
+        "jsonPattern": { "type": "string", "description": "Filename pattern for the machine-readable companion report." },
+        "gitignoreReports": { "type": "boolean", "description": "Whether /16-eyes init added the output dir/pattern to .gitignore." }
+      }
+    },
+    "lastRunPointer": {
+      "type": "string",
+      "description": "Path to the small JSON pointer file /16-eyes audit updates after each run, so /16-eyes fix can find the latest report across sessions."
+    },
+    "lastDiffRunPointer": {
+      "type": "string",
+      "description": "Path to the small JSON pointer file /16-eyes audit-diff updates after each run, so /16-eyes fix can find the latest diff-scoped report across sessions.",
+      "default": ".16-eyes/last-diff-run.json"
+    },
+    "lensesPointer": {
+      "type": "string",
+      "description": "Path to the persisted investigation-lens set written by /16-eyes init (repo profile + tailored lenses). /16-eyes audit and /16-eyes audit-diff both load lenses from here instead of redesigning them per run. If missing, init runs automatically (non-interactively, with defaults) before either command proceeds.",
+      "default": ".16-eyes/lenses.json"
+    },
+    "ci": {
+      "type": "object",
+      "description": "Settings consumed by the optional CI templates (skills/16-eyes/assets/ci/) — not read by audit/audit-diff themselves.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether /16-eyes init scaffolded a GitHub Actions template for this repo.",
+          "default": false
+        },
+        "failOn": {
+          "type": "string",
+          "enum": ["none", "risky", "any"],
+          "default": "none",
+          "description": "Whether the CI job should fail (block a required status check) based on audit-diff results. 'none' = comment only, never fails (default — matches the industry convention of a neutral, non-blocking check). 'risky' = fail if any RISKY finding survived adversarial review. 'any' = fail on any confirmed finding, safe or risky."
+        },
+        "commentOnPr": {
+          "type": "boolean",
+          "default": true,
+          "description": "Whether the CI job posts the audit-diff report as a PR comment."
+        }
+      }
+    },
+    "gates": {
+      "type": "object",
+      "properties": {
+        "workspaces": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["path"],
+            "properties": {
+              "path": { "type": "string", "description": "Workspace/package path relative to repo root ('.' for the whole repo if not a monorepo)." },
+              "test": { "type": "string" },
+              "lint": { "type": "string" },
+              "typecheck": { "type": "string" },
+              "build": { "type": "string" }
+            }
+          }
+        }
+      }
+    },
+    "adversarial": {
+      "type": "object",
+      "properties": {
+        "votesPerFinding": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 5,
+          "default": 3,
+          "description": "Independent refuter agents per high-impact finding during adversarial review."
+        }
+      }
+    }
+  }
+}

--- a/.claude/skills/16-eyes/references/audit-diff-flow.md
+++ b/.claude/skills/16-eyes/references/audit-diff-flow.md
@@ -1,0 +1,555 @@
+# `/16-eyes audit-diff` — analyze a diff or PR
+
+Read-only. Never edits code. **The exact same engine as `/16-eyes audit`** (same
+persisted lenses, same verify → adversarial-review → synthesis pipeline, same
+guards) — the only difference is scope: each lens investigates a diff's changed
+hunks instead of the whole repository. Use this for reviewing a PR before merge;
+use full `/16-eyes audit` for an occasional deep sweep of everything, including
+code nobody touched recently.
+
+## When invoked
+
+1. **Determine `today`** from your own session context, as `YYYY-MM-DD`.
+
+2. **Determine the diff scope**, in this order:
+   - If the user's invocation named an explicit base ref/branch, or a PR number, use
+     that.
+   - Else, if the `GITHUB_BASE_REF` environment variable is set (Bash: `echo
+     "$GITHUB_BASE_REF"` — present in a GitHub Actions `pull_request` job), use it as
+     the base branch.
+   - Else, detect the repo's default branch (Bash: `git symbolic-ref
+     refs/remotes/origin/HEAD` and strip the `refs/remotes/origin/` prefix; if that
+     fails — common on a shallow/fresh clone with no tracking symref — fall back to
+     `main`, then `master`, whichever exists as `origin/<name>`).
+   - `base` = the merge-base of that branch and `HEAD` (Bash: `git merge-base
+     origin/<default> HEAD`), not the branch tip itself — so the diff is exactly what
+     the PR introduces, not everything the base branch has gained since the PR
+     started.
+   - **If a PR number was named and `gh` is available**, prefer `gh pr diff <n>` for
+     the diff text and `gh pr view <n> --json number,title,url` for metadata — this
+     works even without that PR's branch checked out locally (the common case in CI).
+
+3. **Gather the diff** (via `Bash` — the Workflow tool has no filesystem/git access):
+   - Changed file list: `git diff --name-status <base>...HEAD` (or `gh pr view
+     --json files` in PR mode).
+   - Full unified diff: `git diff <base>...HEAD` (or `gh pr diff <n>`).
+   - Read `.16-eyes/config.json` if present and drop any changed file matching
+     `excludePatterns` from what you gather — never send excluded paths to a lens.
+   - **Size guard**: if the diff is large (rule of thumb: over ~2000 changed lines,
+     or includes lockfiles/minified/vendored/generated-looking paths), drop the
+     largest/most-generated files from what gets sent to lenses. **Log which ones and
+     why** in your final summary — never silently claim full coverage of a diff you
+     actually trimmed.
+
+4. **Read `.16-eyes/config.json`** (`depth`, `adversarial.votesPerFinding`,
+   `language`, `lensesPointer`, default `.16-eyes/lenses.json`). **Read the lenses
+   file. If it doesn't exist, run the Auto-bootstrap flow from `init-flow.md` now**
+   (identical to `audit-flow.md` step 4) — then re-read it. `audit-diff` never
+   designs its own lenses; it only ever reuses the persisted set.
+
+5. **Call the `Workflow` tool** with `script` set to the *exact* contents of the code
+   block below, and `args: { today, base, head: 'HEAD', prNumber, changedFiles,
+   diffText, profile, lenses, depth, votesPerFinding, language }` (`profile` is
+   `{ languages, domain_summary }` from the lenses file, same as `audit-flow.md`).
+   This IS the user's explicit opt-in to multi-agent orchestration.
+
+6. **Take the workflow's return value** and write **both** files with `Write`:
+   - Markdown: `<outputDir>/SECURITY_AUDIT_DIFF_<today>.md`.
+   - JSON: `<outputDir>/SECURITY_AUDIT_DIFF_<today>.json`.
+   - Same `<outputDir>` resolution and same-day collision rule (`-2`, `-3`, ...) as
+     `audit-flow.md`.
+   - Then write/overwrite `.16-eyes/last-diff-run.json` (path from
+     `config.lastDiffRunPointer`, default `.16-eyes/last-diff-run.json`) with
+     `{ markdown, json, generatedAt, base, head, prNumber, stats }` — parallel to
+     `audit`'s `last-run.json`, so `/16-eyes fix` can find either report family.
+
+7. **Report a short summary**: the diff range reviewed (`base..head`, or `PR #N`),
+   any files dropped by the size guard, counts (findings confirmed real, safe vs
+   risky, refuted/corrupted), and the paths to both files. **If step 4
+   auto-bootstrapped config/lenses**, say so. Remind the user this only reviewed the
+   diff — pre-existing code is `/16-eyes audit`'s job, not this command's.
+
+## The workflow script
+
+```js
+export const meta = {
+  name: '16-eyes-audit-diff',
+  description:
+    "Run a repo's persisted investigation lenses scoped to a diff, verify every finding, adversarially review high-impact ones, and produce a classified report.",
+  phases: [{ title: 'Lenses' }, { title: 'Verification' }, { title: 'Adversarial review' }, { title: 'Synthesis' }],
+}
+
+// ── Schemas (identical to audit-flow.md — keep them in sync) ──────────────
+const FINDINGS_SCHEMA = {
+  type: 'object',
+  properties: {
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          title: { type: 'string' },
+          file: { type: 'string' },
+          line: { type: 'number' },
+          description: { type: 'string' },
+          initial_impact: { type: 'string', enum: ['high', 'medium', 'low'] },
+          initial_probability: { type: 'string', enum: ['high', 'medium', 'low'] },
+        },
+        required: ['title', 'file', 'description'],
+      },
+    },
+  },
+  required: ['findings'],
+}
+
+const VERDICT_SCHEMA = {
+  type: 'object',
+  properties: {
+    is_real: { type: 'boolean' },
+    impact: { type: 'string', enum: ['high', 'medium', 'low'] },
+    probability: { type: 'string', enum: ['high', 'medium', 'low'] },
+    fix_type: { type: 'string', enum: ['safe', 'risky'] },
+    exploit_scenario: { type: 'string' },
+    why: { type: 'string' },
+    suggested_fix: { type: 'string' },
+  },
+  required: ['is_real', 'impact', 'probability', 'fix_type', 'why'],
+}
+
+const REFUTE_SCHEMA = {
+  type: 'object',
+  properties: { refuted: { type: 'boolean' }, reason: { type: 'string' } },
+  required: ['refuted', 'reason'],
+}
+
+const EXEC_SUMMARY_SCHEMA = {
+  type: 'object',
+  properties: { summary: { type: 'string' } },
+  required: ['summary'],
+}
+
+// ── i18n ───────────────────────────────────────────────────────────────────
+const LANGUAGE_NAMES = { en: 'English', pt: 'Brazilian Portuguese', es: 'Spanish' }
+
+const T = {
+  en: {
+    intro:
+      '> Generated by the `16-eyes` skill: runs this repo\'s tailored investigation lenses (designed once by `/16-eyes init`) against a DIFF only — not the whole repository — verifies each finding skeptically, adversarially reviews (multiple independent skeptics) high-impact findings, and classifies the remainder into SAFE (mechanical fix) vs RISKY (needs a human decision). For a deep sweep of everything, including code this diff never touched, use `/16-eyes audit` instead.',
+    scope: 'Scope',
+    methodology: 'Methodology',
+    lensesRun: 'Lenses run',
+    rawToVerified: 'Raw → verified findings',
+    corruptedSuffix: 'with corrupted/failed verification (see appendix)',
+    adversarialReview: 'Adversarial review',
+    adversarialSummary: (h, v, r) =>
+      `${h} high-impact finding(s) went through ${v} independent reviewer(s) trying to refute them; ${r} were refuted and discarded.`,
+    riskMatrixHeading: 'Risk matrix (impact × probability)',
+    matrixHeaderCol: 'Impact \\ Probability',
+    low: 'Low',
+    medium: 'Medium',
+    high: 'High',
+    safeHeading: 'SAFE findings — mechanical fix, no behavior change',
+    riskyHeading: 'RISKY findings — need a human decision before fixing',
+    none: '_None._',
+    appendixHeading: 'Appendix — discarded',
+    falsePositiveHeading: 'False positive',
+    adversarialDiscardedHeading: 'Discarded in adversarial review',
+    corruptedHeading: 'Corrupted/failed verification — needs manual review',
+    findingWhere: 'Where',
+    findingLens: 'Lens',
+    findingImpactProb: 'Impact/Probability',
+    findingWhat: 'What',
+    findingExploit: 'Exploit scenario',
+    findingWhyRisky: "Why it's risky",
+    findingWhySafe: "Why it's safe to fix",
+    findingSuggestedFix: 'Suggested fix',
+    notSpecified: '(not specified)',
+    reviewersRefuted: 'reviewer(s) refuted',
+  },
+  pt: {
+    intro:
+      '> Gerado pelo skill `16-eyes`: roda as lentes de investigação deste repositório (desenhadas uma vez pelo `/16-eyes init`) contra um DIFF apenas — não o repositório inteiro — verifica cada achado ceticamente, faz revisão adversarial (múltiplos céticos independentes) nos achados de impacto alto, e classifica o resíduo em SAFE (correção mecânica) vs RISKY (decisão humana necessária). Para um sweep completo, incluindo código que este diff não tocou, use `/16-eyes audit`.',
+    scope: 'Escopo',
+    methodology: 'Metodologia',
+    lensesRun: 'Lentes rodadas',
+    rawToVerified: 'Achados brutos → verificados',
+    corruptedSuffix: 'com verificação corrompida/falha (ver apêndice)',
+    adversarialReview: 'Revisão adversarial',
+    adversarialSummary: (h, v, r) =>
+      `${h} achado(s) de impacto alto passaram por ${v} revisor(es) independente(s) tentando refutar; ${r} foram refutados e descartados.`,
+    riskMatrixHeading: 'Matriz de risco (impacto × probabilidade)',
+    matrixHeaderCol: 'Impacto \\ Probabilidade',
+    low: 'Baixa',
+    medium: 'Média',
+    high: 'Alta',
+    safeHeading: 'Achados SAFE — correção mecânica, sem mudança de comportamento',
+    riskyHeading: 'Achados RISKY — precisam de decisão humana antes de corrigir',
+    none: '_Nenhum._',
+    appendixHeading: 'Apêndice — descartados',
+    falsePositiveHeading: 'Falso-positivo',
+    adversarialDiscardedHeading: 'Refutado na revisão adversarial',
+    corruptedHeading: 'Verificação corrompida/falhou — revisar manualmente',
+    findingWhere: 'Onde',
+    findingLens: 'Lente',
+    findingImpactProb: 'Impacto/Probabilidade',
+    findingWhat: 'O quê',
+    findingExploit: 'Cenário de exploração',
+    findingWhyRisky: 'Por quê é risky',
+    findingWhySafe: 'Por quê é seguro corrigir',
+    findingSuggestedFix: 'Sugestão de correção',
+    notSpecified: '(não especificada)',
+    reviewersRefuted: 'revisor(es) refutaram',
+  },
+  es: {
+    intro:
+      '> Generado por el skill `16-eyes`: ejecuta las lentes de investigación de este repositorio (diseñadas una vez por `/16-eyes init`) contra un DIFF solamente — no todo el repositorio — verifica cada hallazgo de forma escéptica, hace una revisión adversarial (varios escépticos independientes) de los hallazgos de alto impacto, y clasifica el resto en SAFE (corrección mecánica) vs RISKY (requiere decisión humana). Para un barrido completo, incluyendo código que este diff no tocó, usa `/16-eyes audit`.',
+    scope: 'Alcance',
+    methodology: 'Metodología',
+    lensesRun: 'Lentes ejecutadas',
+    rawToVerified: 'Hallazgos brutos → verificados',
+    corruptedSuffix: 'con verificación corrupta/fallida (ver apéndice)',
+    adversarialReview: 'Revisión adversarial',
+    adversarialSummary: (h, v, r) =>
+      `${h} hallazgo(s) de alto impacto pasaron por ${v} revisor(es) independiente(s) intentando refutarlos; ${r} fueron refutados y descartados.`,
+    riskMatrixHeading: 'Matriz de riesgo (impacto × probabilidad)',
+    matrixHeaderCol: 'Impacto \\ Probabilidad',
+    low: 'Baja',
+    medium: 'Media',
+    high: 'Alta',
+    safeHeading: 'Hallazgos SAFE — corrección mecánica, sin cambio de comportamiento',
+    riskyHeading: 'Hallazgos RISKY — requieren decisión humana antes de corregir',
+    none: '_Ninguno._',
+    appendixHeading: 'Apéndice — descartados',
+    falsePositiveHeading: 'Falso positivo',
+    adversarialDiscardedHeading: 'Descartado en la revisión adversarial',
+    corruptedHeading: 'Verificación corrupta/fallida — revisar manualmente',
+    findingWhere: 'Dónde',
+    findingLens: 'Lente',
+    findingImpactProb: 'Impacto/Probabilidad',
+    findingWhat: 'Qué',
+    findingExploit: 'Escenario de explotación',
+    findingWhyRisky: 'Por qué es risky',
+    findingWhySafe: 'Por qué es seguro corregir',
+    findingSuggestedFix: 'Corrección sugerida',
+    notSpecified: '(no especificada)',
+    reviewersRefuted: 'revisor(es) refutaron',
+  },
+}
+
+// ── Helpers (identical to audit-flow.md — keep them in sync) ─────────────
+function looksCorrupted(obj) {
+  if (!obj || typeof obj !== 'object') return false
+  const strings = Object.values(obj).filter((v) => typeof v === 'string' && v.length > 0)
+  return strings.length > 0 && strings.every((v) => v.trim().toLowerCase() === 'test')
+}
+
+function dedupKey(f) {
+  const file = (f.file || '').trim().toLowerCase()
+  const line = f.line == null ? '?' : String(f.line)
+  return `${file}:${line}`
+}
+
+function verifyPrompt(f, scopeHint, languageName) {
+  return `You are adversarially verifying a security finding raised by another agent during a diff-scoped review${scopeHint ? ` (${scopeHint})` : ''}.
+
+Finding: "${f.title}"
+File: ${f.file}${f.line ? `:${f.line}` : ''}
+Description: ${f.description}
+Initial impact guess: ${f.initial_impact ?? 'unknown'} · Initial probability guess: ${f.initial_probability ?? 'unknown'}
+
+Re-read the ACTUAL code at that location (and its real callers/config) yourself — do not trust the description above at face value. Then decide:
+- is_real: is this a genuine issue in the code as it exists today (not hypothetical, not already mitigated elsewhere, not dead code)?
+- impact: high/medium/low if exploited (money movement, auth bypass, data breach = high; degraded UX or internal-only = low).
+- probability: high/medium/low that this is actually reachable/exploitable given real callers and current config — not just "possible in theory".
+- fix_type: "safe" if a fix is purely mechanical and changes no behavior for any legitimate flow today (e.g. add a missing check, pin a version); "risky" if fixing it changes behavior for a flow that might be relied on today, touches money/auth, or needs a product decision (threshold, tolerance, UX tradeoff).
+- exploit_scenario: concrete inputs/steps that would trigger it (empty if not real).
+- suggested_fix: a specific, minimal fix.
+- why: your reasoning, referencing the real code you read.
+
+Be skeptical. A finding that sounds scary in the abstract but isn't actually reachable, or is already handled by a check elsewhere, is NOT real — say so.
+
+Write "why", "exploit_scenario", and "suggested_fix" in ${languageName}.`
+}
+
+function refutePrompt(f, languageName) {
+  return `Try to REFUTE this security finding from a diff-scoped review (it already passed one verification pass and was classified impact=high — this is a 2nd, adversarial, independent check before it goes in a report someone will act on).
+
+Finding: "${f.title}"
+File: ${f.file}${f.line ? `:${f.line}` : ''}
+Description: ${f.description}
+Why it was judged real: ${f.verdict?.why ?? ''}
+Exploit scenario claimed: ${f.verdict?.exploit_scenario ?? ''}
+
+Read the actual code yourself. Look hard for a reason this ISN'T actually exploitable: a guard elsewhere, a precondition that can't occur, dead code, a framework default that already prevents it, or a misread of the code. If you genuinely cannot find a flaw in the finding after really trying, refuted=false. If you are UNCERTAIN either way, default to refuted=true — a finding has to survive skepticism to earn a spot in the report, not just avoid being disproven.
+
+Write "reason" in ${languageName}.`
+}
+
+// ── Script body ────────────────────────────────────────────────────────────
+
+const today = (args && args.today) || 'unknown-date'
+const base = (args && args.base) || 'unknown-base'
+const head = (args && args.head) || 'HEAD'
+const prNumber = args && args.prNumber ? String(args.prNumber) : null
+const changedFiles = (args && Array.isArray(args.changedFiles) && args.changedFiles) || []
+const diffText = (args && args.diffText) || ''
+const profile = (args && args.profile) || {}
+const depth = args && args.depth === 'quick' ? 'quick' : 'thorough'
+const configVotes =
+  args && Number.isFinite(args.votesPerFinding) && args.votesPerFinding > 0 ? args.votesPerFinding : null
+const language = args && T[args.language] ? args.language : 'en'
+const L = T[language]
+const languageName = LANGUAGE_NAMES[language]
+
+const scopeLabel = prNumber ? `PR #${prNumber}` : `${base}..${head}`
+
+const lenses = ((args && Array.isArray(args.lenses) && args.lenses) || []).filter((l) => l && l.prompt && l.name)
+if (lenses.length === 0) {
+  return {
+    reportMarkdown: `# 16 Eyes — diff review — ${today}\n\nFailed: no investigation lenses were available (\`.16-eyes/lenses.json\` was empty, and auto-bootstrap did not produce any). Run \`/16-eyes init\` and try again.`,
+    reportJson: JSON.stringify({ error: 'no-lenses-available' }, null, 2),
+    stats: null,
+  }
+}
+
+function diffLensPrompt(lens) {
+  return `You are reviewing ONLY a diff (${scopeLabel}) as part of a security review — not the whole repository. Your focus area: "${lens.focus}".
+
+Changed files in this diff:
+${changedFiles.map((f) => `- ${f}`).join('\n') || '(none)'}
+
+Unified diff:
+\`\`\`diff
+${diffText}
+\`\`\`
+
+${lens.prompt}
+
+Investigate ONLY within these changed hunks, from your focus area above. You may use \`Read\` on the full current file content for necessary surrounding context (e.g. to see a function's full body, or where a caller comes from), but do not go hunting for unrelated issues elsewhere in the repository — that is full \`/16-eyes audit\`'s job, not this one. If nothing in this diff falls under your focus area, return \`{"findings": []}\` — an empty result is a normal, expected outcome for most lenses on most diffs.`
+}
+
+// ── Lenses → verification (pipeline, no barrier) ──────────────────────────
+phase('Lenses')
+const seenKeys = new Set()
+const perLensVerified = await pipeline(
+  lenses,
+  (lens) => agent(diffLensPrompt(lens), { schema: FINDINGS_SCHEMA, phase: 'Lenses', label: `lens:${lens.name}`, model: 'sonnet' }),
+  (raw, lens) => {
+    const findings = (raw?.findings || []).filter((f) => f && f.title && f.file)
+    const fresh = findings.filter((f) => {
+      const k = dedupKey(f)
+      if (seenKeys.has(k)) return false
+      seenKeys.add(k)
+      return true
+    })
+    if (fresh.length < findings.length) {
+      log(`${lens.name}: ${findings.length - fresh.length} finding(s) dropped by dedup (same file:line already seen)`)
+    }
+    return parallel(
+      fresh.map((f) => () =>
+        agent(verifyPrompt(f, scopeLabel, languageName), {
+          schema: VERDICT_SCHEMA,
+          phase: 'Verification',
+          label: `verify:${lens.name}`,
+          model: 'sonnet',
+        }).then((v) => {
+          const corrupted = !v || looksCorrupted(v)
+          return { ...f, lens: lens.name, verdict: corrupted ? null : v, verdict_corrupted: corrupted }
+        }),
+      ),
+    )
+  },
+)
+const allVerified = perLensVerified.flat().filter(Boolean)
+
+const corrupted = allVerified.filter((f) => f.verdict_corrupted)
+const needsVerdict = allVerified.filter((f) => !f.verdict_corrupted && f.verdict)
+const realFindings = needsVerdict.filter((f) => f.verdict.is_real)
+const falsePositives = needsVerdict.filter((f) => !f.verdict.is_real)
+log(
+  `${allVerified.length} unique finding(s) verified: ${realFindings.length} real, ${falsePositives.length} false-positive, ${corrupted.length} corrupted/failed verification (manual review)`,
+)
+
+// ── Adversarial review (high impact only) ────────────────────────────────
+phase('Adversarial review')
+const highImpact = realFindings.filter((f) => f.verdict.impact === 'high')
+const otherImpact = realFindings.filter((f) => f.verdict.impact !== 'high')
+
+const baseVotes = configVotes ?? (depth === 'quick' ? 1 : 3)
+const votesPerFinding = budget.total && budget.remaining() < 200_000 ? 1 : baseVotes
+if (highImpact.length > 0)
+  log(`Adversarial review: ${highImpact.length} high-impact finding(s), ${votesPerFinding} refuter(s) each`)
+
+const adversarial = await parallel(
+  highImpact.map((f) => () =>
+    parallel(
+      Array.from({ length: votesPerFinding }, (_, i) => () =>
+        agent(refutePrompt(f, languageName), {
+          schema: REFUTE_SCHEMA,
+          phase: 'Adversarial review',
+          label: `refute:${f.lens}:${i}`,
+          model: 'sonnet',
+        }),
+      ),
+    ).then((votes) => {
+      const valid = votes.filter(Boolean).filter((v) => !looksCorrupted(v))
+      const refuteCount = valid.filter((v) => v.refuted).length
+      const survived = valid.length > 0 && refuteCount * 2 < valid.length
+      return { ...f, adversarial: { votes: valid.length, refuted: refuteCount, survived } }
+    }),
+  ),
+)
+const survivedHighImpact = adversarial.filter(Boolean).filter((f) => f.adversarial.survived)
+const refutedHighImpact = adversarial.filter(Boolean).filter((f) => !f.adversarial.survived)
+if (refutedHighImpact.length > 0) {
+  log(
+    `${refutedHighImpact.length} high-impact finding(s) refuted by a majority of reviewers — dropped from the final report (listed in the appendix)`,
+  )
+}
+
+const finalReal = [...survivedHighImpact, ...otherImpact]
+const safeFindings = finalReal.filter((f) => f.verdict.fix_type === 'safe')
+const riskyFindings = finalReal.filter((f) => f.verdict.fix_type === 'risky')
+
+// ── Synthesis ───────────────────────────────────────────────────────────────
+phase('Synthesis')
+const execSummaryOut = await agent(
+  `Write a short (3-6 sentence) executive summary in ${languageName} for a diff-scoped security review (${scopeLabel}), given these results:
+- ${lenses.length} investigation lenses run against this diff${profile?.domain_summary ? ` (repo: ${profile.domain_summary})` : ''}.
+- ${allVerified.length} candidate findings verified; ${realFindings.length} confirmed real, ${falsePositives.length} discarded as false-positive.
+- ${refutedHighImpact.length} high-impact finding(s) were refuted by adversarial review and dropped.
+- ${safeFindings.length} findings are SAFE to fix mechanically (no behavior change); ${riskyFindings.length} are RISKY (need a product/human decision before fixing).
+Do not list individual findings — just the shape of the result and what the reader should do next. Mention explicitly that this only reviewed the diff, not the whole repository.`,
+  { schema: EXEC_SUMMARY_SCHEMA, phase: 'Synthesis', label: 'exec-summary', model: 'sonnet' },
+)
+const execSummary = execSummaryOut?.summary || ''
+
+function withId(f, i) {
+  return { id: `${f.lens}-${i}`, ...f }
+}
+const safeStructured = safeFindings.map(withId)
+const riskyStructured = riskyFindings.map(withId)
+
+function impactProbLabel(f) {
+  return `${f.verdict.impact}/${f.verdict.probability}`
+}
+
+function findingBlock(f, i) {
+  return `### ${i + 1}. ${f.title}
+
+- **${L.findingWhere}:** \`${f.file}${f.line ? `:${f.line}` : ''}\`
+- **${L.findingLens}:** ${f.lens} · **${L.findingImpactProb}:** ${impactProbLabel(f)}
+- **${L.findingWhat}:** ${f.description}
+${f.verdict.exploit_scenario ? `- **${L.findingExploit}:** ${f.verdict.exploit_scenario}\n` : ''}- **${f.verdict.fix_type === 'risky' ? L.findingWhyRisky : L.findingWhySafe}:** ${f.verdict.why}
+- **${L.findingSuggestedFix}:** ${f.verdict.suggested_fix || L.notSpecified}
+`
+}
+
+const riskMatrix = (() => {
+  const cells = {
+    high: { high: [], medium: [], low: [] },
+    medium: { high: [], medium: [], low: [] },
+    low: { high: [], medium: [], low: [] },
+  }
+  for (const f of finalReal) {
+    const imp = cells[f.verdict.impact] ? f.verdict.impact : 'medium'
+    const prob = cells[imp][f.verdict.probability] ? f.verdict.probability : 'medium'
+    cells[imp][prob].push(f.title)
+  }
+  const row = (imp) =>
+    `| **${L[imp]}** | ${cells[imp].low.join(' · ') || '—'} | ${cells[imp].medium.join(' · ') || '—'} | ${cells[imp].high.join(' · ') || '—'} |`
+  return `| ${L.matrixHeaderCol} | ${L.low} | ${L.medium} | ${L.high} |\n|---|---|---|---|\n${row('high')}\n${row('medium')}\n${row('low')}`
+})()
+
+const corruptedSuffixText = corrupted.length ? `, ${corrupted.length} ${L.corruptedSuffix}` : ''
+
+const reportMarkdown = `# 16 Eyes — diff review — ${today}
+
+${L.intro}
+
+- **${L.scope}:** ${scopeLabel}${prNumber ? ` (base \`${base}\` → head \`${head}\`)` : ''} · ${changedFiles.length} file(s) changed
+
+${execSummary}
+
+## ${L.methodology}
+
+- **${L.lensesRun} (${lenses.length}):** ${lenses.map((l) => `\`${l.name}\` (${l.focus})`).join(', ')}
+- **${L.rawToVerified}:** ${allVerified.length} candidates, ${realFindings.length} confirmed real, ${falsePositives.length} discarded as false positive${corruptedSuffixText}.
+- **${L.adversarialReview}:** ${L.adversarialSummary(highImpact.length, votesPerFinding, refutedHighImpact.length)}
+
+## ${L.riskMatrixHeading}
+
+${riskMatrix}
+
+---
+
+## ${L.safeHeading} (${safeFindings.length})
+
+${safeFindings.length === 0 ? L.none : safeFindings.map(findingBlock).join('\n')}
+
+---
+
+## ${L.riskyHeading} (${riskyFindings.length})
+
+${riskyFindings.length === 0 ? L.none : riskyFindings.map(findingBlock).join('\n')}
+
+---
+
+## ${L.appendixHeading}
+
+${falsePositives.length === 0 ? '' : `### ${L.falsePositiveHeading} (${falsePositives.length})\n\n${falsePositives.map((f) => `- **${f.title}** (\`${f.file}${f.line ? `:${f.line}` : ''}\`) — ${f.verdict.why}`).join('\n')}\n\n`}${refutedHighImpact.length === 0 ? '' : `### ${L.adversarialDiscardedHeading} (${refutedHighImpact.length})\n\n${refutedHighImpact.map((f) => `- **${f.title}** (\`${f.file}${f.line ? `:${f.line}` : ''}\`) — ${f.adversarial.refuted}/${f.adversarial.votes} ${L.reviewersRefuted}`).join('\n')}\n\n`}${corrupted.length === 0 ? '' : `### ${L.corruptedHeading} (${corrupted.length})\n\n${corrupted.map((f) => `- **${f.title}** (\`${f.file}${f.line ? `:${f.line}` : ''}\`)`).join('\n')}\n`}
+`
+
+const stats = {
+  lenses: lenses.length,
+  candidates: allVerified.length,
+  real: realFindings.length,
+  falsePositives: falsePositives.length,
+  safe: safeFindings.length,
+  risky: riskyFindings.length,
+  refutedHighImpact: refutedHighImpact.length,
+  corrupted: corrupted.length,
+}
+
+const reportJson = JSON.stringify(
+  {
+    schemaVersion: 1,
+    date: today,
+    diffScope: { base, head, prNumber, changedFiles },
+    stats,
+    findings: { safe: safeStructured, risky: riskyStructured },
+    appendix: {
+      falsePositives: falsePositives.map((f, i) => withId(f, i)),
+      refutedHighImpact: refutedHighImpact.map((f, i) => withId(f, i)),
+      corrupted: corrupted.map((f, i) => withId(f, i)),
+    },
+  },
+  null,
+  2,
+)
+
+return { reportMarkdown, reportJson, stats }
+```
+
+## Design notes (for maintainers)
+
+- **Same engine, different scope.** Verify/adversarial-review/synthesis logic, every
+  guard (`looksCorrupted`, the "0 valid votes ≠ survived" rule, dedup) is identical to
+  `audit-flow.md` on purpose — keep the two in sync if either changes. The only real
+  difference is `diffLensPrompt()`, which wraps each persisted lens's own prompt with
+  the diff content and an instruction to stay inside it.
+- **Diff gathering happens outside the Workflow script** (step 2-3 of "When invoked"),
+  same reason as `audit-flow.md`: the tool has no filesystem/git access, so `git diff`/
+  `gh pr diff` output has to be fetched by the orchestrating agent and passed in via
+  `args`.
+- **No lens-design, ever, in this flow** — unlike `audit`, which can fall back to
+  redesigning lenses if truly none exist (guarded by auto-bootstrap), `audit-diff` has
+  no "whole repo" context to profile from a diff alone. It always reuses whatever
+  `init` (interactive or auto-bootstrapped) already produced.
+- **Empty findings per lens are the expected common case** — most lenses' focus areas
+  won't intersect most diffs. This is intentionally simple (run every lens, let
+  irrelevant ones return fast) rather than a fragile pre-filter guessing relevance from
+  file paths.
+- **`last-diff-run.json`** is a separate pointer from `audit`'s `last-run.json` so
+  `/16-eyes fix` (see `fix-flow.md`) can tell a full-audit report from a diff-scoped one
+  and pick whichever is actually newest/relevant.

--- a/.claude/skills/16-eyes/references/audit-flow.md
+++ b/.claude/skills/16-eyes/references/audit-flow.md
@@ -1,0 +1,577 @@
+# `/16-eyes audit` — analyze
+
+Read-only. Never edits code.
+
+## When invoked
+
+1. **Determine `today`** from your own session context (the current date is always
+   available to you) as `YYYY-MM-DD`.
+2. **Determine `focus`** (optional): if the user's invocation named a specific area to
+   concentrate on, pass that as `focus`. Otherwise omit it — the audit runs every
+   persisted lens.
+3. **Read `.16-eyes/config.json`** if it exists (via the `Read` tool — the Workflow script
+   itself has no filesystem access). Extract `depth`, `adversarial.votesPerFinding`,
+   `language`, and `lensesPointer` (default `.16-eyes/lenses.json`). If the file is
+   absent, proceed with documented defaults.
+4. **Read the lenses file** at `lensesPointer`. **If it doesn't exist, run the
+   Auto-bootstrap flow from `init-flow.md` now** — this creates `.16-eyes/config.json`
+   (if that was also missing) and `.16-eyes/lenses.json` non-interactively, then
+   re-read both. Never invent lenses yourself, and never skip this step: `audit` always
+   runs against a persisted, previously-designed lens set, never a set it improvises on
+   the spot.
+5. **Call the `Workflow` tool** with `script` set to the *exact* contents of the code block
+   below (copy it verbatim — do not paraphrase or "improve" it inline), and
+   `args: { today, focus, profile, lenses, depth, votesPerFinding, language }`, where
+   `profile` is `{ languages, domain_summary }` read straight from the lenses file (not
+   re-derived) and `lenses` is that file's `lenses` array verbatim. This IS the user's
+   explicit opt-in to multi-agent orchestration — the user invoking this named skill is
+   the consent; do not ask again before calling `Workflow`.
+6. **Take the workflow's return value** (`{ reportMarkdown, reportJson, stats }`) and write
+   **both** files with the `Write` tool:
+   - Markdown: `<outputDir>/SECURITY_AUDIT_<today>.md` (human-readable).
+   - JSON: `<outputDir>/SECURITY_AUDIT_<today>.json` (machine-readable — `reportJson`,
+     already a JSON string from the script).
+   - `<outputDir>` is `config.output.dir` if set, else `docs/` if that directory exists,
+     else the repo root. If a report for `<today>` already exists at that path (a same-day
+     re-run), append `-2`, `-3`, etc. to BOTH filenames — never overwrite an existing
+     report.
+   - Then write/overwrite `.16-eyes/last-run.json` (path from `config.lastRunPointer`,
+     default `.16-eyes/last-run.json`) with `{ markdown: "<md path>", json: "<json path>",
+     generatedAt: "<ISO timestamp from your own context>", stats }` — this is a small
+     pointer, not the full findings, so `/16-eyes fix` can find the latest run later
+     (including in a different session).
+7. **Report a short summary** to the user: counts (lenses run, findings confirmed real,
+   safe vs risky, any refuted-on-adversarial-review or corrupted-verification items), and
+   the paths to both files. **If step 4 auto-bootstrapped config/lenses**, say so plainly
+   (what was defaulted, and that `/16-eyes init` can be re-run anytime to customize it).
+   Make clear that this skill **only produces the report — it does not touch any code**.
+   Fixing is `/16-eyes fix`, a deliberate separate step; offer it, don't do it unprompted.
+
+## The workflow script
+
+```js
+export const meta = {
+  name: '16-eyes-audit',
+  description:
+    "Run a repo's persisted investigation lenses across the whole codebase, verify every finding, adversarially review high-impact ones, and produce a classified report.",
+  phases: [
+    { title: 'Lens selection' },
+    { title: 'Lenses' },
+    { title: 'Verification' },
+    { title: 'Adversarial review' },
+    { title: 'Synthesis' },
+  ],
+}
+
+// ── Schemas ──────────────────────────────────────────────────────────────
+const LENS_SELECTION_SCHEMA = {
+  type: 'object',
+  properties: { selectedLensNames: { type: 'array', items: { type: 'string' } } },
+  required: ['selectedLensNames'],
+}
+
+const FINDINGS_SCHEMA = {
+  type: 'object',
+  properties: {
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          title: { type: 'string' },
+          file: { type: 'string' },
+          line: { type: 'number' },
+          description: { type: 'string' },
+          initial_impact: { type: 'string', enum: ['high', 'medium', 'low'] },
+          initial_probability: { type: 'string', enum: ['high', 'medium', 'low'] },
+        },
+        required: ['title', 'file', 'description'],
+      },
+    },
+  },
+  required: ['findings'],
+}
+
+const VERDICT_SCHEMA = {
+  type: 'object',
+  properties: {
+    is_real: { type: 'boolean' },
+    impact: { type: 'string', enum: ['high', 'medium', 'low'] },
+    probability: { type: 'string', enum: ['high', 'medium', 'low'] },
+    fix_type: { type: 'string', enum: ['safe', 'risky'] },
+    exploit_scenario: { type: 'string' },
+    why: { type: 'string' },
+    suggested_fix: { type: 'string' },
+  },
+  required: ['is_real', 'impact', 'probability', 'fix_type', 'why'],
+}
+
+const REFUTE_SCHEMA = {
+  type: 'object',
+  properties: {
+    refuted: { type: 'boolean' },
+    reason: { type: 'string' },
+  },
+  required: ['refuted', 'reason'],
+}
+
+const EXEC_SUMMARY_SCHEMA = {
+  type: 'object',
+  properties: { summary: { type: 'string' } },
+  required: ['summary'],
+}
+
+// ── i18n — report content + agent output language ─────────────────────────
+const LANGUAGE_NAMES = { en: 'English', pt: 'Brazilian Portuguese', es: 'Spanish' }
+
+const T = {
+  en: {
+    intro:
+      "> Generated by the `16-eyes` skill: runs this repo's tailored investigation lenses (designed once by `/16-eyes init`) in parallel across the whole codebase, verifies each finding skeptically, adversarially reviews (multiple independent skeptics) high-impact findings, and classifies the remainder into SAFE (mechanical fix) vs RISKY (needs a human decision). Not a linter, and not scoped to a single PR's diff — this is a sweep of the entire repository.",
+    methodology: 'Methodology',
+    repoProfile: 'Repo profile',
+    lensesDesigned: 'Lenses run',
+    rawToVerified: 'Raw → verified findings',
+    corruptedSuffix: 'with corrupted/failed verification (see appendix)',
+    adversarialReview: 'Adversarial review',
+    adversarialSummary: (h, v, r) =>
+      `${h} high-impact finding(s) went through ${v} independent reviewer(s) trying to refute them; ${r} were refuted and discarded.`,
+    riskMatrixHeading: 'Risk matrix (impact × probability)',
+    matrixHeaderCol: 'Impact \\ Probability',
+    low: 'Low',
+    medium: 'Medium',
+    high: 'High',
+    safeHeading: 'SAFE findings — mechanical fix, no behavior change',
+    riskyHeading: 'RISKY findings — need a human decision before fixing',
+    none: '_None._',
+    appendixHeading: 'Appendix — discarded',
+    falsePositiveHeading: 'False positive',
+    adversarialDiscardedHeading: 'Discarded in adversarial review',
+    corruptedHeading: 'Corrupted/failed verification — needs manual review',
+    findingWhere: 'Where',
+    findingLens: 'Lens',
+    findingImpactProb: 'Impact/Probability',
+    findingWhat: 'What',
+    findingExploit: 'Exploit scenario',
+    findingWhyRisky: "Why it's risky",
+    findingWhySafe: "Why it's safe to fix",
+    findingSuggestedFix: 'Suggested fix',
+    notSpecified: '(not specified)',
+    reviewersRefuted: 'reviewer(s) refuted',
+  },
+  pt: {
+    intro:
+      '> Gerado pelo skill `16-eyes`: roda as lentes de investigação deste repositório (desenhadas uma vez pelo `/16-eyes init`) em paralelo em todo o codebase, verifica cada achado ceticamente, faz revisão adversarial (múltiplos céticos independentes) nos achados de impacto alto, e classifica o resíduo em SAFE (correção mecânica) vs RISKY (decisão humana necessária). Não é um linter nem cobre só o diff de um PR — é um sweep do repositório inteiro.',
+    methodology: 'Metodologia',
+    repoProfile: 'Perfil do repo',
+    lensesDesigned: 'Lentes rodadas',
+    rawToVerified: 'Achados brutos → verificados',
+    corruptedSuffix: 'com verificação corrompida/falha (ver apêndice)',
+    adversarialReview: 'Revisão adversarial',
+    adversarialSummary: (h, v, r) =>
+      `${h} achado(s) de impacto alto passaram por ${v} revisor(es) independente(s) tentando refutar; ${r} foram refutados e descartados.`,
+    riskMatrixHeading: 'Matriz de risco (impacto × probabilidade)',
+    matrixHeaderCol: 'Impacto \\ Probabilidade',
+    low: 'Baixa',
+    medium: 'Média',
+    high: 'Alta',
+    safeHeading: 'Achados SAFE — correção mecânica, sem mudança de comportamento',
+    riskyHeading: 'Achados RISKY — precisam de decisão humana antes de corrigir',
+    none: '_Nenhum._',
+    appendixHeading: 'Apêndice — descartados',
+    falsePositiveHeading: 'Falso-positivo',
+    adversarialDiscardedHeading: 'Refutado na revisão adversarial',
+    corruptedHeading: 'Verificação corrompida/falhou — revisar manualmente',
+    findingWhere: 'Onde',
+    findingLens: 'Lente',
+    findingImpactProb: 'Impacto/Probabilidade',
+    findingWhat: 'O quê',
+    findingExploit: 'Cenário de exploração',
+    findingWhyRisky: 'Por quê é risky',
+    findingWhySafe: 'Por quê é seguro corrigir',
+    findingSuggestedFix: 'Sugestão de correção',
+    notSpecified: '(não especificada)',
+    reviewersRefuted: 'revisor(es) refutaram',
+  },
+  es: {
+    intro:
+      '> Generado por el skill `16-eyes`: ejecuta las lentes de investigación de este repositorio (diseñadas una vez por `/16-eyes init`) en paralelo en todo el código, verifica cada hallazgo de forma escéptica, hace una revisión adversarial (varios escépticos independientes) de los hallazgos de alto impacto, y clasifica el resto en SAFE (corrección mecánica) vs RISKY (requiere decisión humana). No es un linter ni se limita al diff de un PR — es un barrido de todo el repositorio.',
+    methodology: 'Metodología',
+    repoProfile: 'Perfil del repositorio',
+    lensesDesigned: 'Lentes ejecutadas',
+    rawToVerified: 'Hallazgos brutos → verificados',
+    corruptedSuffix: 'con verificación corrupta/fallida (ver apéndice)',
+    adversarialReview: 'Revisión adversarial',
+    adversarialSummary: (h, v, r) =>
+      `${h} hallazgo(s) de alto impacto pasaron por ${v} revisor(es) independiente(s) intentando refutarlos; ${r} fueron refutados y descartados.`,
+    riskMatrixHeading: 'Matriz de riesgo (impacto × probabilidad)',
+    matrixHeaderCol: 'Impacto \\ Probabilidad',
+    low: 'Baja',
+    medium: 'Media',
+    high: 'Alta',
+    safeHeading: 'Hallazgos SAFE — corrección mecánica, sin cambio de comportamiento',
+    riskyHeading: 'Hallazgos RISKY — requieren decisión humana antes de corregir',
+    none: '_Ninguno._',
+    appendixHeading: 'Apéndice — descartados',
+    falsePositiveHeading: 'Falso positivo',
+    adversarialDiscardedHeading: 'Descartado en la revisión adversarial',
+    corruptedHeading: 'Verificación corrupta/fallida — revisar manualmente',
+    findingWhere: 'Dónde',
+    findingLens: 'Lente',
+    findingImpactProb: 'Impacto/Probabilidad',
+    findingWhat: 'Qué',
+    findingExploit: 'Escenario de explotación',
+    findingWhyRisky: 'Por qué es risky',
+    findingWhySafe: 'Por qué es seguro corregir',
+    findingSuggestedFix: 'Corrección sugerida',
+    notSpecified: '(no especificada)',
+    reviewersRefuted: 'revisor(es) refutaron',
+  },
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+// Guard against a corruption pattern seen twice in real runs of this exact
+// pattern: a schema-valid object where every string field is literally
+// "test" (stale cache / crossed test fixture). Never trust it blindly —
+// route it to manual review instead of silently trusting or dropping it.
+function looksCorrupted(obj) {
+  if (!obj || typeof obj !== 'object') return false
+  const strings = Object.values(obj).filter((v) => typeof v === 'string' && v.length > 0)
+  return strings.length > 0 && strings.every((v) => v.trim().toLowerCase() === 'test')
+}
+
+function dedupKey(f) {
+  const file = (f.file || '').trim().toLowerCase()
+  const line = f.line == null ? '?' : String(f.line)
+  return `${file}:${line}`
+}
+
+function verifyPrompt(f, focusHint, languageName) {
+  return `You are adversarially verifying a security finding raised by another agent during a full-repo audit${focusHint ? ` (scope: ${focusHint})` : ''}.
+
+Finding: "${f.title}"
+File: ${f.file}${f.line ? `:${f.line}` : ''}
+Description: ${f.description}
+Initial impact guess: ${f.initial_impact ?? 'unknown'} · Initial probability guess: ${f.initial_probability ?? 'unknown'}
+
+Re-read the ACTUAL code at that location (and its real callers/config) yourself — do not trust the description above at face value. Then decide:
+- is_real: is this a genuine issue in the code as it exists today (not hypothetical, not already mitigated elsewhere, not dead code)?
+- impact: high/medium/low if exploited (money movement, auth bypass, data breach = high; degraded UX or internal-only = low).
+- probability: high/medium/low that this is actually reachable/exploitable given real callers and current config — not just "possible in theory".
+- fix_type: "safe" if a fix is purely mechanical and changes no behavior for any legitimate flow today (e.g. add a missing check, pin a version); "risky" if fixing it changes behavior for a flow that might be relied on today, touches money/auth, or needs a product decision (threshold, tolerance, UX tradeoff).
+- exploit_scenario: concrete inputs/steps that would trigger it (empty if not real).
+- suggested_fix: a specific, minimal fix.
+- why: your reasoning, referencing the real code you read.
+
+Be skeptical. A finding that sounds scary in the abstract but isn't actually reachable, or is already handled by a check elsewhere, is NOT real — say so.
+
+Write "why", "exploit_scenario", and "suggested_fix" in ${languageName}.`
+}
+
+function refutePrompt(f, languageName) {
+  return `Try to REFUTE this security finding from a full-repo audit (it already passed one verification pass and was classified impact=high — this is a 2nd, adversarial, independent check before it goes in a report someone will act on).
+
+Finding: "${f.title}"
+File: ${f.file}${f.line ? `:${f.line}` : ''}
+Description: ${f.description}
+Why it was judged real: ${f.verdict?.why ?? ''}
+Exploit scenario claimed: ${f.verdict?.exploit_scenario ?? ''}
+
+Read the actual code yourself. Look hard for a reason this ISN'T actually exploitable: a guard elsewhere, a precondition that can't occur, dead code, a framework default that already prevents it, or a misread of the code. If you genuinely cannot find a flaw in the finding after really trying, refuted=false. If you are UNCERTAIN either way, default to refuted=true — a finding has to survive skepticism to earn a spot in the report, not just avoid being disproven.
+
+Write "reason" in ${languageName}.`
+}
+
+// ── Script body ──────────────────────────────────────────────────────────
+
+const focus = args && args.focus ? String(args.focus) : null
+const today = (args && args.today) || 'unknown-date'
+const profile = (args && args.profile) || {}
+const depth = args && args.depth === 'quick' ? 'quick' : 'thorough'
+const configVotes =
+  args && Number.isFinite(args.votesPerFinding) && args.votesPerFinding > 0 ? args.votesPerFinding : null
+const language = args && T[args.language] ? args.language : 'en'
+const L = T[language]
+const languageName = LANGUAGE_NAMES[language]
+
+const allLenses = ((args && Array.isArray(args.lenses) && args.lenses) || []).filter((l) => l && l.prompt && l.name)
+if (allLenses.length === 0) {
+  return {
+    reportMarkdown: `# 16 Eyes — ${today}\n\nFailed: no investigation lenses were available (\`.16-eyes/lenses.json\` was empty, and auto-bootstrap did not produce any). Run \`/16-eyes init\` and try again.`,
+    reportJson: JSON.stringify({ error: 'no-lenses-available' }, null, 2),
+    stats: null,
+  }
+}
+
+// ── Optional focus-based lens selection (lenses themselves are fixed —
+// designed once by /16-eyes init — a per-invocation "focus" narrows WHICH
+// of them run this time, it never redesigns any) ──────────────────────────
+let lenses = allLenses
+if (focus) {
+  phase('Lens selection')
+  log(`Selecting which of the ${allLenses.length} persisted lens(es) are relevant to focus: "${focus}"...`)
+  const selection = await agent(
+    `Given this focus area for a security review: "${focus}", and this list of available investigation lenses (name — focus), select every lens that's plausibly relevant. Be inclusive when in doubt — a lens can stay even if only partially relevant, but leave out ones with clearly no connection.\n\n${allLenses.map((l) => `- ${l.name} — ${l.focus}`).join('\n')}`,
+    { schema: LENS_SELECTION_SCHEMA, phase: 'Lens selection', label: 'lens-selection', model: 'sonnet' },
+  )
+  const selectedNames = new Set((selection?.selectedLensNames || []).map((n) => String(n)))
+  const filtered = allLenses.filter((l) => selectedNames.has(l.name))
+  if (filtered.length === 0) {
+    log('No persisted lens matched the requested focus — falling back to running all of them.')
+  } else {
+    lenses = filtered
+    log(`${lenses.length}/${allLenses.length} lens(es) selected for this focus.`)
+  }
+}
+
+// ── Lenses → verification (pipeline, no barrier: each lens verifies as soon
+// as it finishes, without waiting for the others) ────────────────────────
+phase('Lenses')
+const seenKeys = new Set() // dedup by order of arrival across concurrent lenses — cost-only, not a correctness guarantee
+const perLensVerified = await pipeline(
+  lenses,
+  (lens) => agent(lens.prompt, { schema: FINDINGS_SCHEMA, phase: 'Lenses', label: `lens:${lens.name}`, model: 'sonnet' }),
+  (raw, lens) => {
+    const findings = (raw?.findings || []).filter((f) => f && f.title && f.file)
+    const fresh = findings.filter((f) => {
+      const k = dedupKey(f)
+      if (seenKeys.has(k)) return false
+      seenKeys.add(k)
+      return true
+    })
+    if (fresh.length < findings.length) {
+      log(`${lens.name}: ${findings.length - fresh.length} finding(s) dropped by dedup (same file:line already seen)`)
+    }
+    return parallel(
+      fresh.map((f) => () =>
+        agent(verifyPrompt(f, focus, languageName), {
+          schema: VERDICT_SCHEMA,
+          phase: 'Verification',
+          label: `verify:${lens.name}`,
+          model: 'sonnet',
+        }).then((v) => {
+          const corrupted = !v || looksCorrupted(v)
+          return { ...f, lens: lens.name, verdict: corrupted ? null : v, verdict_corrupted: corrupted }
+        }),
+      ),
+    )
+  },
+)
+const allVerified = perLensVerified.flat().filter(Boolean)
+
+const corrupted = allVerified.filter((f) => f.verdict_corrupted)
+const needsVerdict = allVerified.filter((f) => !f.verdict_corrupted && f.verdict)
+const realFindings = needsVerdict.filter((f) => f.verdict.is_real)
+const falsePositives = needsVerdict.filter((f) => !f.verdict.is_real)
+log(
+  `${allVerified.length} unique finding(s) verified: ${realFindings.length} real, ${falsePositives.length} false-positive, ${corrupted.length} corrupted/failed verification (manual review)`,
+)
+
+// ── Adversarial review (high impact only) ────────────────────────────────
+phase('Adversarial review')
+const highImpact = realFindings.filter((f) => f.verdict.impact === 'high')
+const otherImpact = realFindings.filter((f) => f.verdict.impact !== 'high')
+
+// budget-aware: drops from the configured/default vote count to 1 refuter per finding
+// if the token budget is running low.
+const baseVotes = configVotes ?? (depth === 'quick' ? 1 : 3)
+const votesPerFinding = budget.total && budget.remaining() < 200_000 ? 1 : baseVotes
+if (highImpact.length > 0)
+  log(`Adversarial review: ${highImpact.length} high-impact finding(s), ${votesPerFinding} refuter(s) each`)
+
+const adversarial = await parallel(
+  highImpact.map((f) => () =>
+    parallel(
+      Array.from({ length: votesPerFinding }, (_, i) => () =>
+        agent(refutePrompt(f, languageName), {
+          schema: REFUTE_SCHEMA,
+          phase: 'Adversarial review',
+          label: `refute:${f.lens}:${i}`,
+          model: 'sonnet',
+        }),
+      ),
+    ).then((votes) => {
+      const valid = votes.filter(Boolean).filter((v) => !looksCorrupted(v))
+      // guard: 0 valid votes must NOT count as "survived" (a real bug seen in an earlier run of this pattern).
+      const refuteCount = valid.filter((v) => v.refuted).length
+      const survived = valid.length > 0 && refuteCount * 2 < valid.length
+      return { ...f, adversarial: { votes: valid.length, refuted: refuteCount, survived } }
+    }),
+  ),
+)
+const survivedHighImpact = adversarial.filter(Boolean).filter((f) => f.adversarial.survived)
+const refutedHighImpact = adversarial.filter(Boolean).filter((f) => !f.adversarial.survived)
+if (refutedHighImpact.length > 0) {
+  log(
+    `${refutedHighImpact.length} high-impact finding(s) refuted by a majority of reviewers — dropped from the final report (listed in the appendix)`,
+  )
+}
+
+const finalReal = [...survivedHighImpact, ...otherImpact]
+const safeFindings = finalReal.filter((f) => f.verdict.fix_type === 'safe')
+const riskyFindings = finalReal.filter((f) => f.verdict.fix_type === 'risky')
+
+// ── Synthesis ───────────────────────────────────────────────────────────────
+phase('Synthesis')
+const execSummaryOut = await agent(
+  `Write a short (3-6 sentence) executive summary in ${languageName} for a full-repo security audit report, given these results:
+- ${lenses.length} investigation lenses run, tailored to this repo${profile?.domain_summary ? ` (${profile.domain_summary})` : ''}.
+- ${allVerified.length} candidate findings verified; ${realFindings.length} confirmed real, ${falsePositives.length} discarded as false-positive.
+- ${refutedHighImpact.length} high-impact finding(s) were refuted by adversarial review and dropped.
+- ${safeFindings.length} findings are SAFE to fix mechanically (no behavior change); ${riskyFindings.length} are RISKY (need a product/human decision before fixing).
+Do not list individual findings — just the shape of the result and what the reader should do next (review the risky findings, decide on each; safe ones can be applied directly).`,
+  { schema: EXEC_SUMMARY_SCHEMA, phase: 'Synthesis', label: 'exec-summary', model: 'sonnet' },
+)
+const execSummary = execSummaryOut?.summary || ''
+
+// stable ids for the structured findings handoff (consumed by /16-eyes fix)
+function withId(f, i) {
+  return { id: `${f.lens}-${i}`, ...f }
+}
+const safeStructured = safeFindings.map(withId)
+const riskyStructured = riskyFindings.map(withId)
+
+function impactProbLabel(f) {
+  return `${f.verdict.impact}/${f.verdict.probability}`
+}
+
+function findingBlock(f, i) {
+  return `### ${i + 1}. ${f.title}
+
+- **${L.findingWhere}:** \`${f.file}${f.line ? `:${f.line}` : ''}\`
+- **${L.findingLens}:** ${f.lens} · **${L.findingImpactProb}:** ${impactProbLabel(f)}
+- **${L.findingWhat}:** ${f.description}
+${f.verdict.exploit_scenario ? `- **${L.findingExploit}:** ${f.verdict.exploit_scenario}\n` : ''}- **${f.verdict.fix_type === 'risky' ? L.findingWhyRisky : L.findingWhySafe}:** ${f.verdict.why}
+- **${L.findingSuggestedFix}:** ${f.verdict.suggested_fix || L.notSpecified}
+`
+}
+
+const riskMatrix = (() => {
+  const cells = {
+    high: { high: [], medium: [], low: [] },
+    medium: { high: [], medium: [], low: [] },
+    low: { high: [], medium: [], low: [] },
+  }
+  for (const f of finalReal) {
+    const imp = cells[f.verdict.impact] ? f.verdict.impact : 'medium'
+    const prob = cells[imp][f.verdict.probability] ? f.verdict.probability : 'medium'
+    cells[imp][prob].push(f.title)
+  }
+  const row = (imp) =>
+    `| **${L[imp]}** | ${cells[imp].low.join(' · ') || '—'} | ${cells[imp].medium.join(' · ') || '—'} | ${cells[imp].high.join(' · ') || '—'} |`
+  return `| ${L.matrixHeaderCol} | ${L.low} | ${L.medium} | ${L.high} |\n|---|---|---|---|\n${row('high')}\n${row('medium')}\n${row('low')}`
+})()
+
+const corruptedSuffixText = corrupted.length ? `, ${corrupted.length} ${L.corruptedSuffix}` : ''
+
+const reportMarkdown = `# 16 Eyes — ${today}
+
+${L.intro}
+
+${execSummary}
+
+## ${L.methodology}
+
+${profile?.languages || profile?.domain_summary ? `- **${L.repoProfile}:** ${(profile?.languages || []).join(', ')} · ${profile?.domain_summary || ''}\n` : ''}- **${L.lensesDesigned} (${lenses.length}):** ${lenses.map((l) => `\`${l.name}\` (${l.focus})`).join(', ')}
+- **${L.rawToVerified}:** ${allVerified.length} candidates, ${realFindings.length} confirmed real, ${falsePositives.length} discarded as false positive${corruptedSuffixText}.
+- **${L.adversarialReview}:** ${L.adversarialSummary(highImpact.length, votesPerFinding, refutedHighImpact.length)}
+
+## ${L.riskMatrixHeading}
+
+${riskMatrix}
+
+---
+
+## ${L.safeHeading} (${safeFindings.length})
+
+${safeFindings.length === 0 ? L.none : safeFindings.map(findingBlock).join('\n')}
+
+---
+
+## ${L.riskyHeading} (${riskyFindings.length})
+
+${riskyFindings.length === 0 ? L.none : riskyFindings.map(findingBlock).join('\n')}
+
+---
+
+## ${L.appendixHeading}
+
+${falsePositives.length === 0 ? '' : `### ${L.falsePositiveHeading} (${falsePositives.length})\n\n${falsePositives.map((f) => `- **${f.title}** (\`${f.file}${f.line ? `:${f.line}` : ''}\`) — ${f.verdict.why}`).join('\n')}\n\n`}${refutedHighImpact.length === 0 ? '' : `### ${L.adversarialDiscardedHeading} (${refutedHighImpact.length})\n\n${refutedHighImpact.map((f) => `- **${f.title}** (\`${f.file}${f.line ? `:${f.line}` : ''}\`) — ${f.adversarial.refuted}/${f.adversarial.votes} ${L.reviewersRefuted}`).join('\n')}\n\n`}${corrupted.length === 0 ? '' : `### ${L.corruptedHeading} (${corrupted.length})\n\n${corrupted.map((f) => `- **${f.title}** (\`${f.file}${f.line ? `:${f.line}` : ''}\`)`).join('\n')}\n`}
+`
+
+const stats = {
+  lenses: lenses.length,
+  candidates: allVerified.length,
+  real: realFindings.length,
+  falsePositives: falsePositives.length,
+  safe: safeFindings.length,
+  risky: riskyFindings.length,
+  refutedHighImpact: refutedHighImpact.length,
+  corrupted: corrupted.length,
+}
+
+const reportJson = JSON.stringify(
+  {
+    schemaVersion: 1,
+    date: today,
+    stats,
+    findings: { safe: safeStructured, risky: riskyStructured },
+    appendix: {
+      falsePositives: falsePositives.map((f, i) => withId(f, i)),
+      refutedHighImpact: refutedHighImpact.map((f, i) => withId(f, i)),
+      corrupted: corrupted.map((f, i) => withId(f, i)),
+    },
+  },
+  null,
+  2,
+)
+
+return { reportMarkdown, reportJson, stats }
+```
+
+## Design notes (for maintainers)
+
+- **Why lenses are no longer designed here:** profiling + lens design moved to
+  `/16-eyes init` (`init-flow.md`) — they're repo-shape work, not per-run work.
+  This script now always receives a persisted `args.lenses` (guaranteed non-empty by the
+  auto-bootstrap step in "When invoked" step 4) and starts straight at the Lenses→Verify
+  pipeline.
+- **`focus` now filters, it never designs.** A per-invocation focus narrows which of the
+  persisted lenses run this time (one small selection agent call) — it can no longer
+  steer what the lenses themselves investigate, since they're fixed at init time. If the
+  selection call returns nothing relevant, fall back to running everything rather than
+  silently producing an empty audit.
+- **Why `pipeline()` for lenses→verify, not `parallel()`+barrier:** verification of
+  lens A's findings starts the moment lens A finishes, without waiting on the
+  slowest lens. This is the canonical "Review → Verify" pipeline pattern from the
+  Workflow tool's own docs.
+- **Why adversarial review only for `impact:"high"`:** cost control — a single
+  skeptical verify pass is enough for medium/low findings; only findings that
+  would justify real urgency get the expensive multi-refuter pass before being
+  trusted enough to land in a report someone acts on.
+- **The "0 valid votes ≠ survived" guard** (`valid.length > 0 && refuteCount * 2
+  < valid.length`) exists because an earlier version of this exact pattern had a
+  real bug: if every refuter agent failed (rate limit, transient error), the
+  finding was treated as "survived" by default — meaning a finding could reach
+  the final report with **zero** actual adversarial scrutiny. Never regress this.
+- **`looksCorrupted()`** exists because two real audit runs of this pattern
+  returned a schema-valid object where every string field was the literal word
+  `"test"` (stale cache / crossed fixture from a prior run). Schema validation
+  alone doesn't catch this — always sanity-check field content, not just shape.
+- **Dedup is best-effort and cost-only**, not a correctness guarantee — a
+  finding that slips past it just gets verified twice, which is harmless.
+- **No filesystem access inside the Workflow script** (by design of the tool) —
+  the script returns `reportMarkdown`/`reportJson` as strings; writing them to
+  disk happens in step 6 of "When invoked" above, outside the script.
+- **`reportJson`'s `findings.safe[]`/`findings.risky[]`** (each with a stable
+  `id: "${lens.name}-${index}"`) exist specifically so `/16-eyes fix` never has
+  to regex structured data out of the markdown prose — see `fix-flow.md`.
+- **`profile`/`depth`/`votesPerFinding`/`language` all come from `args`**,
+  populated by the outer "when invoked" instructions from `.16-eyes/config.json`
+  and `.16-eyes/lenses.json` — every one of them has a safe default when config
+  is absent (and lenses are guaranteed present by auto-bootstrap).
+- **This exact script's Lenses→Synthesis stages are shared, conceptually, with
+  `audit-diff-flow.md`** — that flow wraps each lens's prompt with diff content
+  before running what is otherwise the identical pipeline. If you change the
+  verify/adversarial/synthesis logic here, mirror the change there too.

--- a/.claude/skills/16-eyes/references/ci-flow.md
+++ b/.claude/skills/16-eyes/references/ci-flow.md
@@ -1,0 +1,65 @@
+# CI scaffolding — invoked from `/16-eyes init`
+
+Triggered by `init-flow.md` Phase 5, only when the user answered yes to the Phase 3 "CI
+template?" question. Writes files into the target repo's `.github/workflows/` and
+`.claude/`, which is why it only ever runs after the user has explicitly agreed (Phase 4
+already showed them this was coming — never reach this flow silently).
+
+## 1. Confirm the skill itself is committed to the repo
+
+CI needs `.claude/skills/16-eyes/` present in the checked-out repo — a headless CI job
+can't `npx 16-eyes install` from the registry reliably for every run (version drift,
+registry dependency, extra latency). Check whether `.claude/skills/16-eyes/` exists at
+the repo root:
+
+- **Missing**: tell the user, then run `npx 16-eyes@latest install --project` yourself
+  via `Bash` (a local, reversible file copy — safe to just do, but say what you're
+  about to do first). Remind them to `git add .claude/skills/16-eyes && git commit` —
+  you never commit on their behalf.
+- **Present**: continue.
+
+## 2. Write the GitHub Actions workflow(s)
+
+Copy `../assets/ci/pr-audit-diff.yml` (via `Read` then `Write`) to
+`.github/workflows/16-eyes-audit-diff.yml`. If a file already exists at that path,
+**never overwrite silently** — show the user both versions and ask.
+
+If the user also wants the optional scheduled full-repo sweep (ask this explicitly,
+it's opt-in, not implied by the Phase 3 answer), also copy
+`../assets/ci/nightly-full-audit.yml` to `.github/workflows/16-eyes-full-audit.yml`, same
+overwrite-protection rule.
+
+## 3. Write or merge `.claude/settings.json`
+
+Read `../assets/ci/settings.json` (the `dontAsk`-mode allowlist scoped to exactly what
+`audit-diff` needs).
+
+- **No `.claude/settings.json` exists yet**: write the template as-is.
+- **One already exists**: `Read` it first. **Merge, never overwrite**:
+  - Union the template's `permissions.allow` entries into the existing array
+    (skip duplicates).
+  - If `permissions.defaultMode` is already set to something other than `dontAsk`,
+    **don't silently change it** — tell the user their existing mode may cause the CI
+    job to hang waiting for approval it'll never get, and ask whether to switch it to
+    `dontAsk` for this repo.
+  - Leave every other existing key in the file untouched.
+
+## 4. Tell the user what's still manual
+
+You cannot set repository secrets yourself (that's a GitHub Actions/repo-settings
+action, out of reach for this skill). Tell them plainly:
+
+- Add `ANTHROPIC_API_KEY` as a repository (or organization) secret — Settings → Secrets
+  and variables → Actions, on GitHub's own UI.
+- The workflow **comments on every PR by default and never blocks merge**
+  (`.16-eyes/config.json`'s `ci.failOn` defaults to `"none"`). To make it a required,
+  merge-blocking check: set `ci.failOn` to `"risky"` (fail if any RISKY finding
+  survives) or `"any"` (fail on any confirmed finding), **and** mark the
+  `audit-diff` job as a required status check in the repo's branch protection rules
+  (also a GitHub UI action, not something this skill can do for you).
+- Point them at `docs/ci.md` in this package for the full writeup if they want more
+  detail than this summary.
+
+Set `.16-eyes/config.json`'s `ci.enabled` to `true` (already done in `init-flow.md`
+Phase 5 step 2, just confirm it landed) so `/16-eyes init`, re-run later, knows CI is
+already wired and won't ask again by default.

--- a/.claude/skills/16-eyes/references/fix-flow.md
+++ b/.claude/skills/16-eyes/references/fix-flow.md
@@ -1,0 +1,90 @@
+# `/16-eyes fix` — apply the audit's findings
+
+`fix` is linear and high-stakes (it edits code) — unlike `audit` (parallel, read-only,
+low-stakes). It does **not** use the `Workflow` tool. Work directly in this session with
+`Read`/`Edit`, one locus of accountability, no subagent fan-out.
+
+## Phase 1 — Locate the findings
+
+Try, in order. Both a full-repo `audit` report and a diff-scoped `audit-diff` report are
+valid sources — they carry the identical `findings.safe[]`/`findings.risky[]` shape —
+so consider both, and use whichever is actually the freshest/relevant one:
+
+1. **This conversation** — if `/16-eyes audit` or `/16-eyes audit-diff` already ran
+   earlier in this same session, use its `findings.safe[]`/`findings.risky[]` directly.
+   Cheapest, guaranteed fresh. If the user's `/16-eyes fix` invocation doesn't say which
+   one they mean and both ran this session, ask.
+2. **`.16-eyes/last-run.json`** (full audit) and/or **`.16-eyes/last-diff-run.json`**
+   (diff audit) — `Read` whichever exist, then `Read` the `.json` path each points to.
+   If both exist and the user didn't specify, prefer the more recent `generatedAt`, but
+   say so explicitly rather than silently picking one.
+3. **No pointer, or it's stale/missing** — glob `SECURITY_AUDIT*.json` (matches both
+   `SECURITY_AUDIT_<date>.json` and `SECURITY_AUDIT_DIFF_<date>.json`) in the configured
+   (or default) output directory, take the newest by mtime. Tell the user this was a
+   best-effort recovery, not a guaranteed-fresh source.
+4. **Nothing found anywhere** — say so plainly and run `/16-eyes audit` (or `audit-diff`,
+   whichever fits what the user actually wants fixed) first, then continue here with its
+   output. Never invent findings.
+
+Whichever source you used, **state it and its age** to the user before doing anything
+else (e.g. "using the audit from this session, run 2 minutes ago" vs. "using
+`docs/SECURITY_AUDIT_DIFF_2026-07-10.json` (PR #42), generated 6 days ago — code may
+have changed since").
+
+## Phase 2 — Apply `safe` findings
+
+Group `findings.safe[]` by `file`. For each file, one coherent edit pass covering every
+finding in that file — not one subagent per finding (two editors racing on the same file
+with a stale line number is a real correctness risk). Match the surrounding code's own
+conventions; reuse existing helpers/constants the finding's `suggested_fix` names rather
+than inventing parallel ones. If a file has multiple findings, `Read` it again between
+edits within that same file rather than trusting line numbers that may have shifted.
+
+After all safe findings are applied, run gates **only for the workspace(s) whose files
+were actually touched** — map each touched path to `config.gates.workspaces[]` (from
+`.16-eyes/config.json`; if no config, skip gates and say so). If a gate fails, try to
+localize which specific finding's fix caused it and repair or revert just that one —
+never leave the working tree in a broken state.
+
+## Phase 3 — Apply `risky` findings
+
+Present each `risky` finding **one at a time**: title, `file:line`, the concrete diff
+you're proposing, `why`, and `exploit_scenario`. Require an explicit yes before writing
+anything. This is the most portable confirmation shape across arbitrary repos/sessions —
+it doesn't assume any particular batching UI exists.
+
+You may *propose* grouping multiple risky findings into one confirmation only when
+they're genuinely the same fix repeated at near-identical call sites ("these 3 are the
+same missing check at different call sites — apply all 3 with one confirmation?") — show
+the proposal, then wait for the yes. Never group silently.
+
+A declined finding goes in the ledger as **declined by user** — distinct from **skipped by
+agent** (you looked closer and decided the finding was wrong/inapplicable on inspection;
+say why).
+
+## Hard invariant: never commit, never push
+
+`fix` never runs any git write command — no `git commit`, no `git push`, no `git add`
+even. All changes are left in the working tree for the user to review and commit
+themselves. This is not configurable, by design:
+
+- The tool runs in arbitrary repositories whose commit conventions (message format,
+  signing, hooks, ticket references) it cannot know.
+- It removes the one human checkpoint before a security-relevant change enters history.
+- The verify+adversarial-review pipeline in `audit` is good but not infallible — an
+  auto-commit would make a subtly-wrong "safe" classification permanent before anyone
+  looks at it.
+- This is a public tool installed by strangers — even offering auto-commit as an opt-in
+  config risks someone flipping it on without weighing the risk.
+
+## Phase 4 — Verify and summarize
+
+Run the gates for every workspace touched by either safe or (confirmed) risky changes.
+Close with a ledger, same shape regardless of repo:
+
+- **Applied** — by finding id, by file.
+- **Gated** — risky findings, confirmed vs. declined.
+- **Skipped** — findings the agent chose not to apply on closer inspection, with why.
+- **Verification** — gate results (pass/fail per workspace, or "no gates configured").
+- **Follow-ups** — anything that needs a human decision beyond what `fix` could resolve
+  on its own (e.g. a gate that's still red after a best-effort repair attempt).

--- a/.claude/skills/16-eyes/references/init-flow.md
+++ b/.claude/skills/16-eyes/references/init-flow.md
@@ -1,0 +1,291 @@
+# `/16-eyes init` — configure
+
+Two ways this runs: **standard** (the user typed `/16-eyes init` directly —
+detect → inventory → interview → confirm → write) and **auto-bootstrap**
+(invoked internally by `/16-eyes audit` or `/16-eyes audit-diff` because
+`.16-eyes/lenses.json` doesn't exist yet — no interview, sane defaults, safe
+to run with no human present, e.g. inside a headless CI job). Both end the
+same way: `.16-eyes/lenses.json` gets written — the persisted, repo-tailored
+investigation-lens set that `audit` and `audit-diff` both load from, instead
+of profiling the repo and designing lenses fresh on every single run.
+
+## Standard mode (user-invoked)
+
+Five phases, strictly in order. Do **not** write `.16-eyes/config.json` or
+`.16-eyes/lenses.json` before Phase 5 — everything before that is detection
+and a short interview.
+
+### Phase 1 — Detect existing config
+
+Check whether `.16-eyes/config.json` already exists in the repo root.
+
+- **Exists:** read it, tell the user what it currently has, and ask whether they want to
+  update it (re-run the interview, keeping current values as defaults) or leave it as is.
+  If leaving it as is, ask separately whether they'd also like the investigation lenses
+  regenerated (useful after the repo has changed shape significantly) — if not, stop here.
+- **Doesn't exist:** continue to Phase 2 as a fresh setup.
+
+### Phase 2 — Inventory
+
+Explore the repo (don't ask the user yet — figure out what you can from the code):
+
+- **Quality gates.** Look for test/lint/typecheck/build commands. Don't assume Node/npm —
+  check, in order of what's actually present: `package.json` `scripts` (test/lint/
+  typecheck/build/tsc), a `Makefile` (targets named test/lint/build or similar), Python
+  (`pytest`, `tox.ini`, `pyproject.toml` test config), Rust (`cargo test`), Go (`go test
+  ./...`), or any other convention the repo's own README/CI config documents. If the repo
+  is a monorepo/workspace (npm/yarn/pnpm workspaces, a `packages/`/`apps/` layout with
+  their own manifests), detect gate commands **per workspace**, not just at the root.
+- **Output location.** Does a `docs/` directory exist? That's the default report
+  location; otherwise the repo root.
+- **`.gitignore` contents** — useful context for the exclude-patterns question next.
+
+### Phase 3 — Interview
+
+Ask briefly (don't turn this into a long form — a few grouped questions is fine):
+
+1. **Exclude patterns** — propose this default set, adjusted for anything you saw in
+   `.gitignore`: `node_modules/**`, `dist/**`, `build/**`, `vendor/**`, `**/*.min.js`,
+   `**/fixtures/**`, `**/__snapshots__/**`. Confirm or let the user adjust.
+2. **Output location** — confirm the `docs/`-or-root default, or let them pick a
+   different directory.
+3. **Default depth** — "quick" (fewer lenses, lighter adversarial review — for a fast
+   check) vs "thorough" (the default; more lenses, full adversarial review on every
+   high-impact finding). This also governs how many investigation lenses get designed in
+   Phase 5 below.
+4. **Gitignore the reports?** — ask explicitly, don't decide silently. This matters
+   most for a **public** repository: a generated report describes real vulnerabilities
+   with exploit scenarios, and committing that by accident is a real, non-hypothetical
+   risk. Present it as a real choice (some teams want a committed audit trail; others
+   don't want vulnerability write-ups in git history at all).
+5. **Report language** — default `en`; ask if they'd prefer `pt` or `es` as the default
+   for this repo (either way, `/16-eyes audit`/`audit-diff` can always be asked for a
+   different language on a one-off basis regardless of this default).
+6. **CI template** — ask if they want a GitHub Actions workflow scaffolded that runs
+   `/16-eyes audit-diff` automatically on every PR (see `references/ci-flow.md` for what
+   this writes and where). Default to **no** if unsure — this touches
+   `.github/workflows/`, which shouldn't happen as a side effect of an unrelated yes.
+
+### Phase 4 — Confirm
+
+Show the user the exact `.16-eyes/config.json` you're about to write, **and** tell them
+you're about to profile the repo and design its investigation lenses (a handful of agent
+calls, well under a minute) — get a single go-ahead before doing either.
+
+### Phase 5 — Design lenses & write
+
+1. **Call the `Workflow` tool** with `script` set to the exact contents of the code block
+   in "The lens-design workflow script" below, and `args: { excludePatterns, depth }`
+   from the Phase 3 answers. This is the user's explicit opt-in to multi-agent
+   orchestration (the user invoking `/16-eyes init` is the consent) — do not ask again.
+2. **Write `.16-eyes/config.json`**, matching this shape (documented formally in
+   `../assets/config.schema.json`):
+
+   ```json
+   {
+     "$schema": "../../.claude/skills/16-eyes/assets/config.schema.json",
+     "version": 1,
+     "depth": "thorough",
+     "language": "en",
+     "excludePatterns": [
+       "node_modules/**",
+       "dist/**",
+       "build/**",
+       "vendor/**",
+       "**/*.min.js",
+       "**/fixtures/**",
+       "**/__snapshots__/**"
+     ],
+     "output": {
+       "dir": "docs",
+       "markdownPattern": "SECURITY_AUDIT_{date}.md",
+       "jsonPattern": "SECURITY_AUDIT_{date}.json",
+       "gitignoreReports": true
+     },
+     "lastRunPointer": ".16-eyes/last-run.json",
+     "lastDiffRunPointer": ".16-eyes/last-diff-run.json",
+     "lensesPointer": ".16-eyes/lenses.json",
+     "gates": {
+       "workspaces": [
+         {
+           "path": ".",
+           "test": "npm test",
+           "lint": "npm run lint",
+           "typecheck": "npm run typecheck",
+           "build": "npm run build"
+         }
+       ]
+     },
+     "adversarial": { "votesPerFinding": 3 },
+     "ci": { "enabled": false, "failOn": "none", "commentOnPr": true }
+   }
+   ```
+
+   Omit any gate command you couldn't detect (don't guess a placeholder). If the user
+   chose `depth: "quick"`, set `adversarial.votesPerFinding` to `1` instead of `3`. If they
+   opted to gitignore reports, also add `.16-eyes/lenses.json`'s sibling report files (not
+   `.16-eyes/` itself — `lenses.json`/`config.json`/the run pointers should stay tracked,
+   they're config, not vulnerability write-ups) and the configured report filename
+   pattern to the repo's `.gitignore` (create it if it doesn't exist, append if it does —
+   never overwrite an existing `.gitignore`). If they said yes to the CI template
+   question, set `ci.enabled: true` and follow `references/ci-flow.md` now to scaffold it.
+3. **Write `.16-eyes/lenses.json`**:
+   ```json
+   {
+     "version": 1,
+     "generatedAt": "<ISO timestamp from your own context>",
+     "profile": "<the workflow's `profile` return value, verbatim>",
+     "lenses": "<the workflow's `lenses` return value, verbatim>"
+   }
+   ```
+4. Tell the user it's done: how many lenses were designed and a one-line sense of what
+   they cover (drawn from `profile.domain_summary`), and that `/16-eyes audit`,
+   `audit-diff`, and `fix` will pick all of this up automatically from here on — no need
+   to reference the config or lenses files manually. Mention that re-running `/16-eyes
+   init` regenerates the lenses (useful after the repo's shape changes materially).
+
+## Auto-bootstrap mode (invoked internally by `audit` / `audit-diff`)
+
+Triggered the moment `/16-eyes audit` or `/16-eyes audit-diff` looks for
+`.16-eyes/lenses.json` (per `config.lensesPointer`) and doesn't find it. **Never
+interview, never wait for confirmation** — this must complete unattended, including
+inside a headless CI run with no human in the loop.
+
+1. **If `.16-eyes/config.json` already exists**, read it and reuse its `excludePatterns`/
+   `depth` as-is for lens design below — don't touch anything else in it, don't ask
+   about it. If `lensesPointer` is missing from it, add the default
+   (`.16-eyes/lenses.json`) when you write config back out at the end of this step.
+2. **If `.16-eyes/config.json` doesn't exist**, run Phase 2's inventory automatically
+   (gate detection, output-location detection) and write `.16-eyes/config.json` with the
+   Phase 5 shape above, using every documented default verbatim (`excludePatterns`
+   default set, `output.dir` = `docs/`-or-root per Phase 2, `depth: "thorough"`,
+   `language: "en"`, `output.gitignoreReports: false`, `ci: { enabled: false, failOn:
+   "none", commentOnPr: true }`, `adversarial.votesPerFinding: 3`) — no interview, no
+   confirmation step.
+3. **Call the same `Workflow` script** as Standard mode Phase 5 step 1, with whatever
+   `excludePatterns`/`depth` resulted from step 1 or 2 above.
+4. **Write `.16-eyes/lenses.json`** exactly as in Standard mode Phase 5 step 3.
+5. **Return control** to whichever command triggered this (`audit`/`audit-diff`) and
+   continue its own flow immediately — don't stop here. That command's own final summary
+   to the user must mention that config/lenses were bootstrapped just now with defaults,
+   and that `/16-eyes init` can be run anytime afterward to customize exclude patterns,
+   output location, depth, language, or gates interactively (it will detect the
+   bootstrapped config and offer to update it, per Phase 1 above).
+
+## The lens-design workflow script
+
+```js
+export const meta = {
+  name: '16-eyes-lens-design',
+  description: 'Profile a repo and design a tailored set of security investigation lenses, persisted for /16-eyes audit and /16-eyes audit-diff to reuse.',
+  phases: [{ title: 'Profile' }, { title: 'Lens design' }],
+}
+
+const PROFILE_SCHEMA = {
+  type: 'object',
+  properties: {
+    languages: { type: 'array', items: { type: 'string' } },
+    frameworks: { type: 'array', items: { type: 'string' } },
+    domain_summary: { type: 'string' },
+    architecture_summary: { type: 'string' },
+    risk_relevant_subsystems: { type: 'array', items: { type: 'string' } },
+  },
+  required: ['languages', 'domain_summary', 'architecture_summary', 'risk_relevant_subsystems'],
+}
+
+const LENSES_SCHEMA = {
+  type: 'object',
+  properties: {
+    lenses: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          focus: { type: 'string' },
+          prompt: { type: 'string' },
+        },
+        required: ['name', 'focus', 'prompt'],
+      },
+    },
+  },
+  required: ['lenses'],
+}
+
+const excludePatterns = (args && Array.isArray(args.excludePatterns) && args.excludePatterns) || []
+const depth = args && args.depth === 'quick' ? 'quick' : 'thorough'
+
+const excludeNote = excludePatterns.length
+  ? `\n\nDo not investigate or report findings under these excluded paths (vendored/generated/fixtures, already reviewed as out of scope): ${excludePatterns.join(', ')}.`
+  : ''
+const depthNote =
+  depth === 'quick'
+    ? '\n\nDepth requested: QUICK — prioritize only the 4-8 highest-value lenses (the areas most likely to matter for this repo); skip lower-priority ones entirely rather than covering everything shallowly.'
+    : ''
+
+log('Profiling the repository (stack, domains, architecture)...')
+phase('Profile')
+const profile = await agent(
+  `Profile this repository for a security-audit planning step. Explore its structure (package manifests, lockfiles, top-level directories, README, CI config, entry points, notable frameworks/ORMs/HTTP frameworks). Identify:
+- languages and frameworks in use
+- a short domain summary (what this application/service actually does, for whom)
+- a short architecture summary (monolith vs services, frontend/backend split, datastores, deploy target)
+- risk_relevant_subsystems: a list of specific things THIS repo has that matter for security (e.g. "handles payment/money movement", "has public webhooks", "calls an LLM with user-controlled input", "parses uploaded files", "has its own auth/session system", "runs SQL built from user input somewhere", "has an admin/internal-only surface", "is a monorepo with N packages") — be concrete and specific to what you actually find, not a generic list.${excludeNote}`,
+  { schema: PROFILE_SCHEMA, phase: 'Profile', label: 'profile', model: 'sonnet' },
+)
+log(
+  `Profile: ${(profile?.languages || []).join(', ')} · ${(profile?.risk_relevant_subsystems || []).length} risk-relevant subsystem(s) identified`,
+)
+
+phase('Lens design')
+const lensDesign = await agent(
+  `You are designing the standing investigation plan for a repository's security audits (both full-repo and diff-scoped reviews will reuse this same plan), given this repo profile:
+
+Languages: ${(profile?.languages || []).join(', ')}
+Frameworks: ${(profile?.frameworks || []).join(', ')}
+Domain: ${profile?.domain_summary}
+Architecture: ${profile?.architecture_summary}
+Risk-relevant subsystems found: ${(profile?.risk_relevant_subsystems || []).join('; ')}
+
+Produce a list of investigation LENSES — each one a specific, non-overlapping area an independent subagent will investigate in depth, either across the whole repo or scoped to a diff. Consider (include what applies, SKIP what doesn't, and ADD repo-specific ones not listed here):
+- authentication & session management
+- authorization / access control (roles, tenant isolation, IDOR)
+- injection surfaces per data sink (SQL/NoSQL/command/template) — one lens per DISTINCT sink technology if there's more than one
+- money movement / other irreversible actions (payments, deletions, sends) — validation, idempotency, confirmation
+- third-party webhook handlers (auth, replay, fail-open vs fail-closed)
+- file upload / import / parsing (arbitrary file types, size limits, formula/injection in generated files, zip bombs)
+- LLM/AI usage if any (prompt injection, untrusted data reaching the model, output trusted without validation)
+- frontend security (XSS, CSRF, exposed secrets in client bundle, client-only validation)
+- CI/CD supply chain (unpinned actions/deps, secret handling, install script risk, permission scope of CI tokens)
+- secrets & credentials management (hardcoded values, logging of sensitive data, rotation story)
+- infra-as-config (deploy config, exposed admin surfaces, missing rate limits)
+- dependency vulnerabilities (only if there's a clear signal worth a dedicated lens, not a generic "run npm audit")
+- business-logic-specific risks unique to this repo's actual domain (from the profile above)
+
+Aim for as many lenses as the repo's actual distinct surface area warrants — a small single-purpose service might need 6-8, a large multi-domain backend might need 18-20. Do NOT pad with redundant/near-duplicate lenses just to hit a round number, and do NOT skip a real distinct area to save calls.
+
+For each lens, write: a short "name" (slug-like), a one-line "focus" description, and a full "prompt" — the COMPLETE instructions you'd hand to an independent subagent with no other context, telling it exactly what to explore (which kind of files/patterns to grep for, what to read) and what to return: a list of findings, each with title, file, line (best-effort), description of the concrete issue, and an initial impact/probability guess. Tell each lens agent to anchor every finding to a real file:line it actually read — no speculation about code it didn't look at. Each lens's "prompt" you write MUST also tell that lens agent not to investigate the excluded paths below, if any. Since this same lens may later run scoped to just a diff instead of the whole repo, phrase the prompt so it still makes sense when told "investigate only within these changed files/hunks" — i.e., don't hard-code "explore the whole repo" as the only mode of operation.${excludeNote}${depthNote}`,
+  { schema: LENSES_SCHEMA, phase: 'Lens design', label: 'lens-design', model: 'sonnet' },
+)
+const lenses = (lensDesign?.lenses || []).filter((l) => l && l.prompt && l.name)
+log(`${lenses.length} lens(es) designed: ${lenses.map((l) => l.name).join(', ')}`)
+
+return { profile, lenses }
+```
+
+## Design notes (for maintainers)
+
+- **Why lens design moved here from `audit-flow.md`:** profiling a repo and designing its
+  investigation lenses is repo-shape work, not per-run work — redoing it on every
+  `/16-eyes audit` call (and, worse, on every PR's `/16-eyes audit-diff`) burned two extra
+  agent calls per run for a result that rarely changes between runs, and gave
+  diff-scoped reviews no stable, comparable lens set to check PRs against over time.
+- **Why lenses are phrased to work both full-repo and diff-scoped:** the exact same
+  `lenses.json` is loaded by both `audit` (runs each lens across the whole repo) and
+  `audit-diff` (runs each lens scoped to a diff's changed hunks) — see `audit-flow.md`
+  and `audit-diff-flow.md`.
+- **Auto-bootstrap exists specifically for CI.** A headless `claude -p "/16-eyes
+  audit-diff"` run in a GitHub Action has no human to interview — if it hit Standard
+  mode's Phase 3/4, it would hang waiting for input that will never come. Auto-bootstrap
+  is what makes `audit-diff` safe to wire into CI on a repo that never ran `/16-eyes
+  init` first.


### PR DESCRIPTION
## Summary

Adds a Claude Code skill (`.claude/skills/16-eyes/`) for security audits: `/16-eyes init`, `audit`, `audit-diff`, and `fix`. It's purely additive and opt-in — nothing changes for contributors who don't use Claude Code or don't invoke it; no CI workflow is added by this PR, no existing behavior changes.

What it does when someone does invoke it:
- Designs a set of investigation "lenses" tailored to this repo's actual stack/domain (once, via `init`).
- `audit` runs every lens across the whole codebase; `audit-diff` scopes the same pipeline to a diff/PR.
- Every finding is verified by a second, skeptical agent re-reading the real code (not trusting the first pass), and high-impact findings get an additional adversarial round (multiple independent reviewers actively trying to refute them) before landing in the report.
- `fix` applies safe findings mechanically and asks for confirmation on risky ones — it never commits or pushes on its own.

We've been running this on our own fork and found it useful for catching a few real things (including some CodeQL findings CodeQL itself hadn't caught yet, and some it had that turned out to need care rather than blind fixes). Figured it might be useful to the project directly rather than keeping it fork-only. Totally understand if this isn't a fit for the project — happy to close it out if so.