### PR TITLE
fix: sort saved filters alphabetically in sidebar navigation 🤖🤖🤖

### DIFF
--- a/frontend/src/stores/projects.test.ts
+++ b/frontend/src/stores/projects.test.ts
@@ -147,6 +147,45 @@ describe('project store', () => {
 		})
 	})
 
+	describe('savedFilterProjects', () => {
+		it('should sort filters lexicographically by title regardless of position', () => {
+			const store = useProjectStore()
+			const filterC = createMockProject({id: -3, title: 'Charlie', position: 0})
+			const filterA = createMockProject({id: -4, title: 'Alpha', position: 0})
+			const filterB = createMockProject({id: -5, title: 'Bravo', position: 0})
+
+			store.setProject(filterC)
+			store.setProject(filterA)
+			store.setProject(filterB)
+
+			const titles = store.savedFilterProjects.map(p => p.title)
+			expect(titles).toEqual(['Alpha', 'Bravo', 'Charlie'])
+		})
+
+		it('should exclude archived filters', () => {
+			const store = useProjectStore()
+			const archivedFilter = createMockProject({id: -3, title: 'Archived', isArchived: true})
+
+			store.setProject(archivedFilter)
+
+			expect(store.savedFilterProjects).toHaveLength(0)
+		})
+
+		it('should exclude regular projects and favorites pseudo-project', () => {
+			const store = useProjectStore()
+			const regularProject = createMockProject({id: 1, title: 'Regular'})
+			const favoritesPseudoProject = createMockProject({id: -1, title: 'Favorites'})
+			const filter = createMockProject({id: -2, title: 'Filter'})
+
+			store.setProject(regularProject)
+			store.setProject(favoritesPseudoProject)
+			store.setProject(filter)
+
+			expect(store.savedFilterProjects).toHaveLength(1)
+			expect(store.savedFilterProjects[0].title).toBe('Filter')
+		})
+	})
+
 	describe('isOrphanedSubProject', () => {
 		it('should return false for root projects', () => {
 			const store = useProjectStore()

--- a/frontend/src/stores/projects.ts
+++ b/frontend/src/stores/projects.ts
@@ -43,7 +43,8 @@ export const useProjectStore = defineStore('project', () => {
 	const favoriteProjects = computed(() => projectsArray.value
 		.filter(p => !p.isArchived && p.isFavorite))
 	const savedFilterProjects = computed(() => projectsArray.value
-		.filter(p => !p.isArchived && p.id < -1))
+		.filter(p => !p.isArchived && p.id < -1)
+		.sort((a, b) => a.title.localeCompare(b.title)))
 	const hasProjects = computed(() => projectsArray.value.length > 0)
 
 	const getChildProjects = computed(() => {


### PR DESCRIPTION
## Summary

Fixes #3496. Saved filters in the left-hand sidebar had no meaningful sort order — `SavedFilter.ToProject()` never sets `Position`, so every filter defaults to `0` and ties in the existing `a.position - b.position` sort in `projects.ts`, leaving them in effectively DB row order.

This sorts saved filters lexicographically by title as a stopgap, matching the `localeCompare` pattern already used elsewhere in the store (labels, teams, etc.). A real `position` field for filters (to support manual reordering like projects) is a larger change tracked separately in the linked issue.

## Test plan
- Added unit tests in `frontend/src/stores/projects.test.ts` covering: alphabetical ordering despite tied `position`, exclusion of archived filters, and exclusion of regular projects / the favorites pseudo-project
- `pnpm test:unit` — 1097/1097 passing
- `pnpm lint` / `pnpm typecheck` — no new errors introduced

## Disclosure
This change was written with AI assistance (Claude Code), reviewed and tested by me before opening this PR.