### PR TITLE
fix(teams): preserve members across list responses

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,10 +30,7 @@ RUN export PATH=$PATH:$GOPATH/bin && \
 	mage build:clean && \
     (cd build && mage release:xgo vikunja "${TARGETOS}/${TARGETARCH}/${TARGETVARIANT}")
 
-RUN mkdir -p /tmp /app/vikunja/files && \
-	chmod 1777 /tmp && \
-	chown 568:568 /app/vikunja/files && \
-	chmod 0775 /app/vikunja/files
+RUN mkdir -p /tmp && chmod 1777 /tmp
 
 #  ┬─┐┬ ┐┌┐┐┌┐┐┬─┐┬─┐
 #  │┬┘│ │││││││├─ │┬┘
@@ -53,10 +50,9 @@ WORKDIR /app/vikunja
 ENTRYPOINT [ "/app/vikunja/vikunja" ]
 EXPOSE 3456
 
-COPY --from=apibuilder --chown=568:568 --chmod=1777 /tmp /tmp
-COPY --from=apibuilder --chown=568:568 --chmod=0775 /app/vikunja/files /app/vikunja/files
+COPY --from=apibuilder --chown=1000:1000 --chmod=1777 /tmp /tmp
 
-USER 568:568
+USER 1000
 
 ENV VIKUNJA_SERVICE_ROOTPATH=/app/vikunja/
 ENV VIKUNJA_DATABASE_PATH=/db/vikunja.db

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,10 @@ RUN export PATH=$PATH:$GOPATH/bin && \
 	mage build:clean && \
     (cd build && mage release:xgo vikunja "${TARGETOS}/${TARGETARCH}/${TARGETVARIANT}")
 
-RUN mkdir -p /tmp && chmod 1777 /tmp
+RUN mkdir -p /tmp /app/vikunja/files && \
+	chmod 1777 /tmp && \
+	chown 568:568 /app/vikunja/files && \
+	chmod 0775 /app/vikunja/files
 
 #  ┬─┐┬ ┐┌┐┐┌┐┐┬─┐┬─┐
 #  │┬┘│ │││││││├─ │┬┘
@@ -50,9 +53,10 @@ WORKDIR /app/vikunja
 ENTRYPOINT [ "/app/vikunja/vikunja" ]
 EXPOSE 3456
 
-COPY --from=apibuilder --chown=1000:1000 --chmod=1777 /tmp /tmp
+COPY --from=apibuilder --chown=568:568 --chmod=1777 /tmp /tmp
+COPY --from=apibuilder --chown=568:568 --chmod=0775 /app/vikunja/files /app/vikunja/files
 
-USER 1000
+USER 568:568
 
 ENV VIKUNJA_SERVICE_ROOTPATH=/app/vikunja/
 ENV VIKUNJA_DATABASE_PATH=/db/vikunja.db

--- a/pkg/models/teams.go
+++ b/pkg/models/teams.go
@@ -151,7 +151,7 @@ func addMoreInfoToTeams(s *xorm.Session, teams []*Team) (err error) {
 	}
 
 	// Get all owners and team members
-	users := make(map[int64]*TeamUser)
+	users := []*TeamUser{}
 	err = s.
 		Select("*").
 		Table("users").
