### PR TITLE
fix(modal): prevent scrollbar drag from closing the task detail modal 🤖🤖🤖

### DIFF
--- a/frontend/src/components/misc/Modal.vue
+++ b/frontend/src/components/misc/Modal.vue
@@ -349,6 +349,17 @@ $modal-width: 1024px;
 
 // scrolling-content
 // used e.g. for <TaskDetailViewModal>
+.scrolling {
+	// On desktop the scrollbar lives on .modal-content so that
+	// clicking / dragging the scrollbar does not trigger
+	// @mousedown.self on .modal-container and close the modal.
+	@media screen and (min-width: $tablet) {
+		.modal-container {
+			overflow: visible;
+		}
+	}
+}
+
 .scrolling .modal-content {
 	inline-size: 100%;
 	margin: $modal-margin auto;
@@ -360,13 +371,24 @@ $modal-width: 1024px;
 		max-inline-size: $modal-width;
 	}
 
-	@media screen and (min-width: $tablet) {
-		max-block-size: none; // reset bulma
-		margin: $modal-margin auto; // reset bulma
+	// Wide desktop: modal has 4rem top/bottom margins, so the
+	// content area must be viewport height minus those margins.
+	@media screen and (min-width: $desktop) {
+		max-block-size: calc(100dvh - #{$modal-margin} * 2);
 		inline-size: 100%;
+		overflow-y: auto;
 	}
 
-	@media screen and (max-width: $desktop), print {
+	// Narrow desktop (tablet to desktop): modal fills full width
+	// and height (margin: 0), so the content scrolls within 100dvh.
+	@media screen and (min-width: $tablet) and (max-width: $desktop) {
+		max-block-size: 100dvh;
+		inline-size: 100%;
+		overflow-y: auto;
+		margin: 0;
+	}
+
+	@media screen and (max-width: $tablet), print {
 		margin: 0;
 	}
 }


### PR DESCRIPTION
## Bug

On desktop, dragging the task-detail modal's vertical scrollbar and releasing the mouse outside the modal closes it unexpectedly. This makes it easy to lose the task view while simply scrolling through a long task.

## Cause

The scrollbar sits on `.modal-container`, whose `@mousedown.self` handler treats a press/release on the scrollbar as a backdrop click and closes the modal.

## Fix

On desktop (≥ `$tablet`) `overflow` moves to `.modal-content`, so the scrollbar lives inside the content area instead of the backdrop container. The `$tablet`/`$desktop` breakpoints are adjusted so scrolling stays within `100dvh`. Single file, SCSS only — no behaviour change on mobile.

## Repro / environment

Firefox 153.0 (desktop):

1. Open a task (task-detail modal).
2. Drag the modal's vertical scrollbar.
3. Release the mouse outside the modal.

Without the fix the modal closes; with the fix it stays open.

---

AI-assisted (Claude Code); reviewed, tested and authored by me.
