### PR TITLE
fix(datepicker): bind range value on upcoming tasks view

### DIFF
--- a/.cursor/skills/start-dev-server/SKILL.md
+++ b/.cursor/skills/start-dev-server/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: start-dev-server
+description: >-
+  Starts the local Vikunja development stack (API + frontend Vite server).
+  Use when the user says "start dev server", "start the dev server",
+  "run local dev", or invokes this skill explicitly.
+---
+
+# Start local Vikunja dev server
+
+Bring up the API and frontend for local development. Do not ask for confirmation unless a required prerequisite is missing.
+
+## Expected endpoints
+
+| Service  | URL                        | How it runs                          |
+|----------|----------------------------|--------------------------------------|
+| API      | `http://127.0.0.1:3456`    | `./vikunja` from repo root           |
+| Frontend | `http://127.0.0.1:4173/`   | `pnpm dev` in `frontend/`            |
+
+Frontend proxies API calls via `frontend/.env.local`:
+
+```
+DEV_PROXY=http://127.0.0.1:3456
+```
+
+## Workflow
+
+1. **Check what is already running**
+   - Listeners: API `:3456`, frontend `:4173`
+   - Reuse anything already healthy; only start missing pieces
+
+2. **Ensure frontend proxy config**
+   - If `frontend/.env.local` is missing `DEV_PROXY`, create/update it to `DEV_PROXY=http://127.0.0.1:3456`
+   - Do not commit `.env.local`
+
+3. **Start API if needed**
+   - Prerequisites: `config.yml` at repo root; `vikunja` binary present (run `mage build` if missing)
+   - From repo root, background:
+     ```bash
+     ./vikunja 2>&1 | tee /tmp/vikunja-api.log
+     ```
+   - Wait until logs show the server is listening (or `:3456` is open)
+   - Use full permissions (`all`) so the process can bind and write its DB/files
+
+4. **Start frontend if needed**
+   - Prerequisites: `frontend/node_modules` (run `pnpm install` in `frontend/` if missing)
+   - From `frontend/`, background:
+     ```bash
+     pnpm dev 2>&1 | tee /tmp/vikunja-frontend.log
+     ```
+   - Wait for Vite `ready` / `Local: http://127.0.0.1:4173/`
+   - Use full permissions (`all`); sandbox often breaks `pnpm`/`vite`
+
+5. **Report to the user**
+   - Frontend URL: `http://127.0.0.1:4173/`
+   - API URL: `http://127.0.0.1:3456`
+   - Note if a service was already running vs newly started
+   - On failure, show the relevant log tail from `/tmp/vikunja-api.log` or `/tmp/vikunja-frontend.log`
+
+## Do not
+
+- Run E2E (`mage test:e2e`) or production builds for this task
+- Kill healthy existing servers unless the user asks to restart
+- Commit `.env.local`, `vikunja.db*`, or binary artifacts

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,12 @@ The project consists of:
 - `desktop/` – Electron wrapper application
 - `docs/` – Documentation website
 
+## Fork and PR Safety
+
+- **Never push commits or branches to the `upstream` remote.** Push only to `origin`, which must point to this fork.
+- Open pull requests from branches on this fork. Do not create branches or pull requests that require write access to the upstream repository.
+- Before any push, verify the destination with `git remote -v`.
+
 ## API Version Policy — new work goes to /api/v2
 
 **`/api/v1` is effectively deprecated and frozen.** It still runs and is fully supported for existing clients, but it should not grow.

--- a/frontend/src/components/date/DatepickerWithRange.test.ts
+++ b/frontend/src/components/date/DatepickerWithRange.test.ts
@@ -7,9 +7,9 @@ import en from '@/i18n/lang/en.json'
 
 const i18n = createI18n({legacy: false, locale: 'en', messages: {en}})
 
