### PR TITLE
fix(tasks): don't skip a month when a monthly task repeats from the 29th-31st

### DIFF
--- a/pkg/models/tasks.go
+++ b/pkg/models/tasks.go
@@ -1718,8 +1718,22 @@ func (t *Task) moveTaskToDefaultBuckets(s *xorm.Session, a web.Auth, views []*Pr
 	return nil
 }
 
+// addOneMonthToDate advances d into the next calendar month, clamping the day
+// to that month's last day. time.Date normalizes an out-of-range day instead,
+// which made a monthly task due Jan 31 repeat to Mar 3 - skipping February
+// entirely and permanently shifting the day of month.
 func addOneMonthToDate(d time.Time) time.Time {
-	return time.Date(d.Year(), d.Month()+1, d.Day(), d.Hour(), d.Minute(), d.Second(), d.Nanosecond(), config.GetTimeZone())
+	tz := config.GetTimeZone()
+
+	// Day 0 of the month after next is the last day of next month.
+	lastDayOfNextMonth := time.Date(d.Year(), d.Month()+2, 0, 0, 0, 0, 0, tz).Day()
+
+	day := d.Day()
+	if day > lastDayOfNextMonth {
+		day = lastDayOfNextMonth
+	}
+
+	return time.Date(d.Year(), d.Month()+1, day, d.Hour(), d.Minute(), d.Second(), d.Nanosecond(), tz)
 }
 
 // addRepeatIntervalToTime advances t by whole multiples of duration until

--- a/pkg/models/tasks_test.go
+++ b/pkg/models/tasks_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"code.vikunja.io/api/pkg/config"
 	"code.vikunja.io/api/pkg/db"
 	"code.vikunja.io/api/pkg/events"
 	"code.vikunja.io/api/pkg/files"
@@ -1139,6 +1140,21 @@ func TestUpdateDone(t *testing.T) {
 				assert.Equal(t, oldDiff, newTask.EndDate.Sub(newTask.StartDate))
 				assert.False(t, newTask.Done)
 			})
+			t.Run("due date at the end of a long month", func(t *testing.T) {
+				oldTask := &Task{
+					Done:       false,
+					RepeatMode: TaskRepeatModeMonth,
+					DueDate:    time.Date(2026, 1, 31, 9, 0, 0, 0, config.GetTimeZone()),
+				}
+				newTask := &Task{
+					Done: true,
+				}
+
+				updateDone(oldTask, newTask)
+
+				assert.Equal(t, time.Date(2026, 2, 28, 9, 0, 0, 0, config.GetTimeZone()), newTask.DueDate)
+				assert.False(t, newTask.Done)
+			})
 		})
 		t.Run("reset checklist on recurrence", func(t *testing.T) {
 			const checked = `before<ul data-type="taskList"><li data-checked="true" data-type="taskItem"><label><input type="checkbox" checked="checked"><span></span></label><div><p>Item</p></li></ul>after`
@@ -1180,6 +1196,27 @@ func TestUpdateDone(t *testing.T) {
 			assert.Equal(t, checked, newTask.Description)
 		})
 	})
+}
+
+func Test_addOneMonthToDate(t *testing.T) {
+	tz := config.GetTimeZone()
+	tests := []struct {
+		name string
+		date time.Time
+		want time.Time
+	}{
+		{"same day next month", time.Date(2026, 5, 15, 10, 30, 0, 0, tz), time.Date(2026, 6, 15, 10, 30, 0, 0, tz)},
+		{"clamped to a shorter month", time.Date(2026, 1, 31, 9, 0, 0, 0, tz), time.Date(2026, 2, 28, 9, 0, 0, 0, tz)},
+		{"clamped to a leap february", time.Date(2024, 1, 30, 9, 0, 0, 0, tz), time.Date(2024, 2, 29, 9, 0, 0, 0, tz)},
+		{"clamped to a 30 day month", time.Date(2026, 3, 31, 9, 0, 0, 0, tz), time.Date(2026, 4, 30, 9, 0, 0, 0, tz)},
+		{"across the year boundary", time.Date(2026, 12, 31, 9, 0, 0, 0, tz), time.Date(2027, 1, 31, 9, 0, 0, 0, tz)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, addOneMonthToDate(tt.date))
+		})
+	}
 }
 
 func TestTask_RepeatAfterCap(t *testing.T) {


### PR DESCRIPTION
`addOneMonthToDate` passes `d.Month()+1` with the original day into `time.Date`, which normalizes an out-of-range day forward rather than clamping it.

A task with repeat mode "Monthly" and a due date of Jan 31 gets a new due date of **Mar 3** — February is skipped, and the day of month stays shifted for every occurrence after that (Apr 3, May 3, ...). Same for Mar 31 -> May 1 and May 31 -> Jul 1. It applies to the reminders, start date and end date of the mode too.

This clamps the day to the last day of the target month instead, so Jan 31 repeats to Feb 28 (Feb 29 in a leap year). That matches the "Monthly" label in the UI, and the `FREQ=MONTHLY;BYMONTHDAY=<n>` rule the CalDAV export already emits for this mode — under RFC 5545 an occurrence can never land in the month after next.

Added a table test for `addOneMonthToDate` (short month, leap February, 30-day month, year boundary) and an `updateDone` case for the end-of-month due date. Both fail on main and pass with the fix; the rest of `pkg/models` is unaffected — no fixture uses `repeat_mode: 1`.

I'm aware of #3071 replacing this code path for 3.0.0. Filing anyway since the current behaviour ships until then — happy to close it if you'd rather not carry the change.

AI disclosure: written with Claude Code, reviewed and tested before opening.
