### PR TITLE
Hide filters in caldav

### DIFF
--- a/config-raw.json
+++ b/config-raw.json
@@ -64,6 +64,11 @@
                     "comment": "Enable the caldav endpoint, see the docs for more details"
                 },
                 {
+                    "key": "enablecaldavpseudoprojects",
+                    "default_value": "false",
+                    "comment": "Expose saved filters and the Favorites project as caldav calendars. Off by default: their tasks live in other projects, so most clients show these calendars as empty."
+                },
+                {
                     "key": "motd",
                     "default_value": "",
                     "comment": "Set the motd message, available from the /info endpoint"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -51,6 +51,7 @@ const (
 	ServiceUnixSocketMode                 Key = `service.unixsocketmode`
 	ServicePublicURL                      Key = `service.publicurl`
 	ServiceEnableCaldav                   Key = `service.enablecaldav`
+	ServiceEnableCaldavPseudoProjects     Key = `service.enablecaldavpseudoprojects`
 	ServiceRootpath                       Key = `service.rootpath`
 	ServiceMaxItemsPerPage                Key = `service.maxitemsperpage`
 	ServiceDemoMode                       Key = `service.demomode`
@@ -354,6 +355,7 @@ func initDefaultConfig() {
 	ServiceUnixSocket.setDefault("")
 	ServicePublicURL.setDefault("")
 	ServiceEnableCaldav.setDefault(true)
+	ServiceEnableCaldavPseudoProjects.setDefault(false)
 
 	ServiceRootpath.setDefault(getRootpathLocation())
 	ServiceMaxItemsPerPage.setDefault(50)

--- a/pkg/routes/caldav/handler.go
+++ b/pkg/routes/caldav/handler.go
@@ -252,6 +252,10 @@ func getProjectFromParam(c *echo.Context) (project *models.ProjectWithTasksAndBu
 		return nil, models.ErrProjectDoesNotExist{}
 	}
 
+	if intParam < 0 && !caldavExposesPseudoProjects() {
+		return nil, models.ErrProjectDoesNotExist{ID: intParam}
+	}
+
 	if intParam == models.FavoritesPseudoProjectID {
 		return &models.ProjectWithTasksAndBuckets{Project: models.FavoritesPseudoProject}, nil
 	}

--- a/pkg/routes/caldav/listStorageProvider.go
+++ b/pkg/routes/caldav/listStorageProvider.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"code.vikunja.io/api/pkg/caldav"
+	"code.vikunja.io/api/pkg/config"
 	"code.vikunja.io/api/pkg/db"
 	"code.vikunja.io/api/pkg/events"
 	"code.vikunja.io/api/pkg/log"
@@ -47,6 +48,13 @@ const PrincipalBasePath = DavBasePath + `/principals`
 
 // ProjectHomeSetPath is the CalDAV home-set path Apple clients use after discovery.
 const ProjectHomeSetPath = ProjectBasePath + `/`
+
+// Pseudo-projects (Favorites, saved filters; all with a negative ID) hold tasks which live in
+// other projects, so getTaskURL points their hrefs outside the collection and clients render
+// them as empty. Hidden unless explicitly enabled.
+func caldavExposesPseudoProjects() bool {
+	return config.ServiceEnableCaldavPseudoProjects.GetBool()
+}
 
 // VikunjaCaldavProjectStorage represents a project storage
 type VikunjaCaldavProjectStorage struct {
@@ -146,6 +154,9 @@ func (vcls *VikunjaCaldavProjectStorage) GetResources(rpath string, withChildren
 
 	var resources []data.Resource
 	for _, l := range projects {
+		if l.ID < 0 && !caldavExposesPseudoProjects() {
+			continue
+		}
 		rr := VikunjaProjectResourceAdapter{
 			project: &models.ProjectWithTasksAndBuckets{
 				Project: *l,

--- a/pkg/webtests/caldav_test.go
+++ b/pkg/webtests/caldav_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	"code.vikunja.io/api/pkg/config"
 	"code.vikunja.io/api/pkg/db"
 	"code.vikunja.io/api/pkg/models"
 	"code.vikunja.io/api/pkg/routes/caldav"
@@ -1739,5 +1740,71 @@ END:VTODO` + vtodoFooter
 		assert.Equal(t, int64(86400), after.RepeatAfter, "recurrence must survive completion via CalDAV")
 		assert.True(t, after.DueDate.After(before.DueDate),
 			"due date must be rescheduled even when the VTODO carries no DUE, got %s, was %s", after.DueDate, before.DueDate)
+	})
+}
+
+// TestCaldavPseudoProjects: saved filters (project id <= -2) and Favorites (-1) are synthesized
+// from tasks living in other projects, so their hrefs point outside the collection and clients
+// show them as empty. user1 has both: saved filter 1 (project -2) and favorited tasks.
+func TestCaldavPseudoProjects(t *testing.T) {
+	propfindHomeSet := func(t *testing.T, e *echo.Echo) string {
+		t.Helper()
+
+		const propfindBody = `<?xml version="1.0" encoding="utf-8" ?>
+<A:propfind xmlns:A="DAV:" xmlns:B="urn:ietf:params:xml:ns:caldav">
+	<A:prop>
+		<A:resourcetype />
+	</A:prop>
+</A:propfind>`
+
+		c, rec := createRequest(e, "PROPFIND", propfindBody, nil, nil)
+		c.Request().Header.Set(echo.HeaderContentType, echo.MIMETextXML)
+		c.Request().Header.Set("Depth", "1")
+		c.Request().URL.Path = caldav.ProjectHomeSetPath
+		c.Request().RequestURI = caldav.ProjectHomeSetPath
+
+		result, _ := caldav.BasicAuth(c, testuser1.Username, "12345678")
+		require.True(t, result)
+
+		require.NoError(t, caldav.ProjectHandler(c))
+		assert.Equal(t, 207, rec.Result().StatusCode)
+		return rec.Body.String()
+	}
+
+	t.Run("are not listed as calendars", func(t *testing.T) {
+		e, _ := setupTestEnv()
+
+		body := propfindHomeSet(t, e)
+		assert.Contains(t, body, "/dav/projects/1", "real projects must still be listed")
+		assert.NotContains(t, body, "/dav/projects/-", "no pseudo-project may be listed")
+	})
+
+	t.Run("saved filter returns 404", func(t *testing.T) {
+		e, _ := setupTestEnv()
+		rec, err := newCaldavTestRequestWithUser(t, e, http.MethodGet, caldav.ProjectHandler, &testuser1, ``, nil, map[string]string{"project": "-2"})
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusNotFound, rec.Result().StatusCode)
+	})
+
+	t.Run("favorites returns 404", func(t *testing.T) {
+		e, _ := setupTestEnv()
+		rec, err := newCaldavTestRequestWithUser(t, e, http.MethodGet, caldav.ProjectHandler, &testuser1, ``, nil, map[string]string{"project": "-1"})
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusNotFound, rec.Result().StatusCode)
+	})
+
+	t.Run("are exposed again when enabled", func(t *testing.T) {
+		config.ServiceEnableCaldavPseudoProjects.Set(true)
+		defer config.ServiceEnableCaldavPseudoProjects.Set(false)
+
+		e, _ := setupTestEnv()
+
+		body := propfindHomeSet(t, e)
+		assert.Contains(t, body, "/dav/projects/-2", "saved filter must be listed again")
+		assert.Contains(t, body, "/dav/projects/-1", "favorites must be listed again")
+
+		rec, err := newCaldavTestRequestWithUser(t, e, http.MethodGet, caldav.ProjectHandler, &testuser1, ``, nil, map[string]string{"project": "-2"})
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, rec.Result().StatusCode)
 	})
 }

--- a/pkg/webtests/huma_avatar_upload_test.go
+++ b/pkg/webtests/huma_avatar_upload_test.go
@@ -43,9 +43,9 @@ const avatarUploadPath = "/api/v2/user/settings/avatar"
 func pngBytes(t *testing.T) []byte {
 	t.Helper()
 	img := image.NewRGBA(image.Rect(0, 0, 8, 8))
-	for x := 0; x < 8; x++ {
-		for y := 0; y < 8; y++ {
-			img.Set(x, y, color.RGBA{R: uint8(x * 16), G: uint8(y * 16), B: 100, A: 255})
+	for x := uint8(0); x < 8; x++ {
+		for y := uint8(0); y < 8; y++ {
+			img.Set(int(x), int(y), color.RGBA{R: x * 16, G: y * 16, B: 100, A: 255})
 		}
 	}
 	buf := &bytes.Buffer{}


### PR DESCRIPTION
Currently as discussed in #3483, pseudo projects are exposed via CalDAV. This PR hides the filters and adds a config option `enablecaldavpseudoprojects` which defaults to false to restore the current behavior.

It also fixes a lint issue I found in a test.

I used AI for this.