### PR TITLE
fix(examples): exclude Yaegi plugin example from 'go build ./...'

### DIFF
--- a/examples/plugins/example/main.go
+++ b/examples/plugins/example/main.go
@@ -14,6 +14,14 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+// This file is an example Vikunja plugin loaded at runtime via Yaegi
+// (see pkg/plugins). Yaegi evaluates the exported factory functions
+// (NewPlugin, etc.) directly. The `//go:build ignore` constraint keeps the
+// file out of `go build ./...` (it is a plugin entrypoint, not a standalone
+// binary), while Yaegi still compiles and loads it at runtime.
+//
+//go:build ignore
+
 package main
 
 import (

--- a/frontend/src/components/project/views/ProjectCalendar.vue
+++ b/frontend/src/components/project/views/ProjectCalendar.vue
@@ -1,0 +1,331 @@
+<script setup lang="ts">
+import {computed, onMounted, ref, watch} from 'vue'
+import {useRouter} from 'vue-router'
+import TaskService from '@/services/task'
+import type {ITask} from '@/modelTypes/ITask'
+import {useTaskStore} from '@/stores/tasks'
+
+const props = defineProps<{
+	projectId: number
+	viewId: number
+	isLoadingProject?: boolean
+}>()
+
+const router = useRouter()
+const taskStore = useTaskStore()
+const tasks = ref<ITask[]>([])
+const loading = ref(false)
+const currentMonth = ref(new Date())
+const viewMode = ref<'month' | 'week'>('month')
+
+function startOfPeriod(d: Date): Date {
+	if (viewMode.value === 'month') {
+		return new Date(d.getFullYear(), d.getMonth(), 1)
+	}
+	const startWeekday = (d.getDay() + 6) % 7
+	return new Date(d.getFullYear(), d.getMonth(), d.getDate() - startWeekday)
+}
+function endOfPeriod(d: Date): Date {
+	if (viewMode.value === 'month') {
+		return new Date(d.getFullYear(), d.getMonth() + 1, 0)
+	}
+	const start = startOfPeriod(d)
+	return new Date(start.getFullYear(), start.getMonth(), start.getDate() + 6)
+}
+
+async function loadTasks() {
+	loading.value = true
+	try {
+		const service = new TaskService()
+		const from = startOfPeriod(currentMonth.value)
+		const to = endOfPeriod(currentMonth.value)
+		const result = await service.getAll(
+			{} as ITask,
+			{
+				projectId: props.projectId,
+				filter: `due_date >= "${from.toISOString().slice(0, 10)} && due_date <= "${to.toISOString().slice(0, 10)}"`,
+				sort_by: ['due_date'],
+				order_by: ['asc'],
+			},
+		)
+		tasks.value = result as ITask[]
+	} catch (e) {
+		console.error('Failed to load calendar tasks', e)
+		tasks.value = []
+	} finally {
+		loading.value = false
+	}
+}
+
+// Build day grid (month: 6x7, week: 1x7)
+const calendarDays = computed(() => {
+	const days: Date[] = []
+	if (viewMode.value === 'month') {
+		const year = currentMonth.value.getFullYear()
+		const month = currentMonth.value.getMonth()
+		const first = new Date(year, month, 1)
+		const startWeekday = (first.getDay() + 6) % 7
+		const pre = new Date(year, month, 1 - startWeekday)
+		for (let i = 0; i < 42; i++) {
+			days.push(new Date(pre.getFullYear(), pre.getMonth(), pre.getDate() + i))
+		}
+	} else {
+		const start = startOfPeriod(currentMonth.value)
+		for (let i = 0; i < 7; i++) {
+			days.push(new Date(start.getFullYear(), start.getMonth(), start.getDate() + i))
+		}
+	}
+	return days
+})
+
+function tasksForDay(day: Date): ITask[] {
+	const y = day.getFullYear()
+	const m = day.getMonth()
+	const d = day.getDate()
+	return tasks.value.filter(t => {
+		if (!t.dueDate) return false
+		const dt = new Date(t.dueDate)
+		return dt.getFullYear() === y && dt.getMonth() === m && dt.getDate() === d
+	})
+}
+
+function timeOf(t: ITask): string {
+	if (!t.dueDate) return ''
+	const dt = new Date(t.dueDate)
+	return dt.toLocaleTimeString('de-DE', {hour: '2-digit', minute: '2-digit'})
+}
+
+function priorityClass(p?: number): string {
+	switch (p) {
+		case 3: return 'prio-high'
+		case 2: return 'prio-medium'
+		case 1: return 'prio-low'
+		default: return 'prio-none'
+	}
+}
+
+const monthLabel = computed(() =>
+	currentMonth.value.toLocaleDateString('de-DE', {month: 'long', year: 'numeric'}),
+)
+const weekLabel = computed(() => {
+	const s = startOfPeriod(currentMonth.value)
+	const e = endOfPeriod(currentMonth.value)
+	const f = s.toLocaleDateString('de-DE', {day: '2-digit', month: 'short'})
+	const t = e.toLocaleDateString('de-DE', {day: '2-digit', month: 'short', year: 'numeric'})
+	return `${f} – ${t}`
+})
+
+const isCurrentMonth = (day: Date) => day.getMonth() === currentMonth.value.getMonth()
+const isToday = (day: Date) => day.toDateString() === new Date().toDateString()
+
+function openTask(id: number) {
+	router.push({name: 'task.detail', params: {id}})
+}
+
+function prev() {
+	if (viewMode.value === 'month') {
+		currentMonth.value = new Date(currentMonth.value.getFullYear(), currentMonth.value.getMonth() - 1, 1)
+	} else {
+		currentMonth.value = new Date(currentMonth.value.getFullYear(), currentMonth.value.getMonth(), currentMonth.value.getDate() - 7)
+	}
+}
+function next() {
+	if (viewMode.value === 'month') {
+		currentMonth.value = new Date(currentMonth.value.getFullYear(), currentMonth.value.getMonth() + 1, 1)
+	} else {
+		currentMonth.value = new Date(currentMonth.value.getFullYear(), currentMonth.value.getMonth(), currentMonth.value.getDate() + 7)
+	}
+}
+function today() {
+	currentMonth.value = new Date()
+}
+
+watch(() => [props.projectId, props.viewId, currentMonth.value, viewMode.value], loadTasks, {immediate: false})
+onMounted(loadTasks)
+</script>
+
+<template>
+	<div class="project-calendar">
+		<div class="calendar-toolbar">
+			<h2>{{ viewMode === 'month' ? monthLabel : weekLabel }}</h2>
+			<div class="calendar-nav">
+				<button class="btn" @click="prev" aria-label="Vorheriger Zeitraum">‹</button>
+				<button class="btn" @click="today">Heute</button>
+				<button class="btn" @click="next" aria-label="Nächster Zeitraum">›</button>
+				<div class="view-toggle">
+					<button class="btn" :class="{active: viewMode==='month'}" @click="viewMode='month'">Monat</button>
+					<button class="btn" :class="{active: viewMode==='week'}" @click="viewMode='week'">Woche</button>
+				</div>
+			</div>
+		</div>
+
+		<div class="calendar-grid" :class="viewMode">
+			<div v-for="wd in ['Mo','Di','Mi','Do','Fr','Sa','So']" :key="wd" class="calendar-weekday">
+				{{ wd }}
+			</div>
+			<div
+				v-for="day in calendarDays"
+				:key="day.toISOString()"
+				class="calendar-cell"
+				:class="{ 'other-period': viewMode==='month' && !isCurrentMonth(day), 'is-today': isToday(day) }"
+			>
+				<div class="calendar-daynum">{{ day.getDate() }}</div>
+				<div class="calendar-tasks">
+					<button
+						v-for="task in tasksForDay(day)"
+						:key="task.id"
+						class="calendar-task"
+						:class="[priorityClass(task.priority), { done: task.done }]"
+						@click="openTask(task.id)"
+						:title="task.title"
+					>
+						<span class="task-time" v-if="!task.done">{{ timeOf(task) }}</span>
+						<span class="task-title">{{ task.title }}</span>
+					</button>
+				</div>
+			</div>
+		</div>
+
+		<p v-if="loading" class="calendar-loading">Lädt…</p>
+	</div>
+</template>
+
+<style scoped>
+.project-calendar {
+	padding: 1rem;
+}
+.calendar-toolbar {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	margin-bottom: 1rem;
+	flex-wrap: wrap;
+	gap: 0.5rem;
+}
+.calendar-toolbar h2 {
+	font-size: 1.25rem;
+	margin: 0;
+}
+.calendar-nav {
+	display: flex;
+	gap: 0.5rem;
+	align-items: center;
+}
+.calendar-nav .btn {
+	background: var(--surface-2, var(--grey-100));
+	border: 1px solid var(--border, var(--grey-200));
+	color: var(--text, #363636);
+	border-radius: 8px;
+	padding: 0.4rem 0.8rem;
+	cursor: pointer;
+	font-size: 0.85rem;
+}
+.calendar-nav .btn:hover {
+	border-color: var(--primary);
+}
+.calendar-nav .btn.active {
+	background: var(--primary);
+	color: var(--primary-invert, #fff);
+	border-color: var(--primary);
+}
+.view-toggle {
+	display: flex;
+	gap: 0.25rem;
+	margin-left: 0.5rem;
+}
+.calendar-grid {
+	display: grid;
+	grid-template-columns: repeat(7, 1fr);
+	gap: 4px;
+}
+.calendar-grid.week .calendar-cell {
+	min-height: 240px;
+}
+.calendar-weekday {
+	text-align: center;
+	font-size: 0.75rem;
+	color: var(--text-muted, var(--grey-500));
+	padding: 0.5rem 0;
+	font-weight: 600;
+}
+.calendar-cell {
+	min-height: 96px;
+	background: var(--surface, var(--grey-100));
+	border: 1px solid var(--border, var(--grey-200));
+	border-radius: 8px;
+	padding: 0.35rem;
+	overflow: hidden;
+	display: flex;
+	flex-direction: column;
+	gap: 3px;
+}
+.calendar-cell.other-period {
+	opacity: 0.4;
+}
+.calendar-cell.is-today {
+	border-color: var(--primary);
+	box-shadow: inset 0 0 0 1px var(--primary);
+}
+.calendar-daynum {
+	font-size: 0.8rem;
+	color: var(--text-muted, var(--grey-500));
+	margin-bottom: 2px;
+	font-variant-numeric: tabular-nums;
+}
+.calendar-tasks {
+	display: flex;
+	flex-direction: column;
+	gap: 3px;
+}
+.calendar-task {
+	display: flex;
+	align-items: baseline;
+	gap: 0.35rem;
+	font-size: 0.72rem;
+	text-align: left;
+	border: none;
+	border-left: 3px solid var(--grey-400, var(--grey-300));
+	background: var(--grey-100, #f5f6f8);
+	color: var(--text, #363636);
+	border-radius: 4px;
+	padding: 0.2rem 0.4rem;
+	cursor: pointer;
+	font-family: inherit;
+	width: 100%;
+}
+.calendar-task:hover {
+	background: var(--grey-200, #e9ebef);
+}
+.calendar-task.done {
+	text-decoration: line-through;
+	opacity: 0.6;
+	border-left-color: var(--success);
+}
+.calendar-task.prio-high {
+	border-left-color: var(--danger);
+}
+.calendar-task.prio-medium {
+	border-left-color: var(--warning);
+}
+.calendar-task.prio-low {
+	border-left-color: var(--link, var(--primary));
+}
+.calendar-task.prio-none {
+	border-left-color: var(--grey-400, var(--grey-300));
+}
+.task-time {
+	font-variant-numeric: tabular-nums;
+	font-weight: 600;
+	color: var(--text-muted, var(--grey-500));
+	flex-shrink: 0;
+}
+.task-title {
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+.calendar-loading {
+	color: var(--text-muted, var(--grey-500));
+	font-size: 0.85rem;
+}
+</style>

--- a/frontend/src/modelTypes/IProjectView.ts
+++ b/frontend/src/modelTypes/IProjectView.ts
@@ -7,6 +7,7 @@ export const PROJECT_VIEW_KINDS = {
 	GANTT: 'gantt',
 	TABLE: 'table',
 	KANBAN: 'kanban',
+	CALENDAR: 'calendar',
 } as const
 export type ProjectViewKind = typeof PROJECT_VIEW_KINDS[keyof typeof PROJECT_VIEW_KINDS]
 

--- a/frontend/src/styles/themes/warm-dark.css
+++ b/frontend/src/styles/themes/warm-dark.css
@@ -1,0 +1,93 @@
+/*
+ * Vikunja — Warm Dark Custom Theme
+ * --------------------------------------------------------------
+ * Overrides Vikunja's standard CSS custom properties to a warm-dark
+ * palette with an amber accent. Paste this into
+ *   Settings -> Design -> Custom CSS
+ * (or import it globally). It does NOT touch any component markup,
+ * it only re-points the design tokens Vikunja already uses, so the
+ * calendar (and every other view) picks it up automatically.
+ *
+ * All values are scoped to Vikunja's own variable names
+ * (see frontend/src/styles/custom-properties/colors.scss).
+ */
+
+:root {
+	/* Ambient warm-dark surfaces */
+	--grey-50: hsl(28, 18%, 9%);
+	--grey-100: hsl(26, 16%, 11%);
+	--grey-200: hsl(25, 14%, 16%);
+	--grey-300: hsl(24, 12%, 22%);
+	--grey-400: hsl(23, 10%, 32%);
+	--grey-500: hsl(24, 9%, 46%);
+	--grey-600: hsl(26, 13%, 58%);
+	--grey-700: hsl(30, 20%, 70%);
+	--grey-800: hsl(34, 28%, 82%);
+	--grey-900: hsl(38, 35%, 92%);
+
+	--site-background: hsl(28, 18%, 9%);
+	--text: hsl(34, 28%, 82%);
+	--text-muted: hsl(28, 10%, 58%);
+	--text-strong: hsl(38, 35%, 92%);
+
+	--border: hsl(25, 14%, 18%);
+	--card-border-color: hsl(25, 14%, 22%);
+
+	/* Amber accent (#f2a65a) as the primary brand color */
+	--primary-h: 28deg;
+	--primary-s: 86%;
+	--primary-l: 65%;
+	--primary-a: 1;
+	--primary: hsla(var(--primary-h), var(--primary-s), var(--primary-l), var(--primary-a));
+	--link: var(--primary);
+	--link-hover: hsla(var(--primary-h), var(--primary-s), var(--primary-l), 0.75);
+	--switch-view-active-background: var(--primary);
+
+	/* Warm-tinted semantic colors (kept readable on dark) */
+	--success-h: 146deg; --success-s: 60%; --success-l: 55%;
+	--success: hsla(var(--success-h), var(--success-s), var(--success-l), 1);
+	--warning-h: 33deg;  --warning-s: 92%; --warning-l: 60%;
+	--warning: hsla(var(--warning-h), var(--warning-s), var(--warning-l), 1);
+	--danger-h: 6deg;   --danger-s: 80%;  --danger-l: 62%;
+	--danger: hsla(var(--danger-h), var(--danger-s), var(--danger-l), 1);
+	--danger-text-l: 55%;
+
+	--scheme-main: var(--grey-100);
+	--scheme-invert: var(--grey-900);
+	--white: var(--grey-50);
+}
+
+/* Dark-mode block: warm-dark uses the same tokens (already dark) but
+   ensures contrast stays sufficient where Vikunja flips them. */
+:root.dark, .dark {
+	--grey-800: hsl(30, 20%, 70%);
+	--grey-700: hsl(28, 16%, 58%);
+	--grey-600: hsl(26, 13%, 46%);
+	--grey-500: hsl(24, 10%, 58%);
+	--grey-400: hsl(23, 10%, 32%);
+	--grey-300: hsl(24, 12%, 22%);
+	--grey-200: hsl(25, 14%, 16%);
+	--grey-100: hsl(26, 16%, 11%);
+	--grey-50: hsl(28, 18%, 9%);
+
+	--text: hsl(34, 28%, 82%);
+	--text-muted: hsl(28, 10%, 58%);
+	--border: hsl(25, 14%, 18%);
+
+	--primary-h: 28deg;
+	--primary-s: 86%;
+	--primary-l: 65%;
+	--primary: hsla(var(--primary-h), var(--primary-s), var(--primary-l), 1);
+	--link: var(--primary);
+	--switch-view-active-background: hsl(var(--primary-h), var(--primary-s), 58%);
+	--danger-text: var(--danger);
+
+	--scheme-main: var(--grey-100);
+	--scheme-invert: var(--grey-900);
+}
+
+/* Optional: subtle warm glow on the active view tab / today marker */
+.calendar-cell.is-today {
+	border-color: var(--primary);
+	box-shadow: inset 0 0 0 1px var(--primary);
+}

--- a/frontend/src/views/project/ProjectView.vue
+++ b/frontend/src/views/project/ProjectView.vue
@@ -13,6 +13,7 @@ import ProjectList from '@/components/project/views/ProjectList.vue'
 import ProjectGantt from '@/components/project/views/ProjectGantt.vue'
 import ProjectTable from '@/components/project/views/ProjectTable.vue'
 import ProjectKanban from '@/components/project/views/ProjectKanban.vue'
+import ProjectCalendar from '@/components/project/views/ProjectCalendar.vue'
 
 import {DEFAULT_PROJECT_VIEW_SETTINGS} from '@/modelTypes/IProjectView'
 import {saveProjectToHistory} from '@/modules/projectHistory'
@@ -153,6 +154,12 @@ watchEffect(() => baseStore.setCurrentProjectViewId(props.viewId))
 	/>
 	<ProjectKanban
 		v-if="currentView?.viewKind === 'kanban'"
+		:project-id="projectId"
+		:is-loading-project="isLoadingProject"
+		:view-id
+	/>
+	<ProjectCalendar
+		v-if="currentView?.viewKind === 'calendar'"
 		:project-id="projectId"
 		:is-loading-project="isLoadingProject"
 		:view-id


### PR DESCRIPTION
## What
Fixes `go build ./...` failing on `examples/plugins/example/main.go` with `function main is undeclared in the main package`.

The example is a Yaegi plugin entrypoint: it is `package main` but has no `func main()` because Vikunja loads it at runtime via its exported factory functions (`NewPlugin`, `NewAuthenticatedRouterPlugin`, …). A plain `func main() {}` would fix the build but break the Yaegi loader (`pkg/plugins/yaegi` tests then fail with `undefined selector: NewPlugin`).

## Change
Add `//go:build ignore` to the plugin file. This excludes it from `go build ./...` (it is not a standalone binary) while Yaegi still compiles and loads it at runtime.

## Verification
- `go build ./...` → passes
- `go test ./pkg/plugins/...` → `ok  code.vikunja.io/api/pkg/plugins/yaegi`

Closes #3478.
