### PR TITLE
feat(notifications): use custom logo in notification emails

### DIFF
--- a/config-raw.json
+++ b/config-raw.json
@@ -131,7 +131,7 @@
                 {
                     "key": "customlogourl",
                     "default_value": "",
-                    "comment": "Allow using a custom logo via external URL."
+                    "comment": "Allow using a custom logo via external URL. Also used as the logo in notification emails when set."
                 },
                 {
                     "key": "customlogourldark",

--- a/pkg/notifications/mail_render.go
+++ b/pkg/notifications/mail_render.go
@@ -95,7 +95,7 @@ const mailTemplateHTML = `
 <div style="width: 100%; font-family: 'Open Sans', sans-serif; Text-rendering: optimizeLegibility">
     <div style="width: 600px; margin: 0 auto; Text-align: justify;">
         <h1 style="font-size: 30px; Text-align: center;">
-            <img src="cid:logo.png" style="height: 75px;" alt="Vikunja"/>
+            <img src="{{ .LogoURL }}" style="height: 75px;" alt="Vikunja"/>
         </h1>
         <div class="email-card" style="border: 1px solid #dbdbdb; -webkit-box-shadow: 0.3em 0.3em 0.8em #e6e6e6; box-shadow: 0.3em 0.3em 0.8em #e6e6e6; color: #4a4a4a; padding: 5px 25px; border-radius: 3px; background: #fff;">
 <p>
@@ -544,6 +544,20 @@ func RenderMail(m *Mail, lang string) (mailOpts *mail.Opts, err error) {
 	data["FrontendURL"] = config.ServicePublicURL.GetString()
 	data["CopyURLText"] = i18n.T(lang, "notifications.common.copy_url")
 
+	// Use the configured custom logo in emails when set, otherwise fall back to
+	// the logo embedded in the binary (referenced by its cid). The value is
+	// wrapped in templatehtml.URL because html/template would otherwise strip
+	// the "cid:" scheme (and any non-http custom scheme) as unsafe. Both values
+	// are trusted: the cid is a constant and the custom URL is admin-configured.
+	customLogoURL := config.ServiceCustomLogoURL.GetString()
+	useCustomLogo := customLogoURL != ""
+	if useCustomLogo {
+		// #nosec G203 -- admin-configured logo URL, not user input
+		data["LogoURL"] = templatehtml.URL(customLogoURL)
+	} else {
+		data["LogoURL"] = templatehtml.URL("cid:logo.png")
+	}
+
 	if m.headerLine != nil {
 		// #nosec G203 -- the html is sanitized
 		data["HeaderLineHTML"] = templatehtml.HTML(newNotificationSanitizer().Sanitize(m.headerLine.Text))
@@ -584,7 +598,9 @@ func RenderMail(m *Mail, lang string) (mailOpts *mail.Opts, err error) {
 		ThreadID:    m.threadID,
 	}
 
-	if !m.conversational {
+	// Only embed the default logo when no custom logo URL is configured. With a
+	// custom logo the image is loaded from that remote URL instead.
+	if !m.conversational && !useCustomLogo {
 		mailOpts.EmbedFS = map[string]*embed.FS{
 			"logo.png": &logo,
 		}

--- a/pkg/notifications/mail_test.go
+++ b/pkg/notifications/mail_test.go
@@ -141,6 +141,27 @@ This is a line
 		// Verify no action button is present
 		assert.NotContains(t, mailopts.HTMLMessage, `class="email-button"`)
 	})
+	t.Run("default logo is embedded", func(t *testing.T) {
+		config.ServiceCustomLogoURL.Set("")
+
+		mailopts, err := RenderMail(NewMail().Line("Test"), "en")
+		require.NoError(t, err)
+
+		assert.Contains(t, mailopts.HTMLMessage, `src="cid:logo.png"`)
+		require.NotNil(t, mailopts.EmbedFS)
+		assert.Contains(t, mailopts.EmbedFS, "logo.png")
+	})
+	t.Run("custom logo url is used and default logo is not embedded", func(t *testing.T) {
+		config.ServiceCustomLogoURL.Set("https://example.com/logo.png")
+		t.Cleanup(func() { config.ServiceCustomLogoURL.Set("") })
+
+		mailopts, err := RenderMail(NewMail().Line("Test"), "en")
+		require.NoError(t, err)
+
+		assert.Contains(t, mailopts.HTMLMessage, `src="https://example.com/logo.png"`)
+		assert.NotContains(t, mailopts.HTMLMessage, `src="cid:logo.png"`)
+		assert.Nil(t, mailopts.EmbedFS)
+	})
 	t.Run("with action", func(t *testing.T) {
 		mail := NewMail().
 			From("test@example.com").


### PR DESCRIPTION
### What this PR does

Notification emails always embed the built-in Vikunja logo, ignoring the existing `service.customlogourl` setting that already customizes the logo in the web UI. This PR makes notification emails respect that same setting, so self-hosted instances can brand their emails without a fork.

### Behaviour

- **`service.customlogourl` set** → the email header loads the logo from that URL, and the built-in logo is no longer embedded (`EmbedFS` is skipped).
- **Not set (default)** → unchanged: the embedded `cid:logo.png` is used exactly as before.

The logo `src` is now templated. The value is wrapped in `template.URL` because `html/template` would otherwise strip the `cid:` scheme (and any non-http custom scheme) as unsafe — resulting in `#ZgotmplZ`. Both sources are trusted: the `cid:` reference is a constant and the custom URL is admin-configured via server config, not user input.

Only the non-conversational template carries a logo, so only that path is touched.

### Notes

- The dark-mode variant `customlogourldark` is intentionally not used here — email clients have poor/no `prefers-color-scheme` image-swapping support, so a single logo is the pragmatic choice. Happy to add it if you'd prefer.
- Doc comment for the config key updated to mention it now applies to emails too.

### Tests

Added two subtests to `TestRenderMail`:
- default → HTML contains `src="cid:logo.png"` and `EmbedFS` includes `logo.png`
- custom URL → HTML contains the URL, no `cid:logo.png`, and `EmbedFS` is nil

`go test ./pkg/notifications/` passes; `gofmt`/`go vet` clean.
