### PR TITLE
fix(frontend): make the editor toolbar fit on a single line

### DIFF
--- a/frontend/src/components/input/editor/EditorToolbar.vue
+++ b/frontend/src/components/input/editor/EditorToolbar.vue
@@ -498,27 +498,30 @@ function setLink(event: MouseEvent) {
 	background: var(--white);
 	border: 1px solid var(--grey-200);
 	user-select: none;
-	padding: .5rem;
+	padding: .25rem .375rem;
 	border-radius: $radius;
 	display: flex;
-	flex-wrap: wrap;
+	flex-wrap: nowrap;
+	align-items: center;
+	gap: .125rem;
+}
 
-	> * + * {
-		border-inline-start: 1px solid var(--grey-200);
-		margin-inline-start: 6px;
-		padding-inline-start: 6px;
-	}
+.editor-toolbar__segment {
+	display: contents;
 }
 
 .editor-toolbar__button {
-	min-inline-size: 2rem;
-	block-size: 2rem;
+	min-inline-size: 1.625rem;
+	block-size: 1.625rem;
 	border-radius: $radius;
 	border: 1px solid transparent;
 	color: var(--grey-700);
 	transition: all $transition;
 	background: transparent;
-	margin-inline-end: .25rem;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	padding: 0;
 
 	&:hover {
 		background: var(--grey-100);
@@ -527,11 +530,12 @@ function setLink(event: MouseEvent) {
 
 	.icon {
 		position: relative;
+		font-size: .8125rem;
 
 		.icon__lower-text {
-			font-size: .75rem;
+			font-size: .625rem;
 			position: absolute;
-			inset-block-end: -3px;
+			inset-block-end: -2px;
 			inset-inline-end: -2px;
 			font-weight: bold;
 		}
@@ -539,11 +543,12 @@ function setLink(event: MouseEvent) {
 }
 
 .editor-toolbar__table-buttons {
-	margin-block-start: .5rem;
+	margin-block-start: .25rem;
+	display: flex;
+	flex-wrap: wrap;
+	gap: .25rem;
 
 	> .editor-toolbar__button {
-		margin-inline-end: .5rem;
-		margin-block-end: .5rem;
 		padding: 0 .25rem;
 		border: 1px solid var(--grey-400);
 		font-size: .75rem;

--- a/frontend/src/components/input/editor/TipTap.vue
+++ b/frontend/src/components/input/editor/TipTap.vue
@@ -1038,6 +1038,9 @@ watch(
 .tiptap__editor {
 	&.tiptap__editor-is-edit-enabled {
 		min-block-size: 10rem;
+		background: var(--grey-200);
+		border: 1px solid var(--grey-300);
+		border-radius: $radius;
 
 		.ProseMirror {
 			padding: .5rem;


### PR DESCRIPTION
## Summary

The TipTap editor toolbar wraps onto a second line in narrow containers, pushing later buttons (undo/redo, table) off-screen. This compacts it to always fit on one line:

- Removed per-segment separators; segments become invisible layout containers (`display: contents`)
- Smaller buttons (2rem → 1.625rem) and icons
- `flex-wrap: nowrap` with `gap: .125rem`
- Table option buttons now flow properly in their own wrapped row

Old
<img width="524" height="496" alt="image" src="https://github.com/user-attachments/assets/9c6299c2-bfb8-4862-8df0-c88e05c07236" />



New

<img width="512" height="519" alt="image" src="https://github.com/user-attachments/assets/8bde03fd-e6ec-4a5c-b2ef-a4c29b1b8fcb" />



## Testing

- `cd frontend && pnpm lint:fix && pnpm lint:styles:fix`
- Manually verified at task-detail width in the dev build — toolbar stays on one line

## AI Disclosure

Generated with AI assistance; reviewed and verified locally.