### PR TITLE
docs: add missing trailing periods to Ways to Contribute list in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,11 +20,11 @@ PRs and issues that skip these steps may be closed without detailed review — m
 
 ## Ways to Contribute
 
-- **Bug reports**: Open an issue with steps to reproduce
-- **Bug fixes**: PRs welcome - link the issue you're fixing
-- **Features**: Please open an issue to discuss before starting work
-- **Translations**: See the Translations section below
-- **Documentation**: Improvements to docs are always welcome
+- **Bug reports**: Open an issue with steps to reproduce.
+- **Bug fixes**: PRs welcome - link the issue you're fixing.
+- **Features**: Please open an issue to discuss before starting work.
+- **Translations**: See the Translations section below.
+- **Documentation**: Improvements to docs are always welcome.
 
 ## Development Setup
 


### PR DESCRIPTION
## Description
This PR fixes list item punctuation consistency in `CONTRIBUTING.md`.

## Details
Added trailing periods to bullet items 1–5 under the Ways to Contribute section.