### PR TITLE
feat(views): allow saving a default sort on project views

### DIFF
--- a/frontend/src/components/project/views/ProjectList.vue
+++ b/frontend/src/components/project/views/ProjectList.vue
@@ -113,15 +113,17 @@ import Nothing from '@/components/misc/Nothing.vue'
 import Pagination from '@/components/misc/Pagination.vue'
 import SortPopup from '@/components/project/partials/SortPopup.vue'
 
-import {useTaskList} from '@/composables/useTaskList'
+import {useTaskList, type SortBy} from '@/composables/useTaskList'
 import {useTaskDragToProject} from '@/composables/useTaskDragToProject'
 import {shouldShowTaskInListView} from '@/composables/useTaskListFiltering'
 import {PERMISSIONS as Permissions} from '@/constants/permissions'
 import {calculateItemPosition} from '@/helpers/calculateItemPosition'
+import {sortByFromViewFilter} from '@/helpers/viewSort'
 import type {ITask} from '@/modelTypes/ITask'
 import {isSavedFilter, useSavedFilter} from '@/services/savedFilter'
 
 import {useBaseStore} from '@/stores/base'
+import {useProjectStore} from '@/stores/projects'
 import {useTaskStore} from '@/stores/tasks'
 
 import type {IProject} from '@/modelTypes/IProject'
@@ -136,6 +138,15 @@ const props = defineProps<{
 }>()
 
 const projectId = toRef(props, 'projectId')
+const projectStore = useProjectStore()
+
+const LIST_SORT_DEFAULT: SortBy = {position: 'asc'}
+
+const sortByDefault = computed<SortBy>(() => {
+	const project = projectStore.projects[projectId.value]
+	const view = project?.views?.find(v => v.id === props.viewId)
+	return sortByFromViewFilter(view?.filter) ?? LIST_SORT_DEFAULT
+})
 
 defineOptions({name: 'List'})
 
