### PR TITLE
feat(tasks): Audio attachment preview

### DIFF
--- a/frontend/src/components/misc/Icon.ts
+++ b/frontend/src/components/misc/Icon.ts
@@ -85,6 +85,7 @@ import {
 	faUnlink,
 	faParagraph,
 	faTable,
+	faVolumeHigh,
 	faX, faArrowTurnDown, faListCheck, faXmark, faXmarksLines, faFont, faRulerHorizontal, faUnderline,
 } from '@fortawesome/free-solid-svg-icons'
 import {
@@ -193,6 +194,7 @@ library.add(faTrashAlt)
 library.add(faUser)
 library.add(faUserEdit)
 library.add(faUsers)
+library.add(faVolumeHigh)
 library.add(faArrowDownShortWide)
 library.add(faArrowUpFromBracket)
 library.add(faArrowUpShortWide)

--- a/frontend/src/components/misc/Icon.ts
+++ b/frontend/src/components/misc/Icon.ts
@@ -86,6 +86,7 @@ import {
 	faUnlink,
 	faParagraph,
 	faTable,
+	faVolumeHigh,
 	faX, faArrowTurnDown, faListCheck, faXmark, faXmarksLines, faFont, faRulerHorizontal, faUnderline,
 } from '@fortawesome/free-solid-svg-icons'
 import {
@@ -195,6 +196,7 @@ library.add(faTrashAlt)
 library.add(faUser)
 library.add(faUserEdit)
 library.add(faUsers)
+library.add(faVolumeHigh)
 library.add(faArrowDownShortWide)
 library.add(faArrowUpFromBracket)
 library.add(faArrowUpShortWide)

--- a/frontend/src/components/tasks/partials/Attachments.vue
+++ b/frontend/src/components/tasks/partials/Attachments.vue
@@ -72,6 +72,10 @@
 							{{ getHumanSize(a.file.size) }}
 						</span>
 					</p>
+					<AudioPreview
+						v-if="canPreviewAudio(a)"
+						:model-value="a"
+					/>
 					<p class="attachment-actions">
 						<BaseButton
 							v-tooltip="$t('task.attachment.downloadTooltip')"
@@ -196,7 +200,7 @@ import ProgressBar from '@/components/misc/ProgressBar.vue'
 import BaseButton from '@/components/base/BaseButton.vue'
 
 import AttachmentService from '@/services/attachment'
-import {canPreviewImage, canPreviewPdf} from '@/models/attachment'
+import {canPreviewAudio, canPreviewImage, canPreviewPdf} from '@/models/attachment'
 import {getDisplayName} from '@/models/user'
 import type {IAttachment} from '@/modelTypes/IAttachment'
 import type {ITask} from '@/modelTypes/ITask'
@@ -210,6 +214,7 @@ import {useTaskStore} from '@/stores/tasks'
 import {useI18n} from 'vue-i18n'
 import FilePreview from '@/components/tasks/partials/FilePreview.vue'
 import ImageLightbox from '@/components/misc/ImageLightbox.vue'
+import AudioPreview from '@/components/tasks/partials/AudioPreview.vue'
 
 const props = withDefaults(defineProps<{
 	task: ITask,

--- a/frontend/src/components/tasks/partials/Attachments.vue
+++ b/frontend/src/components/tasks/partials/Attachments.vue
@@ -81,6 +81,10 @@
 							{{ a.file.mime }}
 						</span>
 					</p>
+					<AudioPreview
+						v-if="canPreviewAudio(a)"
+						:model-value="a"
+					/>
 					<p class="attachment-actions">
 						<BaseButton
 							v-tooltip="$t('task.attachment.downloadTooltip')"
@@ -208,7 +212,7 @@ import ProgressBar from '@/components/misc/ProgressBar.vue'
 import BaseButton from '@/components/base/BaseButton.vue'
 
 import AttachmentService from '@/services/attachment'
-import {canPreviewImage, canPreviewPdf} from '@/models/attachment'
+import {canPreviewAudio, canPreviewImage, canPreviewPdf} from '@/models/attachment'
 import type {IAttachment} from '@/modelTypes/IAttachment'
 import type {ITask} from '@/modelTypes/ITask'
 
@@ -220,6 +224,7 @@ import {error, success} from '@/message'
 import {useTaskStore} from '@/stores/tasks'
 import {useI18n} from 'vue-i18n'
 import FilePreview from '@/components/tasks/partials/FilePreview.vue'
+import AudioPreview from '@/components/tasks/partials/AudioPreview.vue'
 
 const props = withDefaults(defineProps<{
 	task: ITask,

--- a/frontend/src/components/tasks/partials/Attachments.vue
+++ b/frontend/src/components/tasks/partials/Attachments.vue
@@ -74,6 +74,7 @@
 					</p>
 					<AudioPreview
 						v-if="canPreviewAudio(a)"
+						:ref="el => setAudioPlayerRef(a, el)"
 						:model-value="a"
 					/>
 					<p class="attachment-actions">
@@ -192,7 +193,7 @@
 </template>
 
 <script setup lang="ts">
-import {ref, shallowReactive, computed, watch, onMounted, onBeforeUnmount, type Ref} from 'vue'
+import {ref, shallowReactive, computed, watch, onMounted, onBeforeUnmount, type Ref, type ComponentPublicInstance} from 'vue'
 import {useDropZone} from '@vueuse/core'
 
 import User from '@/components/misc/User.vue'
@@ -215,6 +216,8 @@ import {useI18n} from 'vue-i18n'
 import FilePreview from '@/components/tasks/partials/FilePreview.vue'
 import ImageLightbox from '@/components/misc/ImageLightbox.vue'
 import AudioPreview from '@/components/tasks/partials/AudioPreview.vue'
+
+type AudioPreviewInstance = InstanceType<typeof AudioPreview>
 
 const props = withDefaults(defineProps<{
 	task: ITask,
@@ -452,7 +455,23 @@ onBeforeUnmount(() => {
 	closePdfPreview()
 })
 
+const audioPlayers = new Map<IAttachment['id'], AudioPreviewInstance>()
+
+function setAudioPlayerRef(attachment: IAttachment, el: Element | ComponentPublicInstance | null) {
+	if (el === null) {
+		audioPlayers.delete(attachment.id)
+		return
+	}
+
+	audioPlayers.set(attachment.id, el as AudioPreviewInstance)
+}
+
 async function viewOrDownload(attachment: IAttachment) {
+	if (canPreviewAudio(attachment) && audioPlayers.has(attachment.id)) {
+		await audioPlayers.get(attachment.id)!.play()
+		return
+	}
+
 	if (!canPreviewImage(attachment) && !canPreviewPdf(attachment)) {
 		downloadAttachment(attachment)
 		return

--- a/frontend/src/components/tasks/partials/Attachments.vue
+++ b/frontend/src/components/tasks/partials/Attachments.vue
@@ -75,7 +75,7 @@
 					<AudioPreview
 						v-if="canPreviewAudio(a)"
 						:ref="el => setAudioPlayerRef(a, el)"
-						:model-value="a"
+						:attachment="a"
 					/>
 					<p class="attachment-actions">
 						<BaseButton

--- a/frontend/src/components/tasks/partials/AudioPreview.test.ts
+++ b/frontend/src/components/tasks/partials/AudioPreview.test.ts
@@ -1,0 +1,211 @@
+import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest'
+import {nextTick} from 'vue'
+import {mount, flushPromises, type VueWrapper} from '@vue/test-utils'
+import AudioPreview from './AudioPreview.vue'
+import XButton from '@/components/input/Button.vue'
+import type {IAttachment} from '@/modelTypes/IAttachment'
+
+const {getBlobUrl} = vi.hoisted(() => ({getBlobUrl: vi.fn()}))
+const {errorMessage} = vi.hoisted(() => ({errorMessage: vi.fn()}))
+
+vi.mock('@/services/attachment', () => ({
+	default: class {
+		getBlobUrl = getBlobUrl
+	},
+}))
+
+vi.mock('@/message', () => ({error: errorMessage}))
+
+vi.mock('vue-i18n', () => ({useI18n: () => ({t: (key: string) => key})}))
+
+function attachment(name: string): IAttachment {
+	return {id: 1, taskId: 1, file: {name, mime: 'audio/mpeg'}} as unknown as IAttachment
+}
+
+const mountedPreviews: VueWrapper[] = []
+
+function mountPreview(name = 'memo.mp3') {
+	const wrapper = mount(AudioPreview, {
+		attachTo: document.body,
+		props: {attachment: attachment(name)},
+		global: {
+			components: {XButton},
+			stubs: {Icon: true, RouterLink: true},
+			mocks: {$t: (key: string) => key},
+		},
+	})
+	mountedPreviews.push(wrapper)
+	return wrapper
+}
+
+function unmountPreview(wrapper: VueWrapper) {
+	mountedPreviews.splice(mountedPreviews.indexOf(wrapper), 1)
+	wrapper.unmount()
+}
+
+async function clickPlay(wrapper: VueWrapper) {
+	await wrapper.find('button').trigger('click')
+}
+
+// The component exposes play() through defineExpose, which the wrapper type does not carry.
+function exposedPlay(wrapper: VueWrapper) {
+	return (wrapper.vm as unknown as {play: () => Promise<void>}).play()
+}
+
+function deferredBlobUrl() {
+	let resolveBlobUrl: (url: string) => void = () => {}
+	getBlobUrl.mockReturnValue(new Promise<string>(resolve => {
+		resolveBlobUrl = resolve
+	}))
+	return (url: string) => resolveBlobUrl(url)
+}
+
+let revokeObjectURL: ReturnType<typeof vi.fn<(url: string) => void>>
+
+beforeEach(() => {
+	// happy-dom lacks media methods; plain functions, not vi.fn: a shared prototype mock merges every element's calls.
+	HTMLMediaElement.prototype.play = () => Promise.resolve()
+	HTMLMediaElement.prototype.pause = () => {}
+	revokeObjectURL = vi.fn<(url: string) => void>()
+	window.URL.revokeObjectURL = revokeObjectURL
+})
+
+afterEach(() => {
+	// The "pause the other player" bookkeeping is module state, so a leftover player leaks into the next test.
+	mountedPreviews.splice(0).forEach(wrapper => wrapper.unmount())
+	getBlobUrl.mockReset()
+	errorMessage.mockReset()
+	document.body.innerHTML = ''
+})
+
+describe('AudioPreview.vue', () => {
+	it('pauses the player that was running when another one starts', async () => {
+		getBlobUrl.mockResolvedValueOnce('blob:a').mockResolvedValueOnce('blob:b')
+
+		const first = mountPreview('a.mp3')
+		const second = mountPreview('b.mp3')
+		await clickPlay(first)
+		await clickPlay(second)
+		await flushPromises()
+
+		const firstPlayer = first.find('audio').element
+		const secondPlayer = second.find('audio').element
+		const pauseFirst = vi.spyOn(firstPlayer, 'pause')
+		const pauseSecond = vi.spyOn(secondPlayer, 'pause')
+
+		firstPlayer.dispatchEvent(new Event('play'))
+		secondPlayer.dispatchEvent(new Event('play'))
+
+		expect(pauseFirst).toHaveBeenCalledTimes(1)
+		expect(pauseSecond).not.toHaveBeenCalled()
+	})
+
+	it('revokes the object url when unmounted', async () => {
+		getBlobUrl.mockResolvedValue('blob:memo')
+
+		const wrapper = mountPreview()
+		await clickPlay(wrapper)
+		await flushPromises()
+		expect(revokeObjectURL).not.toHaveBeenCalled()
+
+		unmountPreview(wrapper)
+
+		expect(revokeObjectURL).toHaveBeenCalledWith('blob:memo')
+	})
+
+	it('fetches the file once when the play button is clicked twice in a row', async () => {
+		const resolveBlobUrl = deferredBlobUrl()
+
+		const wrapper = mountPreview()
+		await clickPlay(wrapper)
+		await clickPlay(wrapper)
+
+		expect(getBlobUrl).toHaveBeenCalledTimes(1)
+
+		resolveBlobUrl('blob:memo')
+		await flushPromises()
+
+		expect(getBlobUrl).toHaveBeenCalledTimes(1)
+		expect(wrapper.find('audio').exists()).toBe(true)
+	})
+
+	it('surfaces a failed download and leaves the play button usable', async () => {
+		const downloadFailed = new Error('nope')
+		getBlobUrl.mockRejectedValueOnce(downloadFailed).mockResolvedValueOnce('blob:memo')
+
+		const wrapper = mountPreview()
+		await clickPlay(wrapper)
+		await flushPromises()
+
+		expect(errorMessage).toHaveBeenCalledWith(downloadFailed)
+		expect(wrapper.find('audio').exists()).toBe(false)
+		expect(wrapper.find('button').attributes('disabled')).toBeUndefined()
+
+		await clickPlay(wrapper)
+		await flushPromises()
+
+		expect(getBlobUrl).toHaveBeenCalledTimes(2)
+		expect(wrapper.find('audio').exists()).toBe(true)
+	})
+
+	it('brings the play button back and reports when the file cannot be decoded', async () => {
+		getBlobUrl.mockResolvedValue('blob:memo')
+
+		const wrapper = mountPreview()
+		await clickPlay(wrapper)
+		await flushPromises()
+
+		wrapper.find('audio').element.dispatchEvent(new Event('error'))
+		await nextTick()
+
+		expect(revokeObjectURL).toHaveBeenCalledWith('blob:memo')
+		expect(errorMessage).toHaveBeenCalledWith({message: 'task.attachment.audioError'})
+		expect(wrapper.find('audio').exists()).toBe(false)
+		expect(wrapper.find('button').exists()).toBe(true)
+	})
+
+	it('revokes a blob that arrives after the component was unmounted', async () => {
+		const resolveBlobUrl = deferredBlobUrl()
+
+		const wrapper = mountPreview()
+		await clickPlay(wrapper)
+		unmountPreview(wrapper)
+
+		resolveBlobUrl('blob:memo')
+		await flushPromises()
+
+		expect(revokeObjectURL).toHaveBeenCalledTimes(1)
+		expect(revokeObjectURL).toHaveBeenCalledWith('blob:memo')
+		expect(document.querySelector('audio')).toBeNull()
+	})
+
+	it('plays the mounted element when play() is called with the file already loaded', async () => {
+		getBlobUrl.mockResolvedValue('blob:memo')
+
+		const wrapper = mountPreview()
+		await clickPlay(wrapper)
+		await flushPromises()
+		const playElement = vi.spyOn(wrapper.find('audio').element, 'play')
+
+		await exposedPlay(wrapper)
+
+		expect(playElement).toHaveBeenCalledTimes(1)
+		expect(getBlobUrl).toHaveBeenCalledTimes(1)
+	})
+
+	it('does not fetch again when play() is called while the download is in flight', async () => {
+		const resolveBlobUrl = deferredBlobUrl()
+
+		const wrapper = mountPreview()
+		await clickPlay(wrapper)
+		await exposedPlay(wrapper)
+
+		expect(getBlobUrl).toHaveBeenCalledTimes(1)
+
+		resolveBlobUrl('blob:memo')
+		await flushPromises()
+
+		expect(getBlobUrl).toHaveBeenCalledTimes(1)
+		expect(wrapper.find('audio').exists()).toBe(true)
+	})
+})

--- a/frontend/src/components/tasks/partials/AudioPreview.vue
+++ b/frontend/src/components/tasks/partials/AudioPreview.vue
@@ -54,7 +54,7 @@ async function loadAudio() {
 
 	loading.value = true
 	try {
-		const url = await attachmentService.getBlobUrl(props.modelValue)
+		const url = await attachmentService.getBlobUrl(props.modelValue) as string
 		if (unmounted) {
 			window.URL.revokeObjectURL(url)
 			return
@@ -91,6 +91,20 @@ function stopOtherPlayers(e: Event) {
 	playing = player
 }
 
+async function play() {
+	if (blobUrl.value === undefined) {
+		// The element autoplays as soon as it gets the blob.
+		await loadAudio()
+		return
+	}
+
+	try {
+		await playerRef.value?.play()
+	} catch {
+		// AbortError when another player pauses this one mid-start, NotAllowedError without a user gesture - neither deserves a toast.
+	}
+}
+
 onBeforeUnmount(() => {
 	unmounted = true
 
@@ -104,6 +118,8 @@ onBeforeUnmount(() => {
 		window.URL.revokeObjectURL(blobUrl.value)
 	}
 })
+
+defineExpose({play})
 </script>
 
 <style scoped lang="scss">

--- a/frontend/src/components/tasks/partials/AudioPreview.vue
+++ b/frontend/src/components/tasks/partials/AudioPreview.vue
@@ -7,10 +7,11 @@
 		controls
 		autoplay
 		@play="stopOtherPlayers"
+		@error="onAudioError"
 	/>
 	<XButton
 		v-else
-		:disabled="attachmentService.loading"
+		:loading="loading"
 		class="audio-play"
 		icon="play"
 		variant="secondary"
@@ -27,21 +28,58 @@ let playing: HTMLAudioElement | null = null
 </script>
 
 <script setup lang="ts">
-import {onBeforeUnmount, ref, shallowReactive} from 'vue'
+import {onBeforeUnmount, ref} from 'vue'
+import {useI18n} from 'vue-i18n'
 import AttachmentService from '@/services/attachment'
 import type {IAttachment} from '@/modelTypes/IAttachment'
+import {error} from '@/message'
 
 const props = defineProps<{
 	modelValue: IAttachment
 }>()
 
-const attachmentService = shallowReactive(new AttachmentService())
+const {t} = useI18n({useScope: 'global'})
+
+const attachmentService = new AttachmentService()
 const blobUrl = ref<string | undefined>(undefined)
 const playerRef = ref<HTMLAudioElement | null>(null)
+const loading = ref(false)
+let unmounted = false
 
 // Fetched on demand: the download endpoint needs the auth header, so no plain-url streaming.
 async function loadAudio() {
-	blobUrl.value = await attachmentService.getBlobUrl(props.modelValue)
+	if (loading.value || blobUrl.value) {
+		return
+	}
+
+	loading.value = true
+	try {
+		const url = await attachmentService.getBlobUrl(props.modelValue)
+		if (unmounted) {
+			window.URL.revokeObjectURL(url)
+			return
+		}
+		blobUrl.value = url
+	} catch (e) {
+		error(e)
+	} finally {
+		loading.value = false
+	}
+}
+
+// Undecodable files only fail once the element has the blob, so swap back to the play button.
+function onAudioError() {
+	if (unmounted || blobUrl.value === undefined) {
+		return
+	}
+
+	if (playing === playerRef.value) {
+		playing = null
+	}
+
+	window.URL.revokeObjectURL(blobUrl.value)
+	blobUrl.value = undefined
+	error({message: t('task.attachment.audioError')})
 }
 
 function stopOtherPlayers() {
@@ -52,6 +90,8 @@ function stopOtherPlayers() {
 }
 
 onBeforeUnmount(() => {
+	unmounted = true
+
 	// A detached element keeps playing for as long as something references it.
 	if (playing === playerRef.value) {
 		playing?.pause()

--- a/frontend/src/components/tasks/partials/AudioPreview.vue
+++ b/frontend/src/components/tasks/partials/AudioPreview.vue
@@ -1,0 +1,52 @@
+<template>
+	<audio
+		v-if="blobUrl"
+		:src="blobUrl"
+		class="audio-player"
+		controls
+		autoplay
+	/>
+	<XButton
+		v-else
+		:disabled="attachmentService.loading"
+		class="audio-play"
+		icon="play"
+		variant="secondary"
+		:shadow="false"
+		@click="loadAudio()"
+	>
+		{{ $t('task.attachment.play') }}
+	</XButton>
+</template>
+
+<script setup lang="ts">
+import {ref, shallowReactive} from 'vue'
+import AttachmentService from '@/services/attachment'
+import type {IAttachment} from '@/modelTypes/IAttachment'
+
+const props = defineProps<{
+	modelValue: IAttachment
+}>()
+
+const attachmentService = shallowReactive(new AttachmentService())
+const blobUrl = ref<string | undefined>(undefined)
+
+// The file is only fetched on demand: the download endpoint needs the auth header, so the
+// player cannot stream from a plain url and would otherwise pull the whole file on page load.
+async function loadAudio() {
+	blobUrl.value = await attachmentService.getBlobUrl(props.modelValue)
+}
+</script>
+
+<style scoped lang="scss">
+.audio-player {
+	inline-size: 100%;
+	max-inline-size: 30rem;
+	block-size: 2.5rem;
+	margin-block: 0 1em;
+}
+
+.audio-play {
+	margin-block: 0 1em;
+}
+</style>

--- a/frontend/src/components/tasks/partials/AudioPreview.vue
+++ b/frontend/src/components/tasks/partials/AudioPreview.vue
@@ -3,7 +3,7 @@
 		v-if="blobUrl"
 		ref="playerRef"
 		:src="blobUrl"
-		:aria-label="modelValue.file.name"
+		:aria-label="attachment.file.name"
 		class="audio-player"
 		controls
 		autoplay
@@ -13,7 +13,7 @@
 	<XButton
 		v-else
 		:loading="loading"
-		:aria-label="$t('task.attachment.playFile', {file: modelValue.file.name})"
+		:aria-label="$t('task.attachment.playFile', {file: attachment.file.name})"
 		class="audio-play"
 		icon="play"
 		variant="secondary"
@@ -37,7 +37,7 @@ import type {IAttachment} from '@/modelTypes/IAttachment'
 import {error} from '@/message'
 
 const props = defineProps<{
-	modelValue: IAttachment
+	attachment: IAttachment
 }>()
 
 const {t} = useI18n({useScope: 'global'})
@@ -56,7 +56,7 @@ async function loadAudio() {
 
 	loading.value = true
 	try {
-		const url = await attachmentService.getBlobUrl(props.modelValue) as string
+		const url = await attachmentService.getBlobUrl(props.attachment) as string
 		if (unmounted) {
 			window.URL.revokeObjectURL(url)
 			return

--- a/frontend/src/components/tasks/partials/AudioPreview.vue
+++ b/frontend/src/components/tasks/partials/AudioPreview.vue
@@ -1,0 +1,78 @@
+<template>
+	<audio
+		v-if="blobUrl"
+		ref="playerRef"
+		:src="blobUrl"
+		class="audio-player"
+		controls
+		autoplay
+		@play="stopOtherPlayers"
+	/>
+	<XButton
+		v-else
+		:disabled="attachmentService.loading"
+		class="audio-play"
+		icon="play"
+		variant="secondary"
+		:shadow="false"
+		@click="loadAudio()"
+	>
+		{{ $t('task.attachment.play') }}
+	</XButton>
+</template>
+
+<script lang="ts">
+// Module scope: starting a player pauses whichever one was playing before it.
+let playing: HTMLAudioElement | null = null
+</script>
+
+<script setup lang="ts">
+import {onBeforeUnmount, ref, shallowReactive} from 'vue'
+import AttachmentService from '@/services/attachment'
+import type {IAttachment} from '@/modelTypes/IAttachment'
+
+const props = defineProps<{
+	modelValue: IAttachment
+}>()
+
+const attachmentService = shallowReactive(new AttachmentService())
+const blobUrl = ref<string | undefined>(undefined)
+const playerRef = ref<HTMLAudioElement | null>(null)
+
+// Fetched on demand: the download endpoint needs the auth header, so no plain-url streaming.
+async function loadAudio() {
+	blobUrl.value = await attachmentService.getBlobUrl(props.modelValue)
+}
+
+function stopOtherPlayers() {
+	if (playing !== null && playing !== playerRef.value) {
+		playing.pause()
+	}
+	playing = playerRef.value
+}
+
+onBeforeUnmount(() => {
+	// A detached element keeps playing for as long as something references it.
+	if (playing === playerRef.value) {
+		playing?.pause()
+		playing = null
+	}
+
+	if (blobUrl.value !== undefined) {
+		window.URL.revokeObjectURL(blobUrl.value)
+	}
+})
+</script>
+
+<style scoped lang="scss">
+.audio-player {
+	inline-size: 100%;
+	max-inline-size: 30rem;
+	block-size: 2.5rem;
+	margin-block: 0 1em;
+}
+
+.audio-play {
+	margin-block: 0 1em;
+}
+</style>

--- a/frontend/src/components/tasks/partials/AudioPreview.vue
+++ b/frontend/src/components/tasks/partials/AudioPreview.vue
@@ -3,6 +3,7 @@
 		v-if="blobUrl"
 		ref="playerRef"
 		:src="blobUrl"
+		:aria-label="modelValue.file.name"
 		class="audio-player"
 		controls
 		autoplay
@@ -12,6 +13,7 @@
 	<XButton
 		v-else
 		:loading="loading"
+		:aria-label="$t('task.attachment.playFile', {file: modelValue.file.name})"
 		class="audio-play"
 		icon="play"
 		variant="secondary"
@@ -131,6 +133,7 @@ defineExpose({play})
 }
 
 .audio-play {
+	max-inline-size: 30rem;
 	margin-block: 0 1em;
 }
 </style>

--- a/frontend/src/components/tasks/partials/AudioPreview.vue
+++ b/frontend/src/components/tasks/partials/AudioPreview.vue
@@ -59,6 +59,10 @@ onBeforeUnmount(() => {
 		playing?.pause()
 		playing = null
 	}
+
+	if (blobUrl.value !== undefined) {
+		window.URL.revokeObjectURL(blobUrl.value)
+	}
 })
 </script>
 

--- a/frontend/src/components/tasks/partials/AudioPreview.vue
+++ b/frontend/src/components/tasks/partials/AudioPreview.vue
@@ -1,10 +1,12 @@
 <template>
 	<audio
 		v-if="blobUrl"
+		ref="playerRef"
 		:src="blobUrl"
 		class="audio-player"
 		controls
 		autoplay
+		@play="stopOtherPlayers"
 	/>
 	<XButton
 		v-else
@@ -19,8 +21,14 @@
 	</XButton>
 </template>
 
+<script lang="ts">
+// Module scope, so that starting one attachment stops whichever was playing before it -
+// every player autoplays as soon as its file arrives.
+let playing: HTMLAudioElement | null = null
+</script>
+
 <script setup lang="ts">
-import {ref, shallowReactive} from 'vue'
+import {onBeforeUnmount, ref, shallowReactive} from 'vue'
 import AttachmentService from '@/services/attachment'
 import type {IAttachment} from '@/modelTypes/IAttachment'
 
@@ -30,12 +38,28 @@ const props = defineProps<{
 
 const attachmentService = shallowReactive(new AttachmentService())
 const blobUrl = ref<string | undefined>(undefined)
+const playerRef = ref<HTMLAudioElement | null>(null)
 
 // The file is only fetched on demand: the download endpoint needs the auth header, so the
 // player cannot stream from a plain url and would otherwise pull the whole file on page load.
 async function loadAudio() {
 	blobUrl.value = await attachmentService.getBlobUrl(props.modelValue)
 }
+
+function stopOtherPlayers() {
+	if (playing !== null && playing !== playerRef.value) {
+		playing.pause()
+	}
+	playing = playerRef.value
+}
+
+onBeforeUnmount(() => {
+	// A detached element keeps playing for as long as something references it.
+	if (playing === playerRef.value) {
+		playing?.pause()
+		playing = null
+	}
+})
 </script>
 
 <style scoped lang="scss">

--- a/frontend/src/components/tasks/partials/AudioPreview.vue
+++ b/frontend/src/components/tasks/partials/AudioPreview.vue
@@ -82,11 +82,13 @@ function onAudioError() {
 	error({message: t('task.attachment.audioError')})
 }
 
-function stopOtherPlayers() {
-	if (playing !== null && playing !== playerRef.value) {
+function stopOtherPlayers(e: Event) {
+	const player = e.currentTarget as HTMLAudioElement
+
+	if (playing !== null && playing !== player) {
 		playing.pause()
 	}
-	playing = playerRef.value
+	playing = player
 }
 
 onBeforeUnmount(() => {

--- a/frontend/src/components/tasks/partials/FilePreview.vue
+++ b/frontend/src/components/tasks/partials/FilePreview.vue
@@ -17,6 +17,17 @@
 		/>
 	</div>
 
+	<!-- Audio icon -->
+	<div
+		v-else-if="isAudio"
+		class="icon-wrapper"
+	>
+		<Icon
+			size="6x"
+			icon="volume-high"
+		/>
+	</div>
+
 	<!-- Fallback -->
 	<div
 		v-else
@@ -33,7 +44,7 @@
 import {computed, ref, shallowReactive, watchEffect} from 'vue'
 import AttachmentService, {PREVIEW_SIZE} from '@/services/attachment'
 import type {IAttachment} from '@/modelTypes/IAttachment'
-import {canPreviewImage, canPreviewPdf} from '@/models/attachment'
+import {canPreviewAudio, canPreviewImage, canPreviewPdf} from '@/models/attachment'
 
 const props = defineProps<{
 	modelValue?: IAttachment
@@ -42,6 +53,7 @@ const props = defineProps<{
 const attachmentService = shallowReactive(new AttachmentService())
 const blobUrl = ref<string | undefined>(undefined)
 const isPdf = computed(() => props.modelValue && canPreviewPdf(props.modelValue))
+const isAudio = computed(() => props.modelValue && canPreviewAudio(props.modelValue))
 
 watchEffect(async () => {
 	if (props.modelValue && canPreviewImage(props.modelValue)) {

--- a/frontend/src/i18n/lang/en.json
+++ b/frontend/src/i18n/lang/en.json
@@ -1111,7 +1111,8 @@
       "unsetAsCover": "Remove cover",
       "successfullyChangedCoverImage": "The cover image was successfully changed.",
       "usedAsCover": "Cover image",
-      "play": "Play"
+      "play": "Play",
+      "audioError": "Could not play this audio file."
     },
     "comment": {
       "title": "Comments",

--- a/frontend/src/i18n/lang/en.json
+++ b/frontend/src/i18n/lang/en.json
@@ -1110,7 +1110,8 @@
       "setAsCover": "Make cover",
       "unsetAsCover": "Remove cover",
       "successfullyChangedCoverImage": "The cover image was successfully changed.",
-      "usedAsCover": "Cover image"
+      "usedAsCover": "Cover image",
+      "play": "Play"
     },
     "comment": {
       "title": "Comments",

--- a/frontend/src/i18n/lang/en.json
+++ b/frontend/src/i18n/lang/en.json
@@ -1083,7 +1083,8 @@
       "setAsCover": "Make cover",
       "unsetAsCover": "Remove cover",
       "successfullyChangedCoverImage": "The cover image was successfully changed.",
-      "usedAsCover": "Cover image"
+      "usedAsCover": "Cover image",
+      "play": "Play"
     },
     "comment": {
       "title": "Comments",

--- a/frontend/src/i18n/lang/en.json
+++ b/frontend/src/i18n/lang/en.json
@@ -1112,6 +1112,7 @@
       "successfullyChangedCoverImage": "The cover image was successfully changed.",
       "usedAsCover": "Cover image",
       "play": "Play",
+      "playFile": "Play {file}",
       "audioError": "Could not play this audio file."
     },
     "comment": {

--- a/frontend/src/models/attachment.test.ts
+++ b/frontend/src/models/attachment.test.ts
@@ -1,6 +1,6 @@
 import {describe, it, expect} from 'vitest'
 
-import {canPreviewImage, canPreviewPdf, canPreview} from './attachment'
+import {canPreviewAudio, canPreviewImage, canPreviewPdf, canPreview} from './attachment'
 import type {IAttachment} from '@/modelTypes/IAttachment'
 
 function attachment(name: string, mime: string): IAttachment {
@@ -36,6 +36,24 @@ describe('canPreviewImage', () => {
 
 	it('refuses svg since it can carry script', () => {
 		expect(canPreviewImage(attachment('evil.jpg', 'image/svg+xml'))).toBe(false)
+	})
+})
+
+describe('canPreviewAudio', () => {
+	it('previews an mp3', () => {
+		expect(canPreviewAudio(attachment('memo.mp3', 'audio/mpeg'))).toBe(true)
+	})
+
+	it('previews an ogg regardless of the file name', () => {
+		expect(canPreviewAudio(attachment('19-40-43', 'audio/ogg'))).toBe(true)
+	})
+
+	it('matches the mime case-insensitively', () => {
+		expect(canPreviewAudio(attachment('memo.mp3', 'AUDIO/MPEG'))).toBe(true)
+	})
+
+	it('refuses a non-audio mime', () => {
+		expect(canPreviewAudio(attachment('memo.mp3', 'text/html'))).toBe(false)
 	})
 })
 

--- a/frontend/src/models/attachment.test.ts
+++ b/frontend/src/models/attachment.test.ts
@@ -1,6 +1,6 @@
 import {describe, it, expect} from 'vitest'
 
-import {canPreviewAudio, canPreviewImage, canPreviewPdf, canPreview} from './attachment'
+import {canPreviewAudio, canPreviewImage, canPreviewPdf} from './attachment'
 import type {IAttachment} from '@/modelTypes/IAttachment'
 
 function attachment(name: string, mime: string): IAttachment {
@@ -54,11 +54,5 @@ describe('canPreviewAudio', () => {
 
 	it('refuses a non-audio mime', () => {
 		expect(canPreviewAudio(attachment('memo.mp3', 'text/html'))).toBe(false)
-	})
-})
-
-describe('canPreview', () => {
-	it('refuses html bytes disguised as a pdf', () => {
-		expect(canPreview(attachment('evil.pdf', 'text/html'))).toBe(false)
 	})
 })

--- a/frontend/src/models/attachment.ts
+++ b/frontend/src/models/attachment.ts
@@ -22,6 +22,12 @@ export function canPreviewPdf(attachment: IAttachment): boolean {
 		&& attachment.file.mime.toLowerCase() === 'application/pdf'
 }
 
+// No suffix allowlist here, unlike images and pdfs: the mime is sniffed server-side and
+// an <audio> element cannot execute a mistyped file, so there is nothing to harden against.
+export function canPreviewAudio(attachment: IAttachment): boolean {
+	return attachment.file.mime.toLowerCase().startsWith('audio/')
+}
+
 export function canPreview(attachment: IAttachment): boolean {
 	return canPreviewImage(attachment) || canPreviewPdf(attachment)
 }

--- a/frontend/src/models/attachment.ts
+++ b/frontend/src/models/attachment.ts
@@ -27,10 +27,6 @@ export function canPreviewAudio(attachment: IAttachment): boolean {
 	return attachment.file.mime.toLowerCase().startsWith('audio/')
 }
 
-export function canPreview(attachment: IAttachment): boolean {
-	return canPreviewImage(attachment) || canPreviewPdf(attachment)
-}
-
 export default class AttachmentModel extends AbstractModel<IAttachment> implements IAttachment {
 	id = 0
 	taskId = 0

--- a/frontend/src/models/attachment.ts
+++ b/frontend/src/models/attachment.ts
@@ -22,6 +22,11 @@ export function canPreviewPdf(attachment: IAttachment): boolean {
 		&& attachment.file.mime.toLowerCase() === 'application/pdf'
 }
 
+// No suffix allowlist, unlike images/pdfs: the blob is typed from the server's sniffed Content-Type, and an <audio> element neither parses HTML nor executes script.
+export function canPreviewAudio(attachment: IAttachment): boolean {
+	return attachment.file.mime.toLowerCase().startsWith('audio/')
+}
+
 export function canPreview(attachment: IAttachment): boolean {
 	return canPreviewImage(attachment) || canPreviewPdf(attachment)
 }


### PR DESCRIPTION
**Play audio attachments right in the task**

Audio files attached to a task now have a Play button next to them in the attachment list. Clicking it loads the file and shows a normal audio player inline — no need to download the file first or open it in another app.

Issue and demonstration screenshot: https://community.vikunja.io/t/audio-player-for-attachments/4727

AI Disclosure: This pull request was developed with AI assistance.