@@ -169,17 +169,19 @@ func addMoreInfoToTeams(s *xorm.Session, teams []*Team) (err error) {
 	if err != nil {
 		return
 	}
+	usersByID := make(map[int64]*TeamUser)
 	for _, u := range users {
 		if _, exists := teamMap[u.TeamID]; !exists {
 			continue
 		}
 		u.Email = ""
 		teamMap[u.TeamID].Members = append(teamMap[u.TeamID].Members, u)
+		usersByID[u.ID] = u
 	}
 
 	// We need to do this in a second loop as owners might not be the last ones in the project
 	for _, team := range teamMap {
-		if teamUser, has := users[team.CreatedByID]; has {
+		if teamUser, has := usersByID[team.CreatedByID]; has {
 			team.CreatedBy = &teamUser.User
 		}
 		sort.Slice(team.Members, func(i, j int) bool {

--- a/pkg/models/teams_test.go
+++ b/pkg/models/teams_test.go
@@ -203,6 +203,43 @@ func TestTeam_ReadAll(t *testing.T) {
 	})
 }
 
+func TestTeamListPreservesMembersForSharedUsers(t *testing.T) {
+	t.Run("team list", func(t *testing.T) {
+		db.LoadAndAssertFixtures(t)
+		s := db.NewSession()
+		defer s.Close()
+
+		teams, _, _, err := (&Team{}).ReadAll(s, &user.User{ID: 1}, "", 1, 50)
+		require.NoError(t, err)
+
+		membersByTeamID := make(map[int64]int)
+		for _, team := range teams.([]*Team) {
+			membersByTeamID[team.ID] = len(team.Members)
+		}
+		assert.Equal(t, 2, membersByTeamID[1])
+		assert.Equal(t, 1, membersByTeamID[2])
+	})
+
+	t.Run("project team list", func(t *testing.T) {
+		db.LoadAndAssertFixtures(t)
+		s := db.NewSession()
+		defer s.Close()
+
+		_, err := s.Insert(&TeamProject{TeamID: 2, ProjectID: 3, Permission: PermissionRead})
+		require.NoError(t, err)
+
+		teams, _, _, err := (&TeamProject{ProjectID: 3}).ReadAll(s, &user.User{ID: 1}, "", 1, 50)
+		require.NoError(t, err)
+
+		membersByTeamID := make(map[int64]int)
+		for _, team := range teams.([]*TeamWithPermission) {
+			membersByTeamID[team.ID] = len(team.Members)
+		}
+		assert.Equal(t, 2, membersByTeamID[1])
+		assert.Equal(t, 1, membersByTeamID[2])
+	})
+}
+
 func TestTeam_Update(t *testing.T) {
 	u := &user.User{ID: 1}
 


### PR DESCRIPTION
## Summary
Fixes incomplete team `members` arrays when a user belongs to multiple teams included in the same response.
`addMoreInfoToTeams` queried one row per `(team_id, user_id)` membership but stored those rows in a map keyed only by user ID. When a user was a member of multiple teams, a later row replaced an earlier one. The subsequent member assignment loop therefore used only the surviving membership row.
The fix stores all queried membership rows in a slice, preserving every team-user relation. It creates a separate `usersByID` map only for resolving `created_by`, where one row per user is appropriate.
This affects both list paths because both use `addMoreInfoToTeams`:
- `GET /api/v1/teams`
- `GET /api/v1/projects/{projectId}/teams`
Fixes #<issue-number>.
## Tests
Added regression coverage that uses the existing fixtures, where user ID `1` belongs to teams `1` and `2`:
- Team list: verifies team `1` returns two members and team `2` returns one.
- Project-team list: shares team `2` with project `3`, then verifies both teams preserve their expected members.
## Manual Verification
Built and deployed the fork to a disposable TrueNAS environment using PostgreSQL 18.
Created three users:
```bash
sudo docker exec -it ix-vikunja-team-membership-test-postgres-vikunja-1 \
  /app/vikunja/vikunja user create \
  --username team-admin \
  --email team-admin@example.test \
  --password '...'
```
```bash
sudo docker exec -it ix-vikunja-team-membership-test-postgres-vikunja-1 \
  /app/vikunja/vikunja user create \
  --username team-secondary \
  --email team-secondary@example.test \
  --password '...'
```
```bash
sudo docker exec -it ix-vikunja-team-membership-test-postgres-vikunja-1 \
  /app/vikunja/vikunja user create \
  --username team-tertiary \
  --email team-tertiary@example.test \
  --password '...'
```
Created two teams with these memberships:
```text
test team 1: team-admin, team-secondary, team-tertiary
team test 2: team-admin, team-secondary
```
Confirmed the five stored membership rows:
```bash
sudo docker exec -it ix-vikunja-team-membership-test-postgres-db-1 \
  psql -U vikunja -d vikunja -c "
SELECT t.id AS team_id, t.name AS team, u.username, tm.admin
FROM team_members tm
JOIN teams t ON t.id = tm.team_id
JOIN users u ON u.id = tm.user_id
WHERE t.name IN ('test team 1', 'team test 2')
ORDER BY t.id, u.username;
"
```
Logged in and queried the actual endpoint:
```bash
curl -sS -X POST http://<host>:3456/api/v1/login \
  -H 'Content-Type: application/json' \
  -d '{"username":"team-admin","password":"..."}'
```
```bash
curl -sS http://<host>:3456/api/v1/teams \
  -H 'Authorization: Bearer <token>'
```
The API correctly returned:
```text
test team 1: team-admin, team-secondary, team-tertiary
team test 2: team-admin, team-secondary
```
`team-secondary` was present in both response arrays.
Also ran:
```bash
git diff --check
```
`mage test:filter "TestTeam_ReadAll"` and `mage lint:fix` could not run in the local development environment because `mage` and `gofmt` were unavailable.
## AI Assistance
Meaningful AI assistance was used to identify the faulty map keying, implement the focused fix, add regression coverage, and guide the container-based verification. I reviewed the changed code and validation results.