@@ -154,7 +165,7 @@ const {
 } = useTaskList(
 	() => projectId.value,
 	() => props.viewId,
-	{position: 'asc'},
+	() => sortByDefault.value,
 	() => projectId.value === -1
 		? ['comment_count', 'is_unread']
 		: ['subtasks', 'comment_count', 'is_unread'],

--- a/frontend/src/components/project/views/ProjectTable.vue
+++ b/frontend/src/components/project/views/ProjectTable.vue
@@ -368,6 +368,7 @@ import type {IProject} from '@/modelTypes/IProject'
 import AssigneeList from '@/components/tasks/partials/AssigneeList.vue'
 import type {IProjectView} from '@/modelTypes/IProjectView'
 import { camelCase } from 'change-case'
+import {sortByFromViewFilter} from '@/helpers/viewSort'
 import {isSavedFilter} from '@/services/savedFilter'
 import {useProjectStore} from '@/stores/projects'
 
@@ -405,10 +406,16 @@ const SORT_BY_DEFAULT: SortBy = {
 const activeColumns = useStorage('tableViewColumns', {...ACTIVE_COLUMNS_DEFAULT})
 const sortBy = useStorage<SortBy>('tableViewSortBy', {...SORT_BY_DEFAULT})
 
+const sortByDefault = computed<SortBy>(() => {
+	const project = projectStore.projects[props.projectId]
+	const view = project?.views?.find(v => v.id === props.viewId)
+	return sortByFromViewFilter(view?.filter) ?? sortBy.value
+})
+
 const taskList = useTaskList(
 	() => props.projectId, 
 	() => props.viewId, 
-	sortBy.value,
+	() => sortByDefault.value,
 	() => ['comment_count', 'is_unread'],
 )
 

--- a/frontend/src/components/project/views/ViewEditForm.vue
+++ b/frontend/src/components/project/views/ViewEditForm.vue
@@ -1,10 +1,17 @@
 <script setup lang="ts">
-import {onBeforeMount, ref} from 'vue'
+import {computed, onBeforeMount, ref} from 'vue'
+import {useI18n} from 'vue-i18n'
 
 import type {IProjectView} from '@/modelTypes/IProjectView'
 import type {IFilters} from '@/modelTypes/ISavedFilter'
 
 import {hasFilterQuery, transformFilterStringForApi, transformFilterStringFromApi} from '@/helpers/filters'
+import {
+	decodeSortSelection,
+	encodeSortSelection,
+	sortByFromViewFilter,
+	viewFilterSortFromSortBy,
+} from '@/helpers/viewSort'
 import {useLabelStore} from '@/stores/labels'
 import {useProjectStore} from '@/stores/projects'
 
@@ -29,21 +36,82 @@ const emit = defineEmits<{
 }>()
 
 const view = ref<IProjectView>()
+const {t} = useI18n({useScope: 'global'})
 
 const labelStore = useLabelStore()
 const projectStore = useProjectStore()
 
+const MANUAL_SORT = 'position:asc'
+
+const sortOptions = computed(() => {
+	const manual = {value: MANUAL_SORT, label: t('sorting.manually')}
+	const rest = [
+		{value: 'title:asc', label: t('sorting.options.titleAsc')},
+		{value: 'title:desc', label: t('sorting.options.titleDesc')},
+		{value: 'priority:desc', label: t('sorting.options.priorityDesc')},
+		{value: 'priority:asc', label: t('sorting.options.priorityAsc')},
+		{value: 'due_date:asc', label: t('sorting.options.dueDateAsc')},
+		{value: 'due_date:desc', label: t('sorting.options.dueDateDesc')},
+		{value: 'start_date:asc', label: t('sorting.options.startDateAsc')},
+		{value: 'start_date:desc', label: t('sorting.options.startDateDesc')},
+		{value: 'end_date:asc', label: t('sorting.options.endDateAsc')},
+		{value: 'end_date:desc', label: t('sorting.options.endDateDesc')},
+		{value: 'percent_done:desc', label: t('sorting.options.percentDoneDesc')},
+		{value: 'percent_done:asc', label: t('sorting.options.percentDoneAsc')},
+		{value: 'created:desc', label: t('sorting.options.createdDesc')},
+		{value: 'created:asc', label: t('sorting.options.createdAsc')},
+		{value: 'updated:desc', label: t('sorting.options.updatedDesc')},
+		{value: 'updated:asc', label: t('sorting.options.updatedAsc')},
+	].sort((a, b) => a.label.localeCompare(b.label))
+
+	return [manual, ...rest]
+})
+
+const showDefaultSort = computed(() =>
+	view.value?.viewKind === 'list' || view.value?.viewKind === 'table',
+)
+
+const defaultSortSelection = computed({
+	get() {
+		return encodeSortSelection(sortByFromViewFilter(view.value?.filter), MANUAL_SORT)
+	},
+	set(value: string) {
+		if (!view.value?.filter) {
+			return
+		}
+		const sort = decodeSortSelection(value)
+		const {sort_by, order_by} = viewFilterSortFromSortBy(sort)
+		view.value.filter.sort_by = sort_by
+		view.value.filter.order_by = order_by
+	},
+})
+
+function readSortArrays(filterInput: IFilters): Pick<IFilters, 'sort_by' | 'order_by'> {
+	const raw = filterInput as IFilters & {
+		sortBy?: IFilters['sort_by']
+		orderBy?: IFilters['order_by']
+	}
+	return {
+		sort_by: raw.sort_by ?? raw.sortBy ?? [],
+		order_by: raw.order_by ?? raw.orderBy ?? [],
+	}
+}
+
 onBeforeMount(() => {
-	const transformFilterFromApi = (filterInput: IFilters): IFilter => {
+	const transformFilterFromApi = (filterInput: IFilters): IFilters => {
 		const filterString = transformFilterStringFromApi(
 			filterInput.filter,
 			labelId => labelStore.getLabelById(labelId)?.title || null,
 			projectId => projectStore.projects[projectId]?.title || null,
 		)
 		
+		const {sort_by, order_by} = readSortArrays(filterInput)
 		const filter: IFilters = {
 			filter: '',
 			s: '',
+			sort_by,
+			order_by,
+			filter_include_nulls: false,
 		}
 		if (hasFilterQuery(filterString)) {
 			filter.filter = filterString
@@ -74,8 +142,14 @@ onBeforeMount(() => {
 
 	const transformed = {
 		...props.modelValue,
-		filter: transformFilterFromApi(props.modelValue.filter),
-		bucketConfiguration: props.modelValue.bucketConfiguration.map(bc => ({
+		filter: transformFilterFromApi(props.modelValue.filter ?? {
+			sort_by: [],
+			order_by: [],
+			filter: '',
+			filter_include_nulls: false,
+			s: '',
+		}),
+		bucketConfiguration: (props.modelValue.bucketConfiguration || []).map(bc => ({
 			title: bc.title,
 			filter: transformFilterFromApi(bc.filter),
 		})),
@@ -96,8 +170,19 @@ function save() {
 				return found?.id || null
 			},
 		)
+		const {sort_by, order_by} = readSortArrays(filterInput || {
+			sort_by: [],
+			order_by: [],
+			filter: '',
+			filter_include_nulls: false,
+			s: '',
+		})
 		const filter: IFilters = {
 			filter_include_nulls: filterInput?.filter_include_nulls ?? false,
+			sort_by,
+			order_by,
+			filter: '',
+			s: '',
 		}
 		if (hasFilterQuery(filterString)) {
 			filter.filter = filterString
@@ -110,7 +195,7 @@ function save() {
 
 	emit('update:modelValue', {
 		...view.value,
-		filter: transformFilterForApi(view.value?.filter),
+		filter: transformFilterForApi(view.value?.filter as IFilters),
 		bucketConfiguration: view.value?.bucketConfiguration.map(bc => ({
 			title: bc.title,
 			filter: transformFilterForApi(bc.filter),
@@ -195,6 +280,35 @@ function handleBubbleSave() {
 			>
 				{{ $t('filters.attributes.includeNulls') }}
 			</FancyCheckbox>
+		</div>
+
+		<div
+			v-if="showDefaultSort"
+			class="field mbe-3"
+		>
+			<label
+				class="label"
+				for="defaultSort"
+			>
+				{{ $t('project.views.defaultSort') }}
+			</label>
+			<p class="is-size-7 has-text-grey mbe-2">
+				{{ $t('project.views.defaultSortDescription') }}
+			</p>
+			<div class="select is-fullwidth">
+				<select
+					id="defaultSort"
+					v-model="defaultSortSelection"
+				>
+					<option
+						v-for="o in sortOptions"
+						:key="o.value"
+						:value="o.value"
+					>
+						{{ o.label }}
+					</option>
+				</select>
+			</div>
 		</div>
 
 		<div
@@ -283,7 +397,7 @@ function handleBubbleSave() {
 					<XButton
 						variant="secondary"
 						icon="plus"
-						@click="() => view.bucketConfiguration.push({title: '', filter: {filter: '', filter_include_nulls: false}})"
+						@click="() => view.bucketConfiguration.push({title: '', filter: {filter: '', filter_include_nulls: false, sort_by: [], order_by: [], s: ''}})"
 					>
 						{{ $t('project.kanban.addBucket') }}
 					</XButton>

--- a/frontend/src/composables/useTaskList.ts
+++ b/frontend/src/composables/useTaskList.ts
@@ -102,16 +102,26 @@ function formatSortOrder(sortBy, params) {
 
 /**
  * This mixin provides a base set of methods and properties to get tasks.
+ *
+ * `sortByDefaultGetter` may return a per-view default (from project view
+ * settings). Prefer a getter so list/table components that survive project
+ * switches still pick up the active view's saved sort.
  */
 export function useTaskList(
 	projectIdGetter: ComputedGetter<IProject['id']>,
 	projectViewIdGetter: ComputedGetter<IProjectView['id']>,
-	sortByDefault: SortBy = SORT_BY_DEFAULT,
+	sortByDefaultGetter: ComputedGetter<SortBy> | SortBy = () => SORT_BY_DEFAULT,
 	expandGetter: ComputedGetter<ExpandTaskFilterParam> = () => 'subtasks',
 ) {
 	
 	const projectId = computed(() => projectIdGetter())
 	const projectViewId = computed(() => projectViewIdGetter())
+	const sortByDefault = computed<SortBy>(() => {
+		if (typeof sortByDefaultGetter === 'function') {
+			return {...sortByDefaultGetter()}
+		}
+		return {...sortByDefaultGetter}
+	})
 
 	const router = useRouter()
 	const viewFiltersStore = useViewFiltersStore()
@@ -133,11 +143,11 @@ export function useTaskList(
 	const sortBy = computed<SortBy>({
 		get() {
 			const raw = sortQuery.value as string | undefined
-			if (!raw) return {...sortByDefault}
-			return parseSortQuery(raw, sortByDefault)
+			if (!raw) return {...sortByDefault.value}
+			return parseSortQuery(raw, sortByDefault.value)
 		},
 		set(val: SortBy) {
-			sortQuery.value = serializeSortBy(val, sortByDefault) || undefined
+			sortQuery.value = serializeSortBy(val, sortByDefault.value) || undefined
 		},
 	})
 

--- a/frontend/src/helpers/viewSort.test.ts
+++ b/frontend/src/helpers/viewSort.test.ts
@@ -1,0 +1,58 @@
+import {describe, expect, it} from 'vitest'
+
+import {
+	decodeSortSelection,
+	encodeSortSelection,
+	sortByFromViewFilter,
+	viewFilterSortFromSortBy,
+} from './viewSort'
+
+describe('sortByFromViewFilter', () => {
+	it('returns null when there is no sort', () => {
+		expect(sortByFromViewFilter(undefined)).toBeNull()
+		expect(sortByFromViewFilter({
+			sort_by: [],
+			order_by: [],
+			filter: '',
+			filter_include_nulls: false,
+			s: '',
+		})).toBeNull()
+	})
+
+	it('reads snake_case sort arrays from the API', () => {
+		expect(sortByFromViewFilter({
+			sort_by: ['due_date', 'id'],
+			order_by: ['asc', 'asc'],
+			filter: '',
+			filter_include_nulls: false,
+			s: '',
+		})).toEqual({due_date: 'asc'})
+	})
+
+	it('reads camelCase sort arrays from assignData', () => {
+		expect(sortByFromViewFilter({
+			sortBy: ['priority'],
+			orderBy: ['desc'],
+			filter: '',
+			filter_include_nulls: false,
+			s: '',
+		} as never)).toEqual({priority: 'desc'})
+	})
+})
+
+describe('viewFilterSortFromSortBy / encodeSortSelection', () => {
+	it('round-trips a primary sort selection', () => {
+		const sort = decodeSortSelection('due_date:asc')
+		expect(sort).toEqual({due_date: 'asc'})
+		expect(viewFilterSortFromSortBy(sort)).toEqual({
+			sort_by: ['due_date'],
+			order_by: ['asc'],
+		})
+		expect(encodeSortSelection(sort)).toBe('due_date:asc')
+	})
+
+	it('treats position as manual', () => {
+		expect(encodeSortSelection({position: 'asc'})).toBe('position:asc')
+		expect(encodeSortSelection(null)).toBe('position:asc')
+	})
+})

--- a/frontend/src/helpers/viewSort.ts
+++ b/frontend/src/helpers/viewSort.ts
@@ -1,0 +1,81 @@
+import type {IFilters} from '@/modelTypes/ISavedFilter'
+import type {SortBy, Order} from '@/composables/useTaskList'
+
+/**
+ * Build a SortBy object from a view's saved filter.sort_by / order_by.
+ * Handles both snake_case (API) and camelCase (AbstractModel.assignData) keys.
+ * Returns null when the view has no meaningful default sort.
+ */
+export function sortByFromViewFilter(filter: IFilters | undefined | null): SortBy | null {
+	if (!filter) {
+		return null
+	}
+
+	const raw = filter as IFilters & {
+		sortBy?: string[]
+		orderBy?: string[]
+	}
+	const sortBy = raw.sort_by ?? raw.sortBy ?? []
+	const orderBy = raw.order_by ?? raw.orderBy ?? []
+
+	if (!Array.isArray(sortBy) || sortBy.length === 0) {
+		return null
+	}
+
+	const result: SortBy = {}
+	for (let i = 0; i < sortBy.length; i++) {
+		const field = sortBy[i]
+		if (!field || field === 'id') {
+			// id is always appended last by formatSortOrder; skip as a sole primary
+			continue
+		}
+		const order = (orderBy[i] === 'desc' ? 'desc' : 'asc') as Order
+		;(result as Record<string, Order>)[field] = order
+	}
+
+	return Object.keys(result).length > 0 ? result : null
+}
+
+/**
+ * Serialize a SortBy object into the IFilters sort_by / order_by arrays
+ * stored on a project view.
+ */
+export function viewFilterSortFromSortBy(sortBy: SortBy): Pick<IFilters, 'sort_by' | 'order_by'> {
+	const keys = Object.keys(sortBy) as (keyof SortBy)[]
+	const sort_by: IFilters['sort_by'] = []
+	const order_by: IFilters['order_by'] = []
+
+	for (const key of keys) {
+		const order = sortBy[key]
+		if (!order || order === 'none') {
+			continue
+		}
+		sort_by.push(key as IFilters['sort_by'][number])
+		order_by.push(order)
+	}
+
+	return {sort_by, order_by}
+}
+
+/**
+ * Encode a single primary sort selection as used by SortPopup / ViewEditForm
+ * (`field:order`, with `position:asc` meaning manual).
+ */
+export function encodeSortSelection(sortBy: SortBy | null | undefined, manual = 'position:asc'): string {
+	if (!sortBy) {
+		return manual
+	}
+	const key = Object.keys(sortBy)[0]
+	if (!key || key === 'position') {
+		return manual
+	}
+	const order = (sortBy as Record<string, Order>)[key] ?? 'asc'
+	return `${key}:${order}`
+}
+
+export function decodeSortSelection(value: string): SortBy {
+	const [field, order] = value.split(':') as [string, Order]
+	const sort: SortBy = {}
+	;(sort as Record<string, Order>)[field || 'position'] = order === 'desc' ? 'desc' : 'asc'
+	return sort
+}

--- a/frontend/src/i18n/lang/en.json
+++ b/frontend/src/i18n/lang/en.json
@@ -561,6 +561,8 @@
       "bucketConfig": "Bucket configuration",
       "bucketConfigManual": "Manual",
       "filter": "Filter",
+      "defaultSort": "Default sort",
+      "defaultSortDescription": "Used when opening this view with no sort in the URL. Everyone with access to the project shares this default.",
       "create": "Create view",
       "createSuccess": "The view was created successfully.",
       "titleRequired": "Please provide a title.",

--- a/frontend/src/modelTypes/ISavedFilter.ts
+++ b/frontend/src/modelTypes/ISavedFilter.ts
@@ -2,8 +2,23 @@ import type {IAbstract} from './IAbstract'
 import type {IUser} from './IUser'
 
 // FIXME: what makes this different from TaskFilterParams?
+export type FilterSortField =
+	| 'id'
+	| 'index'
+	| 'done'
+	| 'title'
+	| 'priority'
+	| 'due_date'
+	| 'start_date'
+	| 'end_date'
+	| 'percent_done'
+	| 'created'
+	| 'updated'
+	| 'done_at'
+	| 'position'
+
 export interface IFilters {
-	sort_by: ('start_date' | 'done' | 'id' | 'position')[],
+	sort_by: FilterSortField[],
 	order_by: ('asc' | 'desc')[],
 	filter: string,
 	filter_include_nulls: boolean,

--- a/frontend/src/models/projectView.ts
+++ b/frontend/src/models/projectView.ts
@@ -1,4 +1,5 @@
 import type {IProjectView, ProjectViewBucketConfigurationMode, ProjectViewKind} from '@/modelTypes/IProjectView'
+import type {IFilters} from '@/modelTypes/ISavedFilter'
 import AbstractModel from '@/models/abstractModel'
 
 export default class ProjectViewModel extends AbstractModel<IProjectView> implements IProjectView {
@@ -7,7 +8,7 @@ export default class ProjectViewModel extends AbstractModel<IProjectView> implem
 	projectId = 0
 	viewKind: ProjectViewKind =  'list'
 
-	filter: IProjectView['filters'] = {
+	filter: IFilters = {
 		sort_by: [],
 		order_by: [],
 		filter: '',
@@ -34,9 +35,11 @@ export default class ProjectViewModel extends AbstractModel<IProjectView> implem
 	}
 
 	static createWithDefaultFilter(data: Partial<IProjectView> = {}): ProjectViewModel {
-		const defaultFilter: IProjectView['filters'] = {
-			sort_by: ['done', 'id'],
-			order_by: ['asc', 'desc'],
+		// Do not bake a default sort here — once ViewEditForm preserves sort_by,
+		// a done/id sort would override manual (position) ordering for new views.
+		const defaultFilter: IFilters = {
+			sort_by: [],
+			order_by: [],
 			filter: 'done = false',
 			filter_include_nulls: true,
 			s: '',

--- a/pkg/db/fixtures/project_views.yml
+++ b/pkg/db/fixtures/project_views.yml
@@ -1015,3 +1015,11 @@
   filter: '{"filter":"start_date > ''2018-12-11T03:46:40+00:00'' || end_date < ''2018-12-13T11:20:01+00:00''","filter_include_nulls":true}'
   updated: '2024-03-18 15:14:13'
   created: '2018-03-18 15:14:13'
+- id: 162
+  title: List with default due date sort
+  project_id: 1
+  view_kind: 0
+  position: 6
+  filter: '{"sort_by":["due_date","id"],"order_by":["asc","asc"],"filter":"","filter_include_nulls":false}'
+  updated: '2024-03-18 15:14:13'
+  created: '2018-03-18 15:14:13'

--- a/pkg/models/task_collection.go
+++ b/pkg/models/task_collection.go
@@ -343,6 +343,11 @@ func (tf *TaskCollection) ReadAll(s *xorm.Session, a web.Auth, search string, pa
 			if view.Filter.FilterIncludeNulls {
 				tf.FilterIncludeNulls = true
 			}
+
+			// Prepend request sort options so query params take precedence over
+			// the view's saved default sort (same pattern as saved filters).
+			tf.SortBy = append(tf.SortBy, view.Filter.SortBy...)
+			tf.OrderBy = append(tf.OrderBy, view.Filter.OrderBy...)
 		}
 
 		if strings.Contains(tf.Filter, taskPropertyBucketID) {

--- a/pkg/models/task_collection_test.go
+++ b/pkg/models/task_collection_test.go
@@ -1670,6 +1670,75 @@ func TestTaskCollection_ReadAll(t *testing.T) {
 			},
 		},
 		{
+			name: "order by due date from view default sort",
+			fields: fields{
+				ProjectID:     1,
+				ProjectViewID: 162,
+			},
+			args: args{
+				a: &user.User{ID: 1},
+			},
+			want: []*Task{
+				// View 162 stores sort_by due_date,id asc — same relative order as
+				// an explicit query sort, with position appended as a tiebreaker.
+				task6,
+				task5,
+				task28,
+				task1,
+				task2,
+				task3,
+				task4,
+				task7,
+				task8,
+				task9,
+				task10,
+				task11,
+				task12,
+				task27,
+				task29,
+				task30,
+				task31,
+				task33,
+				task47,
+				task48,
+			},
+		},
+		{
+			name: "query sort takes precedence over view default sort",
+			fields: fields{
+				ProjectID:     1,
+				ProjectViewID: 162,
+				SortBy:        []string{"title", "id"},
+				OrderBy:       []string{"asc", "asc"},
+			},
+			args: args{
+				a: &user.User{ID: 1},
+			},
+			want: []*Task{
+				// title asc should win over the view's due_date default
+				task48, // "Landingpages update"
+				task1,
+				task10,
+				task11,
+				task12,
+				task2,
+				task27,
+				task28,
+				task29,
+				task3,
+				task30,
+				task31,
+				task33,
+				task4,
+				task47,
+				task5,
+				task6,
+				task7,
+				task8,
+				task9,
+			},
+		},
+		{
 			name: "saved filter with sort order",
 			fields: fields{
 				ProjectID: -2,


### PR DESCRIPTION
## Summary
- Let project views save a default list/table sort under Views settings (stored on the view filter as `sort_by` / `order_by`, same shape as saved filters).
- Backend applies the view default when listing tasks; explicit URL/query sort still wins. Frontend seeds list/table from the saved default when the URL has no `?sort=`.

Closes #3289.

Related: https://community.vikunja.io/t/allow-ordering-by-due-date-in-list-view/3221

## Test plan
- [ ] Edit a List view → set Default sort to Due date (earliest) → save
- [ ] Open the view with no `?sort=` → tasks ordered by due date; Sort popup matches
- [ ] Change sort via Sort popup → URL updates; private/new session without `?sort=` falls back to view default
- [ ] `?sort=title:asc` overrides the view default
- [ ] New views stay Manual until a default sort is set

## Notes
AI-assisted implementation (Cursor), reviewed and UI-tested locally before opening this PR.