-function mountPicker() {
+function mountPicker(modelValue: {dateFrom: string | null, dateTo: string | null} = {dateFrom: '', dateTo: ''}) {
     return mount(DatepickerWithRange, {
-        props: {modelValue: {dateFrom: '', dateTo: ''}},
+        props: {modelValue},
         global: {
             plugins: [i18n],
             stubs: ['RouterLink', 'Modal', 'XButton', 'BaseButton', 'Popup', 'flat-pickr'],
@@ -49,5 +49,22 @@ describe('DatepickerWithRange predefined ranges', () => {
         await wrapper.vm.$nextTick()
         expect((wrapper.vm as any).from).toBe('')
         expect((wrapper.vm as any).to).toBe('')
+    })
+
+    it('seeds its inputs from modelValue on mount', () => {
+        const wrapper = mountPicker({dateFrom: 'now/w', dateTo: 'now/w+1w'})
+        expect((wrapper.vm as any).from).toBe('now/w')
+        expect((wrapper.vm as any).to).toBe('now/w+1w')
+    })
+
+    it('shows the matching preset name for a range restored on mount', () => {
+        const wrapper = mountPicker({dateFrom: 'now/w-1w', dateTo: 'now/w'})
+        expect((wrapper.vm as any).buttonText).toBe('Last Week')
+        expect((wrapper.vm as any).customRangeActive).toBe(false)
+    })
+
+    it('does not emit an update while seeding on mount', () => {
+        const wrapper = mountPicker({dateFrom: 'now/w', dateTo: 'now/w+1w'})
+        expect(wrapper.emitted('update:modelValue')).toBeUndefined()
     })
 })

--- a/frontend/src/components/date/DatepickerWithRange.vue
+++ b/frontend/src/components/date/DatepickerWithRange.vue
@@ -122,9 +122,11 @@ const props = defineProps<{
 }>()
 
 const emit = defineEmits<{
+	// Always the raw input strings (a datemath expression or a date), never a Date
+	// object; null for a side that's been cleared.
 	'update:modelValue': [value: {
-		dateFrom: Date | string | null,
-		dateTo: Date | string | null
+		dateFrom: string | null,
+		dateTo: string | null
 	}]
 }>()
 
@@ -160,6 +162,9 @@ watch(
 			flatpickrRange.value = `${from.value} to ${to.value}`
 		}
 	},
+	// Runs before the from/to watchers below are registered, so seeding the
+	// inputs on mount does not emit an update back to the parent.
+	{immediate: true},
 )
 
 function emitChanged() {

--- a/frontend/src/views/tasks/ShowTasks.vue
+++ b/frontend/src/views/tasks/ShowTasks.vue
@@ -41,7 +41,10 @@
 			v-if="!showAll"
 			class="show-tasks-options"
 		>
-			<DatepickerWithRange @update:modelValue="setDate">
+			<DatepickerWithRange
+				:model-value="dateRange"
+				@update:modelValue="setDate"
+			>
 				<template #trigger="{toggle}">
 					<XButton
 						variant="primary"
@@ -105,7 +108,7 @@ import {computed, ref, watch, watchEffect} from 'vue'
 import {useRoute, useRouter} from 'vue-router'
 import {useI18n} from 'vue-i18n'
 
-import {formatDate} from '@/helpers/time/formatDate'
+import {formatDate, formatISO} from '@/helpers/time/formatDate'
 import {setTitle} from '@/helpers/setTitle'
 
 import BaseButton from '@/components/base/BaseButton.vue'
@@ -162,6 +165,13 @@ setTimeout(() => showNothingToDo.value = true, 100)
 
 const showAll = computed(() => typeof props.dateFrom === 'undefined' || typeof props.dateTo === 'undefined')
 
+// Computed rather than an inline literal so the reference only changes when the
+// range does — the datepicker resyncs its inputs whenever modelValue changes.
+const dateRange = computed(() => ({
+	dateFrom: props.dateFrom ?? null,
+	dateTo: props.dateTo ?? null,
+}))
+
 const filteredLabels = computed(() => {
 	if (!props.labelIds || props.labelIds.length === 0) {
 		return []
@@ -199,16 +209,23 @@ const loading = computed(() => taskStore.isLoading || taskCollectionService.valu
 const filterIdUsedOnOverview = computed(() => authStore.settings?.frontendSettings?.filterIdUsedOnOverview)
 
 interface dateStrings {
-	dateFrom: string,
-	dateTo: string,
+	dateFrom: string | null,
+	dateTo: string | null,
+}
+
+// Datemath expressions pass through unchanged; the router hands us a Date when
+// the URL had no from/to, and that has to be serialised before going back into
+// the query or it lands there as a locale-specific string.
+function toQueryDate(date: Date | string | undefined): string | undefined {
+	return date instanceof Date ? formatISO(date) : date
 }
 
 function setDate(dates: dateStrings) {
 	router.push({
 		name: route.name as string,
 		query: {
-			from: dates.dateFrom ?? props.dateFrom,
-			to: dates.dateTo ?? props.dateTo,
+			from: dates.dateFrom ?? toQueryDate(props.dateFrom),
+			to: dates.dateTo ?? toQueryDate(props.dateTo),
 			showOverdue: props.showOverdue ? 'true' : 'false',
 			showNulls: props.showNulls ? 'true' : 'false',
 		},

--- a/frontend/src/views/time-tracking/TimeTracking.vue
+++ b/frontend/src/views/time-tracking/TimeTracking.vue
@@ -113,7 +113,7 @@
 </template>
 
 <script setup lang="ts">
-import {ref, computed, shallowReactive, watch, nextTick, onMounted} from 'vue'
+import {ref, computed, shallowReactive, watch, onMounted} from 'vue'
 import {useRoute, useRouter} from 'vue-router'
 import {useI18n} from 'vue-i18n'
 
@@ -312,16 +312,6 @@ onMounted(async () => {
 	ready.value = true
 	// One request with the fully-restored filter — no flicker through partial filters.
 	timeTrackingStore.browseEntries(filter.value)
-})
-
-// DatepickerWithRange only syncs its display from modelValue on change, and it
-// remounts each time the modal opens — re-push the value so the range shows.
-watch(filterModalOpen, open => {
-	if (open) {
-		nextTick(() => {
-			dateRange.value = {...dateRange.value}
-		})
-	}
 })
 
 watch(filterQuery, q => {

--- a/frontend/tests/e2e/task/overview.spec.ts
+++ b/frontend/tests/e2e/task/overview.spec.ts
@@ -176,3 +176,19 @@ test.describe('Home Page Task Overview', () => {
 		await expect(page.locator('.home.app-content .content')).not.toContainText('Or import your projects and tasks from other services into Vikunja:')
 	})
 })
+
+test.describe('Upcoming Tasks Date Range', () => {
+	test('Should show the range from the url in the datepicker', async ({authenticatedPage: page, apiContext}) => {
+		await seedTasks(apiContext, 5)
+
+		// '+' has to stay encoded or the query parser turns it into a space.
+		await page.goto('/tasks/by/upcoming?from=now%2Fw&to=now%2Fw%2B1w')
+
+		await page.locator('.datepicker-with-range-container').getByRole('button').first().click()
+
+		const picker = page.locator('.datepicker-with-range')
+		await expect(picker.locator('.control.is-fullwidth input').first()).toHaveValue('now/w')
+		await expect(picker.locator('.control.is-fullwidth input').nth(1)).toHaveValue('now/w+1w')
+		await expect(picker.locator('.selections button.is-active')).toHaveText('This Week')
+	})
+})


### PR DESCRIPTION
## Summary
- Bind `DatepickerWithRange`'s required `modelValue` from the upcoming tasks route so Vue stops warning and the picker reflects the active URL range on mount.
- Seed the picker's from/to inputs immediately (and drop the time-tracking remount workaround that existed only because sync was change-only).
- Add a local `start-dev-server` skill and fork/PR push-safety notes in `AGENTS.md`.

## Test plan
- [x] `pnpm test:unit --run src/components/date/DatepickerWithRange.test.ts` (6/6)
- [x] `mage test:e2e "--grep Upcoming"` (new regression: range from URL seeds the picker)
- [x] `mage test:e2e "tests/e2e/time-tracking/time-tracking.spec.ts"` (14/14, including clear-range)
- [ ] Manually open `/tasks/by/upcoming?from=now%2Fw&to=now%2Fw%2B1w`, open the datepicker, and confirm From/To show `now/w` / `now/w+1w` with **This Week** active
- [ ] Confirm the Vite console no longer logs `Missing required prop: "modelValue"` on that page


Made with [Cursor](https://cursor.com)