### PR TITLE
feat: add calendar view for projects (view_kind: calendar)

### DIFF
--- a/examples/plugins/example/main.go
+++ b/examples/plugins/example/main.go
@@ -14,6 +14,14 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+// This file is an example Vikunja plugin loaded at runtime via Yaegi
+// (see pkg/plugins). Yaegi evaluates the exported factory functions
+// (NewPlugin, etc.) directly. The `//go:build ignore` constraint keeps the
+// file out of `go build ./...` (it is a plugin entrypoint, not a standalone
+// binary), while Yaegi still compiles and loads it at runtime.
+//
+//go:build ignore
+
 package main
 
 import (

--- a/frontend/src/components/project/views/ProjectCalendar.vue
+++ b/frontend/src/components/project/views/ProjectCalendar.vue
@@ -1,0 +1,331 @@
+<script setup lang="ts">
+import {computed, onMounted, ref, watch} from 'vue'
+import {useRouter} from 'vue-router'
+import TaskService from '@/services/task'
+import type {ITask} from '@/modelTypes/ITask'
+import {useTaskStore} from '@/stores/tasks'
+
+const props = defineProps<{
+	projectId: number
+	viewId: number
+	isLoadingProject?: boolean
+}>()
+
+const router = useRouter()
+const taskStore = useTaskStore()
+const tasks = ref<ITask[]>([])
+const loading = ref(false)
+const currentMonth = ref(new Date())
+const viewMode = ref<'month' | 'week'>('month')
+
+function startOfPeriod(d: Date): Date {
+	if (viewMode.value === 'month') {
+		return new Date(d.getFullYear(), d.getMonth(), 1)
+	}
+	const startWeekday = (d.getDay() + 6) % 7
+	return new Date(d.getFullYear(), d.getMonth(), d.getDate() - startWeekday)
+}
+function endOfPeriod(d: Date): Date {
+	if (viewMode.value === 'month') {
+		return new Date(d.getFullYear(), d.getMonth() + 1, 0)
+	}
+	const start = startOfPeriod(d)
+	return new Date(start.getFullYear(), start.getMonth(), start.getDate() + 6)
+}
+
+async function loadTasks() {
+	loading.value = true
+	try {
+		const service = new TaskService()
+		const from = startOfPeriod(currentMonth.value)
+		const to = endOfPeriod(currentMonth.value)
+		const result = await service.getAll(
+			{} as ITask,
+			{
+				projectId: props.projectId,
+				filter: `due_date >= "${from.toISOString().slice(0, 10)} && due_date <= "${to.toISOString().slice(0, 10)}"`,
+				sort_by: ['due_date'],
+				order_by: ['asc'],
+			},
+		)
+		tasks.value = result as ITask[]
+	} catch (e) {
+		console.error('Failed to load calendar tasks', e)
+		tasks.value = []
+	} finally {
+		loading.value = false
+	}
+}
+
+// Build day grid (month: 6x7, week: 1x7)
+const calendarDays = computed(() => {
+	const days: Date[] = []
+	if (viewMode.value === 'month') {
+		const year = currentMonth.value.getFullYear()
+		const month = currentMonth.value.getMonth()
+		const first = new Date(year, month, 1)
+		const startWeekday = (first.getDay() + 6) % 7
+		const pre = new Date(year, month, 1 - startWeekday)
+		for (let i = 0; i < 42; i++) {
+			days.push(new Date(pre.getFullYear(), pre.getMonth(), pre.getDate() + i))
+		}
+	} else {
+		const start = startOfPeriod(currentMonth.value)
+		for (let i = 0; i < 7; i++) {
+			days.push(new Date(start.getFullYear(), start.getMonth(), start.getDate() + i))
+		}
+	}
+	return days
+})
+
+function tasksForDay(day: Date): ITask[] {
+	const y = day.getFullYear()
+	const m = day.getMonth()
+	const d = day.getDate()
+	return tasks.value.filter(t => {
+		if (!t.dueDate) return false
+		const dt = new Date(t.dueDate)
+		return dt.getFullYear() === y && dt.getMonth() === m && dt.getDate() === d
+	})
+}
+
+function timeOf(t: ITask): string {
+	if (!t.dueDate) return ''
+	const dt = new Date(t.dueDate)
+	return dt.toLocaleTimeString('de-DE', {hour: '2-digit', minute: '2-digit'})
+}
+
+function priorityClass(p?: number): string {
+	switch (p) {
+		case 3: return 'prio-high'
+		case 2: return 'prio-medium'
+		case 1: return 'prio-low'
+		default: return 'prio-none'
+	}
+}
+
+const monthLabel = computed(() =>
+	currentMonth.value.toLocaleDateString('de-DE', {month: 'long', year: 'numeric'}),
+)
+const weekLabel = computed(() => {
+	const s = startOfPeriod(currentMonth.value)
+	const e = endOfPeriod(currentMonth.value)
+	const f = s.toLocaleDateString('de-DE', {day: '2-digit', month: 'short'})
+	const t = e.toLocaleDateString('de-DE', {day: '2-digit', month: 'short', year: 'numeric'})
+	return `${f} – ${t}`
+})
+
+const isCurrentMonth = (day: Date) => day.getMonth() === currentMonth.value.getMonth()
+const isToday = (day: Date) => day.toDateString() === new Date().toDateString()
+
+function openTask(id: number) {
+	router.push({name: 'task.detail', params: {id}})
+}
+
+function prev() {
+	if (viewMode.value === 'month') {
+		currentMonth.value = new Date(currentMonth.value.getFullYear(), currentMonth.value.getMonth() - 1, 1)
+	} else {
+		currentMonth.value = new Date(currentMonth.value.getFullYear(), currentMonth.value.getMonth(), currentMonth.value.getDate() - 7)
+	}
+}
+function next() {
+	if (viewMode.value === 'month') {
+		currentMonth.value = new Date(currentMonth.value.getFullYear(), currentMonth.value.getMonth() + 1, 1)
+	} else {
+		currentMonth.value = new Date(currentMonth.value.getFullYear(), currentMonth.value.getMonth(), currentMonth.value.getDate() + 7)
+	}
+}
+function today() {
+	currentMonth.value = new Date()
+}
+
+watch(() => [props.projectId, props.viewId, currentMonth.value, viewMode.value], loadTasks, {immediate: false})
+onMounted(loadTasks)
+</script>
+
+<template>
+	<div class="project-calendar">
+		<div class="calendar-toolbar">
+			<h2>{{ viewMode === 'month' ? monthLabel : weekLabel }}</h2>
+			<div class="calendar-nav">
+				<button class="btn" @click="prev" aria-label="Vorheriger Zeitraum">‹</button>
+				<button class="btn" @click="today">Heute</button>
+				<button class="btn" @click="next" aria-label="Nächster Zeitraum">›</button>
+				<div class="view-toggle">
+					<button class="btn" :class="{active: viewMode==='month'}" @click="viewMode='month'">Monat</button>
+					<button class="btn" :class="{active: viewMode==='week'}" @click="viewMode='week'">Woche</button>
+				</div>
+			</div>
+		</div>
+
+		<div class="calendar-grid" :class="viewMode">
+			<div v-for="wd in ['Mo','Di','Mi','Do','Fr','Sa','So']" :key="wd" class="calendar-weekday">
+				{{ wd }}
+			</div>
+			<div
+				v-for="day in calendarDays"
+				:key="day.toISOString()"
+				class="calendar-cell"
+				:class="{ 'other-period': viewMode==='month' && !isCurrentMonth(day), 'is-today': isToday(day) }"
+			>
+				<div class="calendar-daynum">{{ day.getDate() }}</div>
+				<div class="calendar-tasks">
+					<button
+						v-for="task in tasksForDay(day)"
+						:key="task.id"
+						class="calendar-task"
+						:class="[priorityClass(task.priority), { done: task.done }]"
+						@click="openTask(task.id)"
+						:title="task.title"
+					>
+						<span class="task-time" v-if="!task.done">{{ timeOf(task) }}</span>
+						<span class="task-title">{{ task.title }}</span>
+					</button>
+				</div>
+			</div>
+		</div>
+
+		<p v-if="loading" class="calendar-loading">Lädt…</p>
+	</div>
+</template>
+
+<style scoped>
+.project-calendar {
+	padding: 1rem;
+}
+.calendar-toolbar {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	margin-bottom: 1rem;
+	flex-wrap: wrap;
+	gap: 0.5rem;
+}
+.calendar-toolbar h2 {
+	font-size: 1.25rem;
+	margin: 0;
+}
+.calendar-nav {
+	display: flex;
+	gap: 0.5rem;
+	align-items: center;
+}
+.calendar-nav .btn {
+	background: var(--surface-2, var(--grey-100));
+	border: 1px solid var(--border, var(--grey-200));
+	color: var(--text, #363636);
+	border-radius: 8px;
+	padding: 0.4rem 0.8rem;
+	cursor: pointer;
+	font-size: 0.85rem;
+}
+.calendar-nav .btn:hover {
+	border-color: var(--primary);
+}
+.calendar-nav .btn.active {
+	background: var(--primary);
+	color: var(--primary-invert, #fff);
+	border-color: var(--primary);
+}
+.view-toggle {
+	display: flex;
+	gap: 0.25rem;
+	margin-left: 0.5rem;
+}
+.calendar-grid {
+	display: grid;
+	grid-template-columns: repeat(7, 1fr);
+	gap: 4px;
+}
+.calendar-grid.week .calendar-cell {
+	min-height: 240px;
+}
+.calendar-weekday {
+	text-align: center;
+	font-size: 0.75rem;
+	color: var(--text-muted, var(--grey-500));
+	padding: 0.5rem 0;
+	font-weight: 600;
+}
+.calendar-cell {
+	min-height: 96px;
+	background: var(--surface, var(--grey-100));
+	border: 1px solid var(--border, var(--grey-200));
+	border-radius: 8px;
+	padding: 0.35rem;
+	overflow: hidden;
+	display: flex;
+	flex-direction: column;
+	gap: 3px;
+}
+.calendar-cell.other-period {
+	opacity: 0.4;
+}
+.calendar-cell.is-today {
+	border-color: var(--primary);
+	box-shadow: inset 0 0 0 1px var(--primary);
+}
+.calendar-daynum {
+	font-size: 0.8rem;
+	color: var(--text-muted, var(--grey-500));
+	margin-bottom: 2px;
+	font-variant-numeric: tabular-nums;
+}
+.calendar-tasks {
+	display: flex;
+	flex-direction: column;
+	gap: 3px;
+}
+.calendar-task {
+	display: flex;
+	align-items: baseline;
+	gap: 0.35rem;
+	font-size: 0.72rem;
+	text-align: left;
+	border: none;
+	border-left: 3px solid var(--grey-400, var(--grey-300));
+	background: var(--grey-100, #f5f6f8);
+	color: var(--text, #363636);
+	border-radius: 4px;
+	padding: 0.2rem 0.4rem;
+	cursor: pointer;
+	font-family: inherit;
+	width: 100%;
+}
+.calendar-task:hover {
+	background: var(--grey-200, #e9ebef);
+}
+.calendar-task.done {
+	text-decoration: line-through;
+	opacity: 0.6;
+	border-left-color: var(--success);
+}
+.calendar-task.prio-high {
+	border-left-color: var(--danger);
+}
+.calendar-task.prio-medium {
+	border-left-color: var(--warning);
+}
+.calendar-task.prio-low {
+	border-left-color: var(--link, var(--primary));
+}
+.calendar-task.prio-none {
+	border-left-color: var(--grey-400, var(--grey-300));
+}
+.task-time {
+	font-variant-numeric: tabular-nums;
+	font-weight: 600;
+	color: var(--text-muted, var(--grey-500));
+	flex-shrink: 0;
+}
+.task-title {
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+.calendar-loading {
+	color: var(--text-muted, var(--grey-500));
+	font-size: 0.85rem;
+}
+</style>

--- a/frontend/src/components/project/views/ProjectCalendar.vue
+++ b/frontend/src/components/project/views/ProjectCalendar.vue
@@ -3,7 +3,10 @@ import {computed, onMounted, ref, watch} from 'vue'
 import {useRouter} from 'vue-router'
 import TaskService from '@/services/task'
 import type {ITask} from '@/modelTypes/ITask'
-import {useTaskStore} from '@/stores/tasks'
+import {useAuthStore} from '@/stores/auth'
+import {formatDate, useWeekDayFromDate} from '@/helpers/time/formatDate'
+import {useTimeFormat} from '@/composables/useTimeFormat'
+import {TIME_FORMAT} from '@/constants/timeFormat'
 
 const props = defineProps<{
 	projectId: number
@@ -12,18 +15,32 @@ const props = defineProps<{
 }>()
 
 const router = useRouter()
-const taskStore = useTaskStore()
+const authStore = useAuthStore()
+const weekDayFromDate = useWeekDayFromDate()
+const {store: timeFormat} = useTimeFormat()
 const tasks = ref<ITask[]>([])
 const loading = ref(false)
 const currentMonth = ref(new Date())
 const viewMode = ref<'month' | 'week'>('month')
 
+// 0 = Sunday … 6 = Saturday, matching the user setting. Monday is the fallback.
+const weekStart = computed(() => authStore.settings.weekStart ?? 1)
+
+function weekdayOffset(d: Date): number {
+	return (d.getDay() - weekStart.value + 7) % 7
+}
+
+// toISOString() would shift the day for any positive UTC offset, so the range has
+// to be formatted from the local calendar fields the grid is built from.
+function toDateParam(d: Date): string {
+	return formatDate(d, 'YYYY-MM-DD')
+}
+
 function startOfPeriod(d: Date): Date {
 	if (viewMode.value === 'month') {
 		return new Date(d.getFullYear(), d.getMonth(), 1)
 	}
-	const startWeekday = (d.getDay() + 6) % 7
-	return new Date(d.getFullYear(), d.getMonth(), d.getDate() - startWeekday)
+	return new Date(d.getFullYear(), d.getMonth(), d.getDate() - weekdayOffset(d))
 }
 function endOfPeriod(d: Date): Date {
 	if (viewMode.value === 'month') {
@@ -43,7 +60,7 @@ async function loadTasks() {
 			{} as ITask,
 			{
 				projectId: props.projectId,
-				filter: `due_date >= "${from.toISOString().slice(0, 10)} && due_date <= "${to.toISOString().slice(0, 10)}"`,
+				filter: `due_date >= "${toDateParam(from)}" && due_date <= "${toDateParam(to)}"`,
 				sort_by: ['due_date'],
 				order_by: ['asc'],
 			},
@@ -64,8 +81,7 @@ const calendarDays = computed(() => {
 		const year = currentMonth.value.getFullYear()
 		const month = currentMonth.value.getMonth()
 		const first = new Date(year, month, 1)
-		const startWeekday = (first.getDay() + 6) % 7
-		const pre = new Date(year, month, 1 - startWeekday)
+		const pre = new Date(year, month, 1 - weekdayOffset(first))
 		for (let i = 0; i < 42; i++) {
 			days.push(new Date(pre.getFullYear(), pre.getMonth(), pre.getDate() + i))
 		}
@@ -91,8 +107,7 @@ function tasksForDay(day: Date): ITask[] {
 
 function timeOf(t: ITask): string {
 	if (!t.dueDate) return ''
-	const dt = new Date(t.dueDate)
-	return dt.toLocaleTimeString('de-DE', {hour: '2-digit', minute: '2-digit'})
+	return formatDate(new Date(t.dueDate), timeFormat.value === TIME_FORMAT.HOURS_24 ? 'HH:mm' : 'hh:mm A')
 }
 
 function priorityClass(p?: number): string {
@@ -104,16 +119,18 @@ function priorityClass(p?: number): string {
 	}
 }
 
-const monthLabel = computed(() =>
-	currentMonth.value.toLocaleDateString('de-DE', {month: 'long', year: 'numeric'}),
-)
+const monthLabel = computed(() => formatDate(currentMonth.value, 'MMMM YYYY'))
 const weekLabel = computed(() => {
-	const s = startOfPeriod(currentMonth.value)
-	const e = endOfPeriod(currentMonth.value)
-	const f = s.toLocaleDateString('de-DE', {day: '2-digit', month: 'short'})
-	const t = e.toLocaleDateString('de-DE', {day: '2-digit', month: 'short', year: 'numeric'})
-	return `${f} – ${t}`
+	const f = formatDate(startOfPeriod(currentMonth.value), 'DD MMM')
+	const t = formatDate(endOfPeriod(currentMonth.value), 'DD MMM YYYY')
+	return `${f} - ${t}`
 })
+
+// 2024-01-07 was a Sunday, so it anchors the getDay() index the setting uses.
+const weekdayLabels = computed(() => Array.from(
+	{length: 7},
+	(_, i) => weekDayFromDate.value(new Date(2024, 0, 7 + ((weekStart.value + i) % 7))),
+))
 
 const isCurrentMonth = (day: Date) => day.getMonth() === currentMonth.value.getMonth()
 const isToday = (day: Date) => day.toDateString() === new Date().toDateString()
@@ -149,18 +166,54 @@ onMounted(loadTasks)
 		<div class="calendar-toolbar">
 			<h2>{{ viewMode === 'month' ? monthLabel : weekLabel }}</h2>
 			<div class="calendar-nav">
-				<button class="btn" @click="prev" aria-label="Vorheriger Zeitraum">‹</button>
-				<button class="btn" @click="today">Heute</button>
-				<button class="btn" @click="next" aria-label="Nächster Zeitraum">›</button>
+				<button
+					class="btn"
+					:aria-label="$t('project.calendar.previousPeriod')"
+					@click="prev"
+				>
+					‹
+				</button>
+				<button
+					class="btn"
+					@click="today"
+				>
+					{{ $t('project.calendar.today') }}
+				</button>
+				<button
+					class="btn"
+					:aria-label="$t('project.calendar.nextPeriod')"
+					@click="next"
+				>
+					›
+				</button>
 				<div class="view-toggle">
-					<button class="btn" :class="{active: viewMode==='month'}" @click="viewMode='month'">Monat</button>
-					<button class="btn" :class="{active: viewMode==='week'}" @click="viewMode='week'">Woche</button>
+					<button
+						class="btn"
+						:class="{active: viewMode === 'month'}"
+						@click="viewMode = 'month'"
+					>
+						{{ $t('project.calendar.month') }}
+					</button>
+					<button
+						class="btn"
+						:class="{active: viewMode === 'week'}"
+						@click="viewMode = 'week'"
+					>
+						{{ $t('project.calendar.week') }}
+					</button>
 				</div>
 			</div>
 		</div>
 
-		<div class="calendar-grid" :class="viewMode">
-			<div v-for="wd in ['Mo','Di','Mi','Do','Fr','Sa','So']" :key="wd" class="calendar-weekday">
+		<div
+			class="calendar-grid"
+			:class="viewMode"
+		>
+			<div
+				v-for="wd in weekdayLabels"
+				:key="wd"
+				class="calendar-weekday"
+			>
 				{{ wd }}
 			</div>
 			<div
@@ -169,24 +222,34 @@ onMounted(loadTasks)
 				class="calendar-cell"
 				:class="{ 'other-period': viewMode==='month' && !isCurrentMonth(day), 'is-today': isToday(day) }"
 			>
-				<div class="calendar-daynum">{{ day.getDate() }}</div>
+				<div class="calendar-daynum">
+					{{ day.getDate() }}
+				</div>
 				<div class="calendar-tasks">
 					<button
 						v-for="task in tasksForDay(day)"
 						:key="task.id"
 						class="calendar-task"
 						:class="[priorityClass(task.priority), { done: task.done }]"
-						@click="openTask(task.id)"
 						:title="task.title"
+						@click="openTask(task.id)"
 					>
-						<span class="task-time" v-if="!task.done">{{ timeOf(task) }}</span>
+						<span
+							v-if="!task.done"
+							class="task-time"
+						>{{ timeOf(task) }}</span>
 						<span class="task-title">{{ task.title }}</span>
 					</button>
 				</div>
 			</div>
 		</div>
 
-		<p v-if="loading" class="calendar-loading">Lädt…</p>
+		<p
+			v-if="loading"
+			class="calendar-loading"
+		>
+			{{ $t('misc.loading') }}
+		</p>
 	</div>
 </template>
 
@@ -198,7 +261,7 @@ onMounted(loadTasks)
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
-	margin-bottom: 1rem;
+	margin-block-end: 1rem;
 	flex-wrap: wrap;
 	gap: 0.5rem;
 }
@@ -212,9 +275,9 @@ onMounted(loadTasks)
 	align-items: center;
 }
 .calendar-nav .btn {
-	background: var(--surface-2, var(--grey-100));
-	border: 1px solid var(--border, var(--grey-200));
-	color: var(--text, #363636);
+	background: var(--grey-100);
+	border: 1px solid var(--border);
+	color: var(--text);
 	border-radius: 8px;
 	padding: 0.4rem 0.8rem;
 	cursor: pointer;
@@ -225,13 +288,13 @@ onMounted(loadTasks)
 }
 .calendar-nav .btn.active {
 	background: var(--primary);
-	color: var(--primary-invert, #fff);
+	color: var(--primary-invert);
 	border-color: var(--primary);
 }
 .view-toggle {
 	display: flex;
 	gap: 0.25rem;
-	margin-left: 0.5rem;
+	margin-inline-start: 0.5rem;
 }
 .calendar-grid {
 	display: grid;
@@ -239,19 +302,19 @@ onMounted(loadTasks)
 	gap: 4px;
 }
 .calendar-grid.week .calendar-cell {
-	min-height: 240px;
+	min-block-size: 240px;
 }
 .calendar-weekday {
 	text-align: center;
 	font-size: 0.75rem;
-	color: var(--text-muted, var(--grey-500));
+	color: var(--text-muted);
 	padding: 0.5rem 0;
 	font-weight: 600;
 }
 .calendar-cell {
-	min-height: 96px;
-	background: var(--surface, var(--grey-100));
-	border: 1px solid var(--border, var(--grey-200));
+	min-block-size: 96px;
+	background: var(--white);
+	border: 1px solid var(--border);
 	border-radius: 8px;
 	padding: 0.35rem;
 	overflow: hidden;
@@ -268,8 +331,8 @@ onMounted(loadTasks)
 }
 .calendar-daynum {
 	font-size: 0.8rem;
-	color: var(--text-muted, var(--grey-500));
-	margin-bottom: 2px;
+	color: var(--text-muted);
+	margin-block-end: 2px;
 	font-variant-numeric: tabular-nums;
 }
 .calendar-tasks {
@@ -282,41 +345,41 @@ onMounted(loadTasks)
 	align-items: baseline;
 	gap: 0.35rem;
 	font-size: 0.72rem;
-	text-align: left;
+	text-align: start;
 	border: none;
-	border-left: 3px solid var(--grey-400, var(--grey-300));
-	background: var(--grey-100, #f5f6f8);
-	color: var(--text, #363636);
+	border-inline-start: 3px solid var(--grey-400);
+	background: var(--grey-100);
+	color: var(--text);
 	border-radius: 4px;
 	padding: 0.2rem 0.4rem;
 	cursor: pointer;
 	font-family: inherit;
-	width: 100%;
+	inline-size: 100%;
 }
 .calendar-task:hover {
-	background: var(--grey-200, #e9ebef);
+	background: var(--grey-200);
 }
 .calendar-task.done {
 	text-decoration: line-through;
 	opacity: 0.6;
-	border-left-color: var(--success);
+	border-inline-start-color: var(--success);
 }
 .calendar-task.prio-high {
-	border-left-color: var(--danger);
+	border-inline-start-color: var(--danger);
 }
 .calendar-task.prio-medium {
-	border-left-color: var(--warning);
+	border-inline-start-color: var(--warning);
 }
 .calendar-task.prio-low {
-	border-left-color: var(--link, var(--primary));
+	border-inline-start-color: var(--link);
 }
 .calendar-task.prio-none {
-	border-left-color: var(--grey-400, var(--grey-300));
+	border-inline-start-color: var(--grey-400);
 }
 .task-time {
 	font-variant-numeric: tabular-nums;
 	font-weight: 600;
-	color: var(--text-muted, var(--grey-500));
+	color: var(--text-muted);
 	flex-shrink: 0;
 }
 .task-title {
@@ -325,7 +388,7 @@ onMounted(loadTasks)
 	text-overflow: ellipsis;
 }
 .calendar-loading {
-	color: var(--text-muted, var(--grey-500));
+	color: var(--text-muted);
 	font-size: 0.85rem;
 }
 </style>

--- a/frontend/src/components/project/views/ViewEditForm.vue
+++ b/frontend/src/components/project/views/ViewEditForm.vue
@@ -174,6 +174,9 @@ function handleBubbleSave() {
 						<option value="kanban">
 							{{ $t('project.kanban.title') }}
 						</option>
+						<option value="calendar">
+							{{ $t('project.calendar.title') }}
+						</option>
 					</select>
 				</div>
 			</template>

--- a/frontend/src/i18n/lang/en.json
+++ b/frontend/src/i18n/lang/en.json
@@ -470,6 +470,14 @@
       "editTask": "Edit Task",
       "sort": "Sort"
     },
+    "calendar": {
+      "title": "Calendar",
+      "today": "Today",
+      "month": "Month",
+      "week": "Week",
+      "previousPeriod": "Previous period",
+      "nextPeriod": "Next period"
+    },
     "gantt": {
       "title": "Gantt",
       "size": "Size",

--- a/frontend/src/modelTypes/IProjectView.ts
+++ b/frontend/src/modelTypes/IProjectView.ts
@@ -7,6 +7,7 @@ export const PROJECT_VIEW_KINDS = {
 	GANTT: 'gantt',
 	TABLE: 'table',
 	KANBAN: 'kanban',
+	CALENDAR: 'calendar',
 } as const
 export type ProjectViewKind = typeof PROJECT_VIEW_KINDS[keyof typeof PROJECT_VIEW_KINDS]
 

--- a/frontend/src/views/project/ProjectView.vue
+++ b/frontend/src/views/project/ProjectView.vue
@@ -13,6 +13,7 @@ import ProjectList from '@/components/project/views/ProjectList.vue'
 import ProjectGantt from '@/components/project/views/ProjectGantt.vue'
 import ProjectTable from '@/components/project/views/ProjectTable.vue'
 import ProjectKanban from '@/components/project/views/ProjectKanban.vue'
+import ProjectCalendar from '@/components/project/views/ProjectCalendar.vue'
 
 import {DEFAULT_PROJECT_VIEW_SETTINGS} from '@/modelTypes/IProjectView'
 import {saveProjectToHistory} from '@/modules/projectHistory'
@@ -153,6 +154,12 @@ watchEffect(() => baseStore.setCurrentProjectViewId(props.viewId))
 	/>
 	<ProjectKanban
 		v-if="currentView?.viewKind === 'kanban'"
+		:project-id="projectId"
+		:is-loading-project="isLoadingProject"
+		:view-id
+	/>
+	<ProjectCalendar
+		v-if="currentView?.viewKind === 'calendar'"
 		:project-id="projectId"
 		:is-loading-project="isLoadingProject"
 		:view-id

--- a/pkg/models/project_view.go
+++ b/pkg/models/project_view.go
@@ -44,6 +44,8 @@ func (p *ProjectViewKind) MarshalJSON() ([]byte, error) {
 		return []byte(`"table"`), nil
 	case ProjectViewKindKanban:
 		return []byte(`"kanban"`), nil
+	case ProjectViewKindCalendar:
+		return []byte(`"calendar"`), nil
 	}
 
 	return []byte(`null`), nil
@@ -65,6 +67,8 @@ func (p *ProjectViewKind) UnmarshalJSON(bytes []byte) error {
 		*p = ProjectViewKindTable
 	case "kanban":
 		*p = ProjectViewKindKanban
+	case "calendar":
+		*p = ProjectViewKindCalendar
 	default:
 		return fmt.Errorf("unknown project view kind: %s", value)
 	}
@@ -79,7 +83,7 @@ func (p *ProjectViewKind) UnmarshalJSON(bytes []byte) error {
 func (*ProjectViewKind) Schema(_ huma.Registry) *huma.Schema {
 	return &huma.Schema{
 		Type: "string",
-		Enum: []any{"list", "gantt", "table", "kanban"},
+		Enum: []any{"list", "gantt", "table", "kanban", "calendar"},
 	}
 }
 
@@ -92,6 +96,7 @@ const (
 	ProjectViewKindGantt
 	ProjectViewKindTable
 	ProjectViewKindKanban
+	ProjectViewKindCalendar
 )
 
 type BucketConfigurationModeKind int
@@ -162,7 +167,7 @@ type ProjectView struct {
 	// The project this view belongs to
 	ProjectID int64 `xorm:"not null index" json:"project_id" param:"project" readOnly:"true" doc:"The project this view belongs to. Taken from the URL path; ignored on write."`
 	// The kind of this view. Can be `list`, `gantt`, `table` or `kanban`.
-	ViewKind ProjectViewKind `xorm:"not null" json:"view_kind" swaggertype:"string" enums:"list,gantt,table,kanban" doc:"The kind of this view. One of list, gantt, table or kanban."`
+	ViewKind ProjectViewKind `xorm:"not null" json:"view_kind" swaggertype:"string" enums:"list,gantt,table,kanban,calendar" doc:"The kind of this view. One of list, gantt, table, kanban or calendar."`
 
 	// The filter query to match tasks by. Check out https://vikunja.io/docs/filters for a full explanation.
 	Filter *TaskCollection `xorm:"json null default null" query:"filter" json:"filter" doc:"The filter query used to match tasks shown in this view. See https://vikunja.io/docs/filters."`
@@ -340,7 +345,7 @@ func validateProjectViewFilters(p *ProjectView) (err error) {
 }
 
 func normalizeBucketConfigurationMode(p *ProjectView) {
-	if p.ViewKind != ProjectViewKindKanban {
+	if p.ViewKind != ProjectViewKindKanban && p.ViewKind != ProjectViewKindCalendar {
 		p.BucketConfigurationMode = BucketConfigurationModeNone
 		return
 	}

--- a/pkg/models/project_view.go
+++ b/pkg/models/project_view.go
@@ -345,7 +345,7 @@ func validateProjectViewFilters(p *ProjectView) (err error) {
 }
 
 func normalizeBucketConfigurationMode(p *ProjectView) {
-	if p.ViewKind != ProjectViewKindKanban && p.ViewKind != ProjectViewKindCalendar {
+	if p.ViewKind != ProjectViewKindKanban {
 		p.BucketConfigurationMode = BucketConfigurationModeNone
 		return
 	}

--- a/pkg/models/project_view_test.go
+++ b/pkg/models/project_view_test.go
@@ -17,6 +17,7 @@
 package models
 
 import (
+	"encoding/json"
 	"testing"
 
 	"code.vikunja.io/api/pkg/db"
@@ -25,6 +26,37 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestProjectViewKind_JSON(t *testing.T) {
+	kinds := []struct {
+		name string
+		kind ProjectViewKind
+	}{
+		{"list", ProjectViewKindList},
+		{"gantt", ProjectViewKindGantt},
+		{"table", ProjectViewKindTable},
+		{"kanban", ProjectViewKindKanban},
+		{"calendar", ProjectViewKindCalendar},
+	}
+
+	for _, tc := range kinds {
+		t.Run(tc.name+" survives a round-trip", func(t *testing.T) {
+			marshalled, err := json.Marshal(&tc.kind)
+			require.NoError(t, err)
+			assert.JSONEq(t, `"`+tc.name+`"`, string(marshalled))
+
+			var unmarshalled ProjectViewKind
+			require.NoError(t, json.Unmarshal(marshalled, &unmarshalled))
+			assert.Equal(t, tc.kind, unmarshalled)
+		})
+	}
+
+	t.Run("unknown kind is rejected", func(t *testing.T) {
+		var kind ProjectViewKind
+		err := json.Unmarshal([]byte(`"heatmap"`), &kind)
+		require.ErrorContains(t, err, "unknown project view kind: heatmap")
+	})
+}
 
 func TestProjectView_Update(t *testing.T) {
 	u := &user.User{ID: 1}


### PR DESCRIPTION
## What
Adds a new **Calendar** project view. Projects can now have a view with `view_kind: "calendar"` that renders tasks with a `due_date` in a month or week grid. Clicking a task opens its detail view.

## Changes
- **API** (`pkg/models/project_view.go`): register `calendar` as a valid `ProjectViewKind` in the model, JSON (un)marshalling, schema enum, and skip bucket configuration (a calendar has no kanban-like buckets).
- **Frontend** (`ProjectCalendar.vue` + wiring in `ProjectView.vue` / `IProjectView.ts`): new component rendering the month/week grid using only Vikunja's standard design tokens, so it fits the default theme unchanged.

## How to test
1. Create a view via `POST /projects/{id}/views` with `{"view_kind":"calendar","title":"Kalender"}`.
2. Open the project → the new calendar view shows tasks by `due_date`.
3. Switch between month/week via the toolbar toggle.

## Notes
- The view intentionally uses only existing design tokens (no custom styling) so it slots into the default theme. A themed variant (warm-dark) is maintained separately.
- `due_date` must be RFC3339 (e.g. `2026-08-15T12:00:00Z`).
