### PR TITLE
Add a project card image, separate from the project background

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -174,6 +174,9 @@ linters:
           - contextcheck
         path: pkg/routes/api/v2/backgrounds.go # the unsplash provider intentionally uses context.Background(); its interface is shared with v1 and can't take a context
       - linters:
+          - contextcheck
+        path: pkg/routes/api/v2/card_backgrounds.go # same unsplash provider, same reason as backgrounds.go above
+      - linters:
           - revive
         text: 'var-naming: avoid package names that conflict with Go standard library package names'
       - linters:

--- a/frontend/src/components/project/ProjectImagePicker.vue
+++ b/frontend/src/components/project/ProjectImagePicker.vue
@@ -1,0 +1,322 @@
+<template>
+	<CreateEdit
+		v-if="uploadEnabled || unsplashEnabled"
+		:title="$t(`${i18nPrefix}.title`)"
+		:loading="unsplashService.loading"
+		class="project-background-setting"
+		:wide="true"
+	>
+		<div
+			v-if="uploadEnabled"
+			class="mbe-4"
+		>
+			<input
+				ref="uploadInput"
+				accept="image/*"
+				class="is-hidden"
+				type="file"
+				@change="upload"
+			>
+			<XButton
+				:loading="uploadService.loading"
+				variant="primary"
+				@click="uploadInput?.click()"
+			>
+				{{ $t(`${i18nPrefix}.upload`) }}
+			</XButton>
+		</div>
+		<template v-if="unsplashEnabled">
+			<input
+				v-model="searchTerm"
+				:class="{'is-loading': unsplashService.loading}"
+				class="input is-expanded"
+				:placeholder="$t(`${i18nPrefix}.searchPlaceholder`)"
+				type="text"
+				@keyup="debounceNewSearch()"
+			>
+
+			<p class="unsplash-credit">
+				<BaseButton
+					class="unsplash-credit__link"
+					href="https://unsplash.com"
+				>
+					{{ $t(`${i18nPrefix}.poweredByUnsplash`) }}
+				</BaseButton>
+			</p>
+
+			<ul
+				class="image-search__result-list"
+				:style="{'--image-aspect-ratio': aspectRatio}"
+			>
+				<li
+					v-for="im in searchResult"
+					:key="im.id"
+					class="image-search__result-item"
+					:style="{'background-image': `url(${blurHashes[im.id]})`}"
+				>
+					<CustomTransition name="fade">
+						<BaseButton
+							v-if="thumbs[im.id]"
+							class="image-search__image-button"
+							@click="set(im.id)"
+						>
+							<img
+								class="image-search__image"
+								:src="thumbs[im.id]"
+								alt=""
+							>
+						</BaseButton>
+					</CustomTransition>
+
+					<BaseButton
+						:href="`https://unsplash.com/@${im.info.author}?utm_source=vikunja&utm_medium=referral`"
+						class="image-search__info"
+					>
+						{{ im.info.authorName }}
+					</BaseButton>
+				</li>
+			</ul>
+			<XButton
+				v-if="searchResult.length > 0"
+				:disabled="unsplashService.loading"
+				class="is-load-more-button mbs-4"
+				:shadow="false"
+				variant="secondary"
+				@click="search(currentPage + 1)"
+			>
+				{{ unsplashService.loading ? $t('misc.loading') : $t(`${i18nPrefix}.loadMore`) }}
+			</XButton>
+		</template>
+
+		<template #footer>
+			<XButton
+				v-if="hasImage(currentProject)"
+				:shadow="false"
+				variant="tertiary"
+				danger
+				@click.prevent.stop="remove"
+			>
+				{{ $t(`${i18nPrefix}.remove`) }}
+			</XButton>
+			<XButton
+				variant="secondary"
+				@click.prevent.stop="$router.back()"
+			>
+				{{ $t('misc.close') }}
+			</XButton>
+		</template>
+	</CreateEdit>
+</template>
+
+
+<script setup lang="ts">
+import {ref, computed} from 'vue'
+import {useI18n} from 'vue-i18n'
+import {useRoute, useRouter} from 'vue-router'
+import {useDebounceFn} from '@vueuse/core'
+
+import BaseButton from '@/components/base/BaseButton.vue'
+import CustomTransition from '@/components/misc/CustomTransition.vue'
+
+import {useBaseStore} from '@/stores/base'
+import {useProjectStore} from '@/stores/projects'
+
+import type BackgroundImageModel from '@/models/backgroundImage'
+import type {IProject} from '@/modelTypes/IProject'
+import type {IFile} from '@/modelTypes/IFile'
+
+import {getBlobFromBlurHash} from '@/helpers/getBlobFromBlurHash'
+import {useTitle} from '@/composables/useTitle'
+
+import CreateEdit from '@/components/misc/CreateEdit.vue'
+import {success} from '@/message'
+
+const props = withDefaults(defineProps<{
+	i18nPrefix: string
+	unsplashService: UnsplashServiceLike
+	uploadService: UploadServiceLike
+	uploadEnabled: boolean
+	unsplashEnabled: boolean
+	hasImage: (project: IProject) => boolean
+	removeImage: (project: IProject) => Promise<IProject>
+	aspectRatio?: string
+}>(), {
+	aspectRatio: '16 / 10',
+})
+
+defineOptions({name: 'ProjectImagePicker'})
+
+// Duck-typed shapes shared by the background and card-image service pairs
+// (backgroundUnsplash/cardBackgroundUnsplash, backgroundUpload/cardBackgroundUpload) —
+// this component drives whichever pair is passed in, so it isn't tied to one image kind.
+interface UnsplashServiceLike {
+	loading: boolean
+	getAll(model: object, params: {s: string, p: number}): Promise<BackgroundImageModel[]>
+	update(model: {id: string, projectId: IProject['id']}): Promise<IProject>
+	thumb(model: BackgroundImageModel): Promise<string>
+}
+interface UploadServiceLike {
+	loading: boolean
+	create(projectId: IProject['id'], file: IFile): Promise<IProject>
+}
+
+const SEARCH_DEBOUNCE = 300
+
+const {t} = useI18n({useScope: 'global'})
+const baseStore = useBaseStore()
+const route = useRoute()
+const router = useRouter()
+
+useTitle(() => t(`${props.i18nPrefix}.title`))
+
+const searchTerm = ref('')
+const searchResult = ref<BackgroundImageModel[]>([])
+const thumbs = ref<Record<string, string>>({})
+const blurHashes = ref<Record<string, string>>({})
+const currentPage = ref(1)
+
+// We're using debounce to not search on every keypress but with a delay.
+const debounceNewSearch = useDebounceFn(newSearch, SEARCH_DEBOUNCE)
+
+const projectStore = useProjectStore()
+
+const currentProject = computed(() => baseStore.currentProject)
+
+// Show the default collection of images
+newSearch()
+
+function newSearch() {
+	if (!props.unsplashEnabled) {
+		return
+	}
+	// This is an extra method to reset a few things when searching to not break loading more photos.
+	searchResult.value = []
+	thumbs.value = {}
+	search()
+}
+
+async function search(page = 1) {
+	currentPage.value = page
+	const result = await props.unsplashService.getAll({}, {s: searchTerm.value, p: page})
+	searchResult.value = searchResult.value.concat(result)
+	result.forEach((image: BackgroundImageModel) => {
+		getBlobFromBlurHash(image.blurHash)
+			.then((b) => {
+				blurHashes.value[image.id] = window.URL.createObjectURL(b)
+			})
+
+		props.unsplashService.thumb(image).then(b => {
+			thumbs.value[image.id] = b
+		})
+	})
+}
+
+async function set(imageId: string) {
+	// Don't set an image if we're in the process of setting one
+	if (props.unsplashService.loading) {
+		return
+	}
+
+	const project = await props.unsplashService.update({
+		id: imageId,
+		projectId: route.params.projectId as unknown as IProject['id'],
+	})
+	await baseStore.handleSetCurrentProject({project, forceUpdate: true})
+	projectStore.setProject(project)
+	success({message: t(`${props.i18nPrefix}.success`)})
+}
+
+const uploadInput = ref<HTMLInputElement | null>(null)
+async function upload() {
+	if (uploadInput.value?.files?.length === 0) {
+		return
+	}
+
+	const project = await props.uploadService.create(
+		route.params.projectId as unknown as IProject['id'],
+		uploadInput.value?.files[0] as unknown as IFile,
+	)
+	await baseStore.handleSetCurrentProject({project, forceUpdate: true})
+	projectStore.setProject(project)
+	success({message: t(`${props.i18nPrefix}.success`)})
+}
+
+async function remove() {
+	const project = await props.removeImage(currentProject.value)
+	await baseStore.handleSetCurrentProject({project, forceUpdate: true})
+	projectStore.setProject(project)
+	success({message: t(`${props.i18nPrefix}.removeSuccess`)})
+	router.back()
+}
+</script>
+
+<style lang="scss" scoped>
+.unsplash-credit {
+	text-align: end;
+	font-size: .8rem;
+}
+
+.unsplash-credit__link {
+	color: var(--grey-800);
+}
+
+.image-search__result-list {
+	--items-per-row: 1;
+	margin: 1rem 0 0;
+	display: grid;
+	gap: 1rem;
+	grid-template-columns: repeat(var(--items-per-row), 1fr);
+
+	@media screen and (min-width: $mobile) {
+		--items-per-row: 2;
+	}
+	@media screen and (min-width: $tablet) {
+		--items-per-row: 4;
+	}
+	@media screen and (min-width: $tablet) {
+		--items-per-row: 5;
+	}
+}
+
+.image-search__result-item {
+	margin-block-start: 0; // FIXME: removes padding from .content
+	aspect-ratio: var(--image-aspect-ratio, 16 / 10);
+	background-size: cover;
+	background-position: center;
+	display: flex;
+	position: relative;
+}
+
+.image-search__image-button {
+	inline-size: 100%;
+}
+
+.image-search__image {
+	inline-size: 100%;
+	block-size: 100%;
+	object-fit: cover;
+}
+
+.image-search__info {
+	position: absolute;
+	inset-block-end: 0;
+	inline-size: 100%;
+	padding: .25rem 0;
+	opacity: 0;
+	text-align: center;
+	background: rgba(0, 0, 0, 0.5);
+	font-size: .75rem;
+	font-weight: bold;
+	color: $white;
+	transition: opacity $transition;
+}
+.image-search__result-item:hover .image-search__info {
+		opacity: 1;
+}
+
+.is-load-more-button {
+	margin: 1rem auto 0 !important;
+	display: block;
+	inline-size: 200px;
+}
+</style>

--- a/frontend/src/components/project/ProjectSettingsDropdown.vue
+++ b/frontend/src/components/project/ProjectSettingsDropdown.vue
@@ -71,6 +71,13 @@
 				{{ $t('menu.setBackground') }}
 			</DropdownItem>
 			<DropdownItem
+				v-if="backgroundsEnabled"
+				:to="{ name: 'project.settings.cardImage', params: { projectId: project.id } }"
+				icon="file-image"
+			>
+				{{ $t('menu.setCardImage') }}
+			</DropdownItem>
+			<DropdownItem
 				:to="{ name: 'project.settings.share', params: { projectId: project.id } }"
 				icon="share-alt"
 			>

--- a/frontend/src/components/project/partials/ProjectCard.vue
+++ b/frontend/src/components/project/partials/ProjectCard.vue
@@ -59,7 +59,7 @@ import type {IProject} from '@/modelTypes/IProject'
 
 import BaseButton from '@/components/base/BaseButton.vue'
 
-import {useProjectBackground} from '@/composables/useProjectBackground'
+import {useProjectCardBackground} from '@/composables/useProjectCardBackground'
 import {useProjectStore} from '@/stores/projects'
 import {getProjectTitle} from '@/helpers/getProjectTitle'
 
@@ -67,7 +67,7 @@ const props = defineProps<{
 	project: IProject,
 }>()
 
-const {background, blurHashUrl} = useProjectBackground(() => props.project)
+const {background, blurHashUrl} = useProjectCardBackground(() => props.project)
 
 const projectStore = useProjectStore()
 

--- a/frontend/src/composables/useProjectBackground.ts
+++ b/frontend/src/composables/useProjectBackground.ts
@@ -3,22 +3,30 @@ import ProjectService from '@/services/project'
 import type {IProject} from '@/modelTypes/IProject'
 import {getBlobFromBlurHash} from '@/helpers/getBlobFromBlurHash'
 
-export function useProjectBackground(project: MaybeRefOrGetter<IProject | null>) {
-	const background = ref<string | null>(null)
-	const backgroundLoading = ref(false)
+// Shared by useProjectBackground and useProjectCardBackground — same watch/blurhash
+// logic, parameterized by which pair of project fields to watch and how to fetch
+// the image itself.
+export function useProjectImage(
+	project: MaybeRefOrGetter<IProject | null>,
+	getInformation: (project: IProject) => unknown,
+	getBlurHash: (project: IProject) => string,
+	fetchImage: (project: IProject) => Promise<string>,
+) {
+	const image = ref<string | null>(null)
+	const imageLoading = ref(false)
 	const blurHashUrl = ref('')
 
 	watch(
 		() => [
 			toValue(project)?.id ?? null,
-			toValue(project)?.backgroundBlurHash ?? null,
-		] as [IProject['id'] | null, IProject['backgroundBlurHash'] | null],
+			toValue(project) ? getBlurHash(toValue(project) as IProject) : null,
+		] as [IProject['id'] | null, string | null],
 		async ([projectId, blurHash], oldValue) => {
 			const projectValue = toValue(project)
 			if (
 				projectValue === null ||
-				!projectValue.backgroundInformation ||
-				backgroundLoading.value
+				!getInformation(projectValue) ||
+				imageLoading.value
 			) {
 				return
 			}
@@ -32,28 +40,42 @@ export function useProjectBackground(project: MaybeRefOrGetter<IProject | null>)
 				return
 			}
 
-			backgroundLoading.value = true
+			imageLoading.value = true
 
 			try {
 				const blurHashPromise = getBlobFromBlurHash(blurHash).then((blurHash) => {
 					blurHashUrl.value = blurHash ? window.URL.createObjectURL(blurHash) : ''
 				})
 
-				const projectService = new ProjectService()
-				const backgroundPromise = projectService.background(projectValue).then((result) => {
-					background.value = result
+				const imagePromise = fetchImage(projectValue).then((result) => {
+					image.value = result
 				})
-				await Promise.all([blurHashPromise, backgroundPromise])
+				await Promise.all([blurHashPromise, imagePromise])
 			} finally {
-				backgroundLoading.value = false
+				imageLoading.value = false
 			}
 		},
 		{immediate: true},
 	)
 
 	return {
-		background,
+		image,
 		blurHashUrl,
-		backgroundLoading,
+		imageLoading,
+	}
+}
+
+export function useProjectBackground(project: MaybeRefOrGetter<IProject | null>) {
+	const {image, blurHashUrl, imageLoading} = useProjectImage(
+		project,
+		p => p.backgroundInformation,
+		p => p.backgroundBlurHash,
+		p => new ProjectService().background(p),
+	)
+
+	return {
+		background: image,
+		blurHashUrl,
+		backgroundLoading: imageLoading,
 	}
 }

--- a/frontend/src/composables/useProjectCardBackground.ts
+++ b/frontend/src/composables/useProjectCardBackground.ts
@@ -1,0 +1,19 @@
+import type {MaybeRefOrGetter} from 'vue'
+import ProjectService from '@/services/project'
+import type {IProject} from '@/modelTypes/IProject'
+import {useProjectImage} from '@/composables/useProjectBackground'
+
+export function useProjectCardBackground(project: MaybeRefOrGetter<IProject | null>) {
+	const {image, blurHashUrl, imageLoading} = useProjectImage(
+		project,
+		p => p.cardBackgroundInformation,
+		p => p.cardBackgroundBlurHash,
+		p => new ProjectService().cardBackground(p),
+	)
+
+	return {
+		background: image,
+		blurHashUrl,
+		backgroundLoading: imageLoading,
+	}
+}

--- a/frontend/src/i18n/lang/en.json
+++ b/frontend/src/i18n/lang/en.json
@@ -389,6 +389,16 @@
       "success": "The background has been set successfully!",
       "removeSuccess": "The background has been removed successfully!"
     },
+    "cardImage": {
+      "title": "Set project card image",
+      "remove": "Remove card image",
+      "upload": "Choose a card image from your pc",
+      "searchPlaceholder": "Search for an image…",
+      "poweredByUnsplash": "Powered by Unsplash",
+      "loadMore": "Load more photos",
+      "success": "The card image has been set successfully!",
+      "removeSuccess": "The card image has been removed successfully!"
+    },
     "delete": {
       "title": "Delete \"{project}\"",
       "header": "Delete this project",
@@ -1369,6 +1379,7 @@
     "delete": "Delete",
     "unarchive": "Un-Archive",
     "setBackground": "Background settings",
+    "setCardImage": "Card image settings",
     "share": "Share",
     "createProject": "Create project",
     "cantArchiveIsDefault": "You cannot archive this because it is your default project.",

--- a/frontend/src/modelTypes/IProject.ts
+++ b/frontend/src/modelTypes/IProject.ts
@@ -15,10 +15,12 @@ export interface IProject extends IAbstract {
 	hexColor: string
 	identifier: string
 	backgroundInformation: unknown | null // FIXME: improve type
+	cardBackgroundInformation: unknown | null // FIXME: improve type
 	isFavorite: boolean
 	subscription: ISubscription
 	position: number
 	backgroundBlurHash: string
+	cardBackgroundBlurHash: string
 	parentProjectId: number
 	views: IProjectView[]
 	

--- a/frontend/src/models/project.ts
+++ b/frontend/src/models/project.ts
@@ -20,10 +20,12 @@ export default class ProjectModel extends AbstractModel<IProject> implements IPr
 	hexColor = ''
 	identifier = ''
 	backgroundInformation: unknown | null = null
+	cardBackgroundInformation: unknown | null = null
 	isFavorite = false
 	subscription: ISubscription = null
 	position = 0
 	backgroundBlurHash = ''
+	cardBackgroundBlurHash = ''
 	parentProjectId = 0
 	views: IProjectView[] = []
 	

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -280,6 +280,14 @@ const router = createRouter({
 			},
 		},
 		{
+			path: '/projects/:projectId/settings/card-image',
+			name: 'project.settings.cardImage',
+			component: () => import('@/views/project/settings/ProjectSettingsCardImage.vue'),
+			meta: {
+				showAsModal: true,
+			},
+		},
+		{
 			path: '/projects/:projectId/settings/duplicate',
 			name: 'project.settings.duplicate',
 			component: () => import('@/views/project/settings/ProjectSettingsDuplicate.vue'),

--- a/frontend/src/services/cardBackgroundUnsplash.ts
+++ b/frontend/src/services/cardBackgroundUnsplash.ts
@@ -1,0 +1,48 @@
+import AbstractService from './abstractService'
+import BackgroundImageModel from '../models/backgroundImage'
+import ProjectModel from '@/models/project'
+import {apiV2Url} from '@/helpers/fetcher'
+import type { IBackgroundImage } from '@/modelTypes/IBackgroundImage'
+import type { IProject } from '@/modelTypes/IProject'
+
+// Reuses the shared /backgrounds/unsplash/search and thumb endpoints (generic,
+// exist on both v1 and v2) — only the "set" endpoint is card-specific and v2-only.
+export default class CardBackgroundUnsplashService extends AbstractService<IBackgroundImage> {
+	constructor() {
+		super({
+			getAll: '/backgrounds/unsplash/search',
+		})
+	}
+
+	modelFactory(data: Partial<IBackgroundImage>) {
+		return new BackgroundImageModel(data)
+	}
+
+	modelUpdateFactory(data) {
+		return new ProjectModel(data)
+	}
+
+	async thumb(model) {
+		const response = await this.http({
+			url: `/backgrounds/unsplash/images/${model.id}/thumb`,
+			method: 'GET',
+			responseType: 'blob',
+		})
+		return window.URL.createObjectURL(new Blob([response.data]))
+	}
+
+	// v2 rejects unknown properties, so only {id} is sent — projectId is
+	// path-only, matching how EmailUpdateService (@/services/emailUpdate) does it.
+	async update(model: {id: string, projectId: IProject['id']}) {
+		const cancel = this.setLoading()
+		try {
+			const response = await this.http.put(
+				apiV2Url(`projects/${model.projectId}/card-backgrounds/unsplash`),
+				{id: model.id},
+			)
+			return this.modelUpdateFactory(response.data)
+		} finally {
+			cancel()
+		}
+	}
+}

--- a/frontend/src/services/cardBackgroundUpload.ts
+++ b/frontend/src/services/cardBackgroundUpload.ts
@@ -1,0 +1,34 @@
+import AbstractService from './abstractService'
+import ProjectModel from '@/models/project'
+import {apiV2Url} from '@/helpers/fetcher'
+
+import type { IProject } from '@/modelTypes/IProject'
+import type { IFile } from '@/modelTypes/IFile'
+
+// The card image upload endpoint only exists on /api/v2, hence the absolute URL.
+export default class CardBackgroundUploadService extends AbstractService {
+	constructor() {
+		super({
+			create: 'projects/{projectId}/card-backgrounds/upload',
+		})
+	}
+
+	useCreateInterceptor() {
+		return false
+	}
+
+	modelCreateFactory(data: Partial<IProject>) {
+		return new ProjectModel(data)
+	}
+
+	/**
+	 * Uploads a file to the server
+	 */
+	create(projectId: IProject['id'], file: IFile) {
+		return this.uploadFile(
+			apiV2Url(this.getReplacedRoute(this.paths.create, {projectId})),
+			file,
+			'background',
+		)
+	}
+}

--- a/frontend/src/services/project.ts
+++ b/frontend/src/services/project.ts
@@ -3,6 +3,7 @@ import ProjectModel from '@/models/project'
 import type {IProject} from '@/modelTypes/IProject'
 import TaskService from './task'
 import {colorFromHex} from '@/helpers/color/colorFromHex'
+import {apiV2Url} from '@/helpers/fetcher'
 
 export default class ProjectService extends AbstractService<IProject> {
 	constructor() {
@@ -61,6 +62,35 @@ export default class ProjectService extends AbstractService<IProject> {
 				...project,
 				backgroundInformation: null,
 				backgroundBlurHash: '',
+			}
+		} finally {
+			cancel()
+		}
+	}
+
+	// The card image endpoints only exist on /api/v2, hence the absolute URLs.
+	async cardBackground(project: Pick<IProject, 'id' | 'cardBackgroundInformation'>) {
+		if (project.cardBackgroundInformation === null) {
+			return ''
+		}
+
+		const response = await this.http({
+			url: apiV2Url(`projects/${project.id}/card-background`),
+			method: 'GET',
+			responseType: 'blob',
+		})
+		return window.URL.createObjectURL(new Blob([response.data]))
+	}
+
+	async removeCardBackground(project: IProject) {
+		const cancel = this.setLoading()
+
+		try {
+			await this.http.delete(apiV2Url(`projects/${project.id}/card-background`))
+			return {
+				...project,
+				cardBackgroundInformation: null,
+				cardBackgroundBlurHash: '',
 			}
 		} finally {
 			cancel()

--- a/frontend/src/views/project/settings/ProjectSettingsBackground.vue
+++ b/frontend/src/views/project/settings/ProjectSettingsBackground.vue
@@ -1,302 +1,42 @@
 <template>
-	<CreateEdit
-		v-if="uploadBackgroundEnabled || unsplashBackgroundEnabled"
-		:title="$t('project.background.title')"
-		:loading="backgroundService.loading"
-		class="project-background-setting"
-		:wide="true"
-	>
-		<div
-			v-if="uploadBackgroundEnabled"
-			class="mbe-4"
-		>
-			<input
-				ref="backgroundUploadInput"
-				accept="image/*"
-				class="is-hidden"
-				type="file"
-				@change="uploadBackground"
-			>
-			<XButton
-				:loading="backgroundUploadService.loading"
-				variant="primary"
-				@click="backgroundUploadInput?.click()"
-			>
-				{{ $t('project.background.upload') }}
-			</XButton>
-		</div>
-		<template v-if="unsplashBackgroundEnabled">
-			<input
-				v-model="backgroundSearchTerm"
-				:class="{'is-loading': backgroundService.loading}"
-				class="input is-expanded"
-				:placeholder="$t('project.background.searchPlaceholder')"
-				type="text"
-				@keyup="debounceNewBackgroundSearch()"
-			>
-
-			<p class="unsplash-credit">
-				<BaseButton
-					class="unsplash-credit__link"
-					href="https://unsplash.com"
-				>
-					{{ $t('project.background.poweredByUnsplash') }}
-				</BaseButton>
-			</p>
-
-			<ul class="image-search__result-list">
-				<li
-					v-for="im in backgroundSearchResult"
-					:key="im.id"
-					class="image-search__result-item"
-					:style="{'background-image': `url(${backgroundBlurHashes[im.id]})`}"
-				>
-					<CustomTransition name="fade">
-						<BaseButton
-							v-if="backgroundThumbs[im.id]"
-							class="image-search__image-button"
-							@click="setBackground(im.id)"
-						>
-							<img
-								class="image-search__image"
-								:src="backgroundThumbs[im.id]"
-								alt=""
-							>
-						</BaseButton>
-					</CustomTransition>
-
-					<BaseButton
-						:href="`https://unsplash.com/@${im.info.author}?utm_source=vikunja&utm_medium=referral`"
-						class="image-search__info"
-					>
-						{{ im.info.authorName }}
-					</BaseButton>
-				</li>
-			</ul>
-			<XButton
-				v-if="backgroundSearchResult.length > 0"
-				:disabled="backgroundService.loading"
-				class="is-load-more-button mbs-4"
-				:shadow="false"
-				variant="secondary"
-				@click="searchBackgrounds(currentPage + 1)"
-			>
-				{{ backgroundService.loading ? $t('misc.loading') : $t('project.background.loadMore') }}
-			</XButton>
-		</template>
-
-		<template #footer>
-			<XButton
-				v-if="hasBackground"
-				:shadow="false"
-				variant="tertiary"
-				danger
-				@click.prevent.stop="removeBackground"
-			>
-				{{ $t('project.background.remove') }}
-			</XButton>
-			<XButton
-				variant="secondary"
-				@click.prevent.stop="$router.back()"
-			>
-				{{ $t('misc.close') }}
-			</XButton>
-		</template>
-	</CreateEdit>
+	<ProjectImagePicker
+		i18n-prefix="project.background"
+		:unsplash-service="backgroundUnsplashService"
+		:upload-service="backgroundUploadService"
+		:upload-enabled="uploadBackgroundEnabled"
+		:unsplash-enabled="unsplashBackgroundEnabled"
+		:has-image="hasBackground"
+		:remove-image="removeBackground"
+	/>
 </template>
 
-
 <script setup lang="ts">
-import {ref, computed, shallowReactive} from 'vue'
-import {useI18n} from 'vue-i18n'
-import {useRoute, useRouter} from 'vue-router'
-import {useDebounceFn} from '@vueuse/core'
+import {computed, shallowReactive} from 'vue'
 
-import BaseButton from '@/components/base/BaseButton.vue'
-import CustomTransition from '@/components/misc/CustomTransition.vue'
-
-import {useBaseStore} from '@/stores/base'
-import {useProjectStore} from '@/stores/projects'
 import {useConfigStore} from '@/stores/config'
 
 import BackgroundUnsplashService from '@/services/backgroundUnsplash'
 import BackgroundUploadService from '@/services/backgroundUpload'
 import ProjectService from '@/services/project'
-import type BackgroundImageModel from '@/models/backgroundImage'
+import type {IProject} from '@/modelTypes/IProject'
 
-import {getBlobFromBlurHash} from '@/helpers/getBlobFromBlurHash'
-import {useTitle} from '@/composables/useTitle'
-
-import CreateEdit from '@/components/misc/CreateEdit.vue'
-import {success} from '@/message'
+import ProjectImagePicker from '@/components/project/ProjectImagePicker.vue'
 
 defineOptions({name: 'ProjectSettingBackground'})
 
-const SEARCH_DEBOUNCE = 300
-
-const {t} = useI18n({useScope: 'global'})
-const baseStore = useBaseStore()
-const route = useRoute()
-const router = useRouter()
-
-useTitle(() => t('project.background.title'))
-
-const backgroundService = shallowReactive(new BackgroundUnsplashService())
-const backgroundSearchTerm = ref('')
-const backgroundSearchResult = ref([])
-const backgroundThumbs = ref<Record<string, string>>({})
-const backgroundBlurHashes = ref<Record<string, string>>({})
-const currentPage = ref(1)
-
-// We're using debounce to not search on every keypress but with a delay.
-const debounceNewBackgroundSearch = useDebounceFn(newBackgroundSearch, SEARCH_DEBOUNCE)
-
-const backgroundUploadService = ref(new BackgroundUploadService())
-const projectService = ref(new ProjectService())
-const projectStore = useProjectStore()
+const backgroundUnsplashService = shallowReactive(new BackgroundUnsplashService())
+const backgroundUploadService = shallowReactive(new BackgroundUploadService())
+const projectService = new ProjectService()
 const configStore = useConfigStore()
 
 const unsplashBackgroundEnabled = computed(() => configStore.enabledBackgroundProviders.includes('unsplash'))
 const uploadBackgroundEnabled = computed(() => configStore.enabledBackgroundProviders.includes('upload'))
-const currentProject = computed(() => baseStore.currentProject)
-const hasBackground = computed(() => !!currentProject.value.backgroundInformation)
 
-// Show the default collection of backgrounds
-newBackgroundSearch()
-
-function newBackgroundSearch() {
-	if (!unsplashBackgroundEnabled.value) {
-		return
-	}
-	// This is an extra method to reset a few things when searching to not break loading more photos.
-	backgroundSearchResult.value = []
-	backgroundThumbs.value = {}
-	searchBackgrounds()
+function hasBackground(project: IProject) {
+	return !!project.backgroundInformation
 }
 
-async function searchBackgrounds(page = 1) {
-	currentPage.value = page
-	const result = await backgroundService.getAll({}, {s: backgroundSearchTerm.value, p: page})
-	backgroundSearchResult.value = backgroundSearchResult.value.concat(result)
-	result.forEach((background: BackgroundImageModel) => {
-		getBlobFromBlurHash(background.blurHash)
-			.then((b) => {
-				backgroundBlurHashes.value[background.id] = window.URL.createObjectURL(b)
-			})
-
-		backgroundService.thumb(background).then(b => {
-			backgroundThumbs.value[background.id] = b
-		})
-	})
-}
-
-
-async function setBackground(backgroundId: string) {
-	// Don't set a background if we're in the process of setting one
-	if (backgroundService.loading) {
-		return
-	}
-
-	const project = await backgroundService.update({
-		id: backgroundId,
-		projectId: route.params.projectId,
-	})
-	await baseStore.handleSetCurrentProject({project, forceUpdate: true})
-	projectStore.setProject(project)
-	success({message: t('project.background.success')})
-}
-
-const backgroundUploadInput = ref<HTMLInputElement | null>(null)
-async function uploadBackground() {
-	if (backgroundUploadInput.value?.files?.length === 0) {
-		return
-	}
-
-	const project = await backgroundUploadService.value.create(
-		route.params.projectId,
-		backgroundUploadInput.value?.files[0],
-	)
-	await baseStore.handleSetCurrentProject({project, forceUpdate: true})
-	projectStore.setProject(project)
-	success({message: t('project.background.success')})
-}
-
-async function removeBackground() {
-	const project = await projectService.value.removeBackground(currentProject.value)
-	await baseStore.handleSetCurrentProject({project, forceUpdate: true})
-	projectStore.setProject(project)
-	success({message: t('project.background.removeSuccess')})
-	router.back()
+function removeBackground(project: IProject) {
+	return projectService.removeBackground(project)
 }
 </script>
-
-<style lang="scss" scoped>
-.unsplash-credit {
-	text-align: end;
-	font-size: .8rem;
-}
-
-.unsplash-credit__link {
-	color: var(--grey-800);
-}
-
-.image-search__result-list {
-	--items-per-row: 1;
-	margin: 1rem 0 0;
-	display: grid;
-	gap: 1rem;
-	grid-template-columns: repeat(var(--items-per-row), 1fr);
-
-	@media screen and (min-width: $mobile) {
-		--items-per-row: 2;
-	}
-	@media screen and (min-width: $tablet) {
-		--items-per-row: 4;
-	}
-	@media screen and (min-width: $tablet) {
-		--items-per-row: 5;
-	}
-}
-
-.image-search__result-item {
-	margin-block-start: 0; // FIXME: removes padding from .content
-	aspect-ratio: 16 / 10;
-	background-size: cover;
-	background-position: center;
-	display: flex;
-	position: relative;
-}
-
-.image-search__image-button {
-	inline-size: 100%;
-}
-
-.image-search__image {
-	inline-size: 100%;
-	block-size: 100%;
-	object-fit: cover;
-}
-
-.image-search__info {
-	position: absolute;
-	inset-block-end: 0;
-	inline-size: 100%;
-	padding: .25rem 0;
-	opacity: 0;
-	text-align: center;
-	background: rgba(0, 0, 0, 0.5);
-	font-size: .75rem;
-	font-weight: bold;
-	color: $white;
-	transition: opacity $transition;
-}
-.image-search__result-item:hover .image-search__info {
-		opacity: 1;
-}
-
-.is-load-more-button {
-	margin: 1rem auto 0 !important;
-	display: block;
-	inline-size: 200px;
-}
-</style>

--- a/frontend/src/views/project/settings/ProjectSettingsCardImage.vue
+++ b/frontend/src/views/project/settings/ProjectSettingsCardImage.vue
@@ -1,0 +1,45 @@
+<template>
+	<ProjectImagePicker
+		i18n-prefix="project.cardImage"
+		:unsplash-service="cardBackgroundUnsplashService"
+		:upload-service="cardBackgroundUploadService"
+		:upload-enabled="uploadCardImageEnabled"
+		:unsplash-enabled="unsplashCardImageEnabled"
+		:has-image="hasCardImage"
+		:remove-image="removeCardImage"
+		aspect-ratio="1 / 1"
+	/>
+</template>
+
+<script setup lang="ts">
+import {computed, shallowReactive} from 'vue'
+
+import {useConfigStore} from '@/stores/config'
+
+import CardBackgroundUnsplashService from '@/services/cardBackgroundUnsplash'
+import CardBackgroundUploadService from '@/services/cardBackgroundUpload'
+import ProjectService from '@/services/project'
+import type {IProject} from '@/modelTypes/IProject'
+
+import ProjectImagePicker from '@/components/project/ProjectImagePicker.vue'
+
+defineOptions({name: 'ProjectSettingCardImage'})
+
+const cardBackgroundUnsplashService = shallowReactive(new CardBackgroundUnsplashService())
+const cardBackgroundUploadService = shallowReactive(new CardBackgroundUploadService())
+const projectService = new ProjectService()
+const configStore = useConfigStore()
+
+// Card images reuse the same provider config as the full background (see
+// ProjectSettingsDropdown.vue's backgroundsEnabled computed for the same choice).
+const unsplashCardImageEnabled = computed(() => configStore.enabledBackgroundProviders.includes('unsplash'))
+const uploadCardImageEnabled = computed(() => configStore.enabledBackgroundProviders.includes('upload'))
+
+function hasCardImage(project: IProject) {
+	return !!project.cardBackgroundInformation
+}
+
+function removeCardImage(project: IProject) {
+	return projectService.removeCardBackground(project)
+}
+</script>

--- a/pkg/db/fixtures/files.yml
+++ b/pkg/db/fixtures/files.yml
@@ -3,3 +3,8 @@
   size: 100
   created: 2019-10-13 20:33:11
   created_by_id: 1
+- id: 2
+  name: test-card
+  size: 100
+  created: 2019-10-13 20:33:11
+  created_by_id: 6

--- a/pkg/db/fixtures/projects.yml
+++ b/pkg/db/fixtures/projects.yml
@@ -306,6 +306,7 @@
   identifier: TEST6
   owner_id: 6
   background_file_id: 1
+  card_background_file_id: 2
   position: 8
   updated: 2018-12-02 15:13:12
   created: 2018-12-01 15:13:12

--- a/pkg/files/filehandling.go
+++ b/pkg/files/filehandling.go
@@ -153,6 +153,12 @@ func InitTestFileFixtures(t *testing.T) {
 	testfile := &File{ID: 1}
 	err := storage.Write(testfile.fileID(), bytes.NewReader([]byte("testfile1")), 9)
 	require.NoError(t, err)
+
+	// File 2 backs project 35's card_background_file_id fixture (distinct from its
+	// background_file_id 1), so duplicate/download tests touching both have real bytes.
+	testCardFile := &File{ID: 2}
+	err = storage.Write(testCardFile.fileID(), bytes.NewReader([]byte("testfile2")), 9)
+	require.NoError(t, err)
 }
 
 // InitTests handles the actual bootstrapping of the test env

--- a/pkg/migration/20260823105730.go
+++ b/pkg/migration/20260823105730.go
@@ -1,0 +1,44 @@
+// Vikunja is a to-do list application to facilitate your life.
+// Copyright 2018-present Vikunja and contributors. All rights reserved.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package migration
+
+import (
+	"src.techknowlogick.com/xormigrate"
+	"xorm.io/xorm"
+)
+
+type projects20260823105730 struct {
+	CardBackgroundFileID   int64  `xorm:"null"`
+	CardBackgroundBlurHash string `xorm:"varchar(50) null"`
+}
+
+func (projects20260823105730) TableName() string {
+	return "projects"
+}
+
+func init() {
+	migrations = append(migrations, &xormigrate.Migration{
+		ID:          "20260823105730",
+		Description: "Add card_background_file_id and card_background_blur_hash to projects",
+		Migrate: func(tx *xorm.Engine) error {
+			return partialSync(tx, projects20260823105730{})
+		},
+		Rollback: func(tx *xorm.Engine) error {
+			return nil
+		},
+	})
+}

--- a/pkg/models/error.go
+++ b/pkg/models/error.go
@@ -564,6 +564,33 @@ func (err *ErrProjectHasNoBackground) HTTPError() web.HTTPError {
 	}
 }
 
+// ErrProjectHasNoCardBackground represents an error where a project has no card image set.
+type ErrProjectHasNoCardBackground struct {
+	ProjectID int64
+}
+
+// IsErrProjectHasNoCardBackground checks if an error is ErrProjectHasNoCardBackground.
+func IsErrProjectHasNoCardBackground(err error) bool {
+	_, ok := err.(*ErrProjectHasNoCardBackground)
+	return ok
+}
+
+func (err *ErrProjectHasNoCardBackground) Error() string {
+	return fmt.Sprintf("Project has no card image [ProjectID: %d]", err.ProjectID)
+}
+
+// ErrCodeProjectHasNoCardBackground holds the unique world-error code of this error
+const ErrCodeProjectHasNoCardBackground = 3017
+
+// HTTPError holds the http error description
+func (err *ErrProjectHasNoCardBackground) HTTPError() web.HTTPError {
+	return web.HTTPError{
+		HTTPCode: http.StatusNotFound,
+		Code:     ErrCodeProjectHasNoCardBackground,
+		Message:  "Project card image not found",
+	}
+}
+
 // ErrParentProjectIsArchived represents an error, where a project's parent is archived
 type ErrParentProjectIsArchived struct {
 	ProjectID       int64

--- a/pkg/models/export.go
+++ b/pkg/models/export.go
@@ -194,6 +194,11 @@ func exportProjectsAndTasks(s *xorm.Session, u *user.User, wr *zip.Writer) (task
 				ID: p.BackgroundFileID,
 			}
 		}
+		if p.CardBackgroundFileID > 0 {
+			p.CardBackgroundInformation = &files.File{
+				ID: p.CardBackgroundFileID,
+			}
+		}
 		pp := &ProjectWithTasksAndBuckets{
 			Project: *p,
 		}
@@ -383,23 +388,25 @@ func exportProjectBackgrounds(s *xorm.Session, u *user.User, wr *zip.Writer) (er
 
 	backgroundFiles := make(map[int64]io.ReadCloser)
 	for _, l := range projects {
-		if l.BackgroundFileID == 0 {
-			continue
-		}
-
-		bgFile := &files.File{
-			ID: l.BackgroundFileID,
-		}
-		err = bgFile.LoadFileByID()
-		if err != nil {
-			var pathError *fs.PathError
-			if errors.As(err, &pathError) {
+		for _, fileID := range []int64{l.BackgroundFileID, l.CardBackgroundFileID} {
+			if fileID == 0 {
 				continue
 			}
-			return err
-		}
 
-		backgroundFiles[l.BackgroundFileID] = bgFile.File
+			bgFile := &files.File{
+				ID: fileID,
+			}
+			err = bgFile.LoadFileByID()
+			if err != nil {
+				var pathError *fs.PathError
+				if errors.As(err, &pathError) {
+					continue
+				}
+				return err
+			}
+
+			backgroundFiles[fileID] = bgFile.File
+		}
 	}
 
 	return utils.WriteFilesToZip(backgroundFiles, wr)

--- a/pkg/models/project.go
+++ b/pkg/models/project.go
@@ -66,6 +66,13 @@ type Project struct {
 	// Contains a very small version of the project background to use as a blurry preview until the actual background is loaded. Check out https://blurha.sh/ to learn how it works.
 	BackgroundBlurHash string `xorm:"varchar(50) null" json:"background_blur_hash" readOnly:"true" doc:"A small BlurHash preview of the project background, shown until the real background loads. See https://blurha.sh/."`
 
+	// The id of the file this project has set as its card image
+	CardBackgroundFileID int64 `xorm:"null" json:"-"`
+	// Holds extra information about the card image set since some background providers require attribution or similar. If not null, the card image can be accessed at /projects/{projectID}/card-background
+	CardBackgroundInformation interface{} `xorm:"-" json:"card_background_information" readOnly:"true" doc:"Extra information about the card image (e.g. attribution). When not null, the card image is available at /projects/{projectID}/card-background."`
+	// Contains a very small version of the project card image to use as a blurry preview until the actual image is loaded. Check out https://blurha.sh/ to learn how it works.
+	CardBackgroundBlurHash string `xorm:"varchar(50) null" json:"card_background_blur_hash" readOnly:"true" doc:"A small BlurHash preview of the project card image, shown until the real image loads. See https://blurha.sh/."`
+
 	// True if a project is a favorite. Favorite projects show up in a separate parent project. This value depends on the user making the call to the api.
 	IsFavorite bool `xorm:"-" json:"is_favorite" doc:"Whether the project is a favorite of the requesting user. This value is per-user and depends on who makes the call."`
 
@@ -446,6 +453,18 @@ func (p *Project) ReadOne(s *xorm.Session, a web.Auth) (err error) {
 		}
 	}
 
+	// Get any card image information if there is one set
+	if p.CardBackgroundFileID != 0 {
+		p.CardBackgroundInformation, err = GetUnsplashPhotoByFileID(s, p.CardBackgroundFileID)
+		if err != nil && !files.IsErrFileIsNotUnsplashFile(err) {
+			return
+		}
+
+		if err != nil && files.IsErrFileIsNotUnsplashFile(err) {
+			p.CardBackgroundInformation = &ProjectBackgroundType{Type: ProjectBackgroundUpload}
+		}
+	}
+
 	// For saved filters, IsFavorite was already set from the SavedFilter struct.
 	// Don't overwrite it with the project favorites lookup.
 	if !isFilter {
@@ -637,7 +656,7 @@ func getUserProjectsStatement(userID int64, search string) *builder.Builder {
 	}
 
 	return builder.
-		Select("l.id, l.title, l.description, l.identifier, l.hex_color, l.owner_id, l.parent_project_id, l.is_archived, l.background_file_id, l.background_blur_hash, l.position, l.created, l.updated").
+		Select("l.id, l.title, l.description, l.identifier, l.hex_color, l.owner_id, l.parent_project_id, l.is_archived, l.background_file_id, l.background_blur_hash, l.card_background_file_id, l.card_background_blur_hash, l.position, l.created, l.updated").
 		From("projects", "l").
 		Join("LEFT", "team_projects tl", "tl.project_id = l.id").
 		Join("LEFT", "team_members tm2", "tm2.team_id = tl.team_id").
@@ -702,7 +721,7 @@ func getAllProjectsForUser(s *xorm.Session, userID int64, opts *projectOptions) 
 
 	baseQuery := querySQLString + `
 UNION ALL
-SELECT p.id, p.title, p.description, p.identifier, p.hex_color, p.owner_id, p.parent_project_id, p.is_archived, p.background_file_id, p.background_blur_hash, p.position, p.created, p.updated FROM projects p
+SELECT p.id, p.title, p.description, p.identifier, p.hex_color, p.owner_id, p.parent_project_id, p.is_archived, p.background_file_id, p.background_blur_hash, p.card_background_file_id, p.card_background_blur_hash, p.position, p.created, p.updated FROM projects p
 INNER JOIN all_projects ap ON p.parent_project_id = ap.id`
 
 	columnStr := strings.Join([]string{
@@ -716,6 +735,8 @@ INNER JOIN all_projects ap ON p.parent_project_id = ap.id`
 		"all_projects.is_archived",
 		"all_projects.background_file_id",
 		"all_projects.background_blur_hash",
+		"all_projects.card_background_file_id",
+		"all_projects.card_background_blur_hash",
 		"all_projects.position",
 		"all_projects.created",
 		"all_projects.updated",
@@ -845,7 +866,7 @@ func addProjectDetails(s *xorm.Session, projects []*Project, a web.Auth) (err er
 	for _, p := range projects {
 		ownerIDs = append(ownerIDs, p.OwnerID)
 		projectIDs = append(projectIDs, p.ID)
-		fileIDs = append(fileIDs, p.BackgroundFileID)
+		fileIDs = append(fileIDs, p.BackgroundFileID, p.CardBackgroundFileID)
 	}
 
 	owners, err := user.GetUsersByIDs(s, ownerIDs)
@@ -902,6 +923,9 @@ func addProjectDetails(s *xorm.Session, projects []*Project, a web.Auth) (err er
 		if p.BackgroundFileID != 0 {
 			p.BackgroundInformation = &ProjectBackgroundType{Type: ProjectBackgroundUpload}
 		}
+		if p.CardBackgroundFileID != 0 {
+			p.CardBackgroundInformation = &ProjectBackgroundType{Type: ProjectBackgroundUpload}
+		}
 
 		// Don't override the favorite state if it was already set from before (favorite saved filters do this)
 		if p.IsFavorite {
@@ -939,6 +963,9 @@ func addProjectDetails(s *xorm.Session, projects []*Project, a web.Auth) (err er
 		// Only override the file info if we have info for unsplash backgrounds
 		if _, exists := unsplashPhotos[l.BackgroundFileID]; exists {
 			l.BackgroundInformation = unsplashPhotos[l.BackgroundFileID]
+		}
+		if _, exists := unsplashPhotos[l.CardBackgroundFileID]; exists {
+			l.CardBackgroundInformation = unsplashPhotos[l.CardBackgroundFileID]
 		}
 	}
 
@@ -1540,6 +1567,11 @@ func (p *Project) Delete(s *xorm.Session, a web.Auth) (err error) {
 		return
 	}
 
+	err = fullProject.DeleteCardBackgroundFileIfExists(s)
+	if err != nil {
+		return
+	}
+
 	// If we're deleting a default project, remove it as default
 	if isDefaultProject {
 		_, err = s.Where("default_project_id = ?", p.ID).
@@ -1652,6 +1684,45 @@ func ClearProjectBackground(s *xorm.Session, projectID int64) (err error) {
 	_, err = s.
 		Where("id = ?", projectID).
 		Cols("background_file_id", "background_blur_hash").
+		Update(&Project{})
+	return
+}
+
+// DeleteCardBackgroundFileIfExists deletes the project's card image file from the db and the
+// filesystem, if one exists
+func (p *Project) DeleteCardBackgroundFileIfExists(s *xorm.Session) (err error) {
+	if p.CardBackgroundFileID == 0 {
+		return
+	}
+
+	file := files.File{ID: p.CardBackgroundFileID}
+	err = file.Delete(s)
+	if err != nil && files.IsErrFileDoesNotExist(err) {
+		return nil
+	}
+
+	return err
+}
+
+// SetProjectCardBackground sets a background file as the project's card image in the db
+func SetProjectCardBackground(s *xorm.Session, projectID int64, background *files.File, blurHash string) (err error) {
+	l := &Project{
+		ID:                     projectID,
+		CardBackgroundFileID:   background.ID,
+		CardBackgroundBlurHash: blurHash,
+	}
+	_, err = s.
+		Where("id = ?", l.ID).
+		Cols("card_background_file_id", "card_background_blur_hash").
+		Update(l)
+	return
+}
+
+// ClearProjectCardBackground clears the card image fields for a project without touching other columns.
+func ClearProjectCardBackground(s *xorm.Session, projectID int64) (err error) {
+	_, err = s.
+		Where("id = ?", projectID).
+		Cols("card_background_file_id", "card_background_blur_hash").
 		Update(&Project{})
 	return
 }

--- a/pkg/models/project_duplicate.go
+++ b/pkg/models/project_duplicate.go
@@ -115,7 +115,14 @@ func (pd *ProjectDuplicate) Create(s *xorm.Session, doer web.Auth) (err error) {
 
 	log.Debugf("Duplicated all views, buckets and positions from project %d into %d", pd.ProjectID, pd.Project.ID)
 
-	err = duplicateProjectBackground(s, pd, doer)
+	err = duplicateProjectImage(s, pd, doer, "background", pd.Project.BackgroundFileID, pd.Project.BackgroundBlurHash,
+		func() { pd.Project.BackgroundFileID = 0 }, SetProjectBackground)
+	if err != nil {
+		return
+	}
+
+	err = duplicateProjectImage(s, pd, doer, "card image", pd.Project.CardBackgroundFileID, pd.Project.CardBackgroundBlurHash,
+		func() { pd.Project.CardBackgroundFileID = 0 }, SetProjectCardBackground)
 	if err != nil {
 		return
 	}
@@ -290,17 +297,22 @@ func duplicateViews(s *xorm.Session, pd *ProjectDuplicate, doer web.Auth, taskMa
 	return
 }
 
-func duplicateProjectBackground(s *xorm.Session, pd *ProjectDuplicate, doer web.Auth) (err error) {
-	if pd.Project.BackgroundFileID == 0 {
+// duplicateProjectImage copies whichever project image (full background or card
+// image) fileID identifies into pd.Project, via setImage (SetProjectBackground or
+// SetProjectCardBackground). clearFileID resets the source project's in-memory field
+// when the underlying file already vanished, mirroring the two callers' prior
+// behavior of zeroing their own respective FileID field on that path.
+func duplicateProjectImage(s *xorm.Session, pd *ProjectDuplicate, doer web.Auth, label string, fileID int64, blurHash string, clearFileID func(), setImage func(s *xorm.Session, projectID int64, file *files.File, blurHash string) error) (err error) {
+	if fileID == 0 {
 		return
 	}
 
-	log.Debugf("Duplicating background %d from project %d into %d", pd.Project.BackgroundFileID, pd.ProjectID, pd.Project.ID)
+	log.Debugf("Duplicating %s %d from project %d into %d", label, fileID, pd.ProjectID, pd.Project.ID)
 
-	f := &files.File{ID: pd.Project.BackgroundFileID}
+	f := &files.File{ID: fileID}
 	err = f.LoadFileMetaByID(s)
 	if err != nil && files.IsErrFileDoesNotExist(err) {
-		pd.Project.BackgroundFileID = 0
+		clearFileID()
 		return nil
 	}
 	if err != nil {
@@ -322,7 +334,7 @@ func duplicateProjectBackground(s *xorm.Session, pd *ProjectDuplicate, doer web.
 	}
 
 	// Get unsplash info if applicable
-	up, err := GetUnsplashPhotoByFileID(s, pd.Project.BackgroundFileID)
+	up, err := GetUnsplashPhotoByFileID(s, fileID)
 	if err != nil && !files.IsErrFileIsNotUnsplashFile(err) {
 		return err
 	}
@@ -334,11 +346,11 @@ func duplicateProjectBackground(s *xorm.Session, pd *ProjectDuplicate, doer web.
 		}
 	}
 
-	if err := SetProjectBackground(s, pd.Project.ID, file, pd.Project.BackgroundBlurHash); err != nil {
+	if err := setImage(s, pd.Project.ID, file, blurHash); err != nil {
 		return err
 	}
 
-	log.Debugf("Duplicated project background from project %d into %d", pd.ProjectID, pd.Project.ID)
+	log.Debugf("Duplicated project %s from project %d into %d", label, pd.ProjectID, pd.Project.ID)
 
 	return nil
 }

--- a/pkg/models/project_test.go
+++ b/pkg/models/project_test.go
@@ -667,6 +667,11 @@ func TestProject_Delete(t *testing.T) {
 		db.AssertMissing(t, "files", map[string]interface{}{
 			"id": 1,
 		})
+		// Project 35 also has a card image (card_background_file_id 2, distinct
+		// from the background's file 1) — deleting the project must clean both up.
+		db.AssertMissing(t, "files", map[string]interface{}{
+			"id": 2,
+		})
 	})
 	t.Run("default project of the same user", func(t *testing.T) {
 		db.LoadAndAssertFixtures(t)

--- a/pkg/modules/background/background.go
+++ b/pkg/modules/background/background.go
@@ -30,9 +30,23 @@ type Image struct {
 	BlurHash string `json:"blur_hash" doc:"A BlurHash placeholder for the image."`
 	// This can be used to supply extra information from an image provider to clients
 	Info interface{} `json:"info,omitempty" doc:"Provider-specific extra information about the image (e.g. the Unsplash author for attribution)."`
+	// Target is set server-side by the calling handler, never by the client, to tell
+	// a Provider's Set method which project field (full background vs card image) to
+	// write. It defaults to TargetBackground so every existing caller is unaffected.
+	Target Target `xorm:"-" json:"-"`
 }
 
 const MaxBackgroundImageHeight = 3840
+
+// Target tells a Provider's Set method which project image field to write.
+type Target int
+
+const (
+	// TargetBackground is the full project background shown on the project header.
+	TargetBackground Target = iota
+	// TargetCard is the small image shown on the project's card in the project grid.
+	TargetCard
+)
 
 // Provider represents something that is able to get a project of images and set one of them as background
 type Provider interface {

--- a/pkg/modules/background/handler/background.go
+++ b/pkg/modules/background/handler/background.go
@@ -206,7 +206,7 @@ func (bp *BackgroundProvider) UploadBackground(c *echo.Context) error {
 	}
 	defer srcf.Close()
 
-	if err := ValidateAndSaveBackgroundUpload(s, auth, project, srcf, file.Filename, uint64(file.Size)); err != nil {
+	if err := ValidateAndSaveBackgroundUpload(s, auth, project, srcf, file.Filename, uint64(file.Size), background.TargetBackground); err != nil {
 		_ = s.Rollback()
 		if IsErrFileIsNoImage(err) {
 			return c.JSON(http.StatusBadRequest, models.Message{Message: "Uploaded file is no image."})
@@ -235,7 +235,7 @@ func (bp *BackgroundProvider) UploadBackground(c *echo.Context) error {
 // handler. project must already be loaded and the caller must have verified write
 // permission. On a non-image it returns ErrFileIsNoImage; on a recognized but
 // undecodable format ErrFileUnsupportedImageFormat.
-func ValidateAndSaveBackgroundUpload(s *xorm.Session, auth web.Auth, project *models.Project, srcf io.ReadSeeker, filename string, filesize uint64) error {
+func ValidateAndSaveBackgroundUpload(s *xorm.Session, auth web.Auth, project *models.Project, srcf io.ReadSeeker, filename string, filesize uint64, target background.Target) error {
 	mime, err := mimetype.DetectReader(srcf)
 	if err != nil {
 		return err
@@ -256,14 +256,14 @@ func ValidateAndSaveBackgroundUpload(s *xorm.Session, auth web.Auth, project *mo
 
 	// DetectReader consumed the head of the reader; SaveBackgroundFile seeks back to
 	// the start itself, so no rewind is needed here.
-	if err := SaveBackgroundFile(s, auth, project, srcf, filename, filesize); err != nil {
+	if err := SaveBackgroundFile(s, auth, project, srcf, filename, filesize, target); err != nil {
 		return err
 	}
 
 	return project.ReadOne(s, auth)
 }
 
-func SaveBackgroundFile(s *xorm.Session, auth web.Auth, project *models.Project, srcf io.ReadSeeker, filename string, filesize uint64) (err error) {
+func SaveBackgroundFile(s *xorm.Session, auth web.Auth, project *models.Project, srcf io.ReadSeeker, filename string, filesize uint64, target background.Target) (err error) {
 	mime, _ := mimetype.DetectReader(srcf)
 	_, _ = srcf.Seek(0, io.SeekStart)
 	src, err := imaging.Decode(srcf)
@@ -299,14 +299,19 @@ func SaveBackgroundFile(s *xorm.Session, auth web.Auth, project *models.Project,
 
 	// Generate a blurHash
 	_, _ = srcf.Seek(0, io.SeekStart)
-	project.BackgroundBlurHash, err = CreateBlurHash(srcf)
+	blurHash, err := CreateBlurHash(srcf)
 	if err != nil {
 		return err
+	}
+	if target == background.TargetCard {
+		project.CardBackgroundBlurHash = blurHash
+	} else {
+		project.BackgroundBlurHash = blurHash
 	}
 
 	// Save it
 	p := upload.Provider{}
-	img := &background.Image{ID: strconv.FormatInt(f.ID, 10)}
+	img := &background.Image{ID: strconv.FormatInt(f.ID, 10), Target: target}
 	err = p.Set(s, img, project, auth)
 	return err
 }
@@ -414,8 +419,25 @@ func LoadProjectBackgroundForDownload(s *xorm.Session, project *models.Project) 
 	if project.BackgroundFileID == 0 {
 		return nil, nil, &models.ErrProjectHasNoBackground{ProjectID: project.ID}
 	}
+	return loadFileForDownload(s, project.BackgroundFileID)
+}
 
-	bgFile = &files.File{ID: project.BackgroundFileID}
+// LoadProjectCardBackgroundForDownload is the card-image counterpart of
+// LoadProjectBackgroundForDownload. Returns ErrProjectHasNoCardBackground when the
+// project has none; the caller owns committing the session and closing bgFile.File.
+func LoadProjectCardBackgroundForDownload(s *xorm.Session, project *models.Project) (bgFile *files.File, stat os.FileInfo, err error) {
+	if project.CardBackgroundFileID == 0 {
+		return nil, nil, &models.ErrProjectHasNoCardBackground{ProjectID: project.ID}
+	}
+	return loadFileForDownload(s, project.CardBackgroundFileID)
+}
+
+// loadFileForDownload opens fileID (bytes ready to read) and stats it for the modtime
+// the download uses for caching. It also fires the Unsplash pingback side effect,
+// required by Unsplash's API guidelines and done server-side so no user details are
+// exposed. The caller owns committing the session and closing bgFile.File.
+func loadFileForDownload(s *xorm.Session, fileID int64) (bgFile *files.File, stat os.FileInfo, err error) {
+	bgFile = &files.File{ID: fileID}
 	if err := bgFile.LoadFileByID(); err != nil {
 		return nil, nil, err
 	}

--- a/pkg/modules/background/unsplash/unsplash.go
+++ b/pkg/modules/background/unsplash/unsplash.go
@@ -325,15 +325,19 @@ func (p *Provider) Set(s *xorm.Session, image *background.Image, project *models
 		return
 	}
 
-	// Remove the old background if one exists
-	if project.BackgroundFileID != 0 {
-		file := files.File{ID: project.BackgroundFileID}
+	// Remove the old background (or card image) if one exists
+	oldFileID := project.BackgroundFileID
+	if image.Target == background.TargetCard {
+		oldFileID = project.CardBackgroundFileID
+	}
+	if oldFileID != 0 {
+		file := files.File{ID: oldFileID}
 		err = file.Delete(s)
 		if err != nil && !files.IsErrFileDoesNotExist(err) {
 			return err
 		}
 
-		err = models.RemoveUnsplashPhoto(s, project.BackgroundFileID)
+		err = models.RemoveUnsplashPhoto(s, oldFileID)
 		if err != nil && !files.IsErrFileDoesNotExist(err) {
 			return err
 		}
@@ -351,6 +355,12 @@ func (p *Provider) Set(s *xorm.Session, image *background.Image, project *models
 		return
 	}
 	log.Debugf("Saved unsplash photo %s as file %d with new entry %d", image.ID, file.ID, unsplashPhoto.ID)
+
+	if image.Target == background.TargetCard {
+		project.CardBackgroundFileID = file.ID
+		project.CardBackgroundInformation = unsplashPhoto
+		return models.SetProjectCardBackground(s, project.ID, file, photo.BlurHash)
+	}
 
 	// Set the file in the project
 	project.BackgroundFileID = file.ID

--- a/pkg/modules/background/upload/upload.go
+++ b/pkg/modules/background/upload/upload.go
@@ -53,6 +53,10 @@ func (p *Provider) Search(_ *xorm.Session, _ string, _ int64) (result []*backgro
 // @Failure 500 {object} models.Message "Internal error"
 // @Router /projects/{id}/backgrounds/upload [put]
 func (p *Provider) Set(s *xorm.Session, img *background.Image, project *models.Project, _ web.Auth) (err error) {
+	if img.Target == background.TargetCard {
+		return p.setCard(s, img, project)
+	}
+
 	// Remove the old background if one exists
 	if project.BackgroundFileID != 0 {
 		file := files.File{ID: project.BackgroundFileID}
@@ -71,4 +75,25 @@ func (p *Provider) Set(s *xorm.Session, img *background.Image, project *models.P
 	project.BackgroundInformation = &models.ProjectBackgroundType{Type: models.ProjectBackgroundUpload}
 
 	return models.SetProjectBackground(s, project.ID, file, project.BackgroundBlurHash)
+}
+
+func (p *Provider) setCard(s *xorm.Session, img *background.Image, project *models.Project) (err error) {
+	// Remove the old card image if one exists
+	if project.CardBackgroundFileID != 0 {
+		file := files.File{ID: project.CardBackgroundFileID}
+		err := file.Delete(s)
+		if err != nil && !files.IsErrFileDoesNotExist(err) {
+			return err
+		}
+	}
+
+	file := &files.File{}
+	file.ID, err = strconv.ParseInt(img.ID, 10, 64)
+	if err != nil {
+		return
+	}
+
+	project.CardBackgroundInformation = &models.ProjectBackgroundType{Type: models.ProjectBackgroundUpload}
+
+	return models.SetProjectCardBackground(s, project.ID, file, project.CardBackgroundBlurHash)
 }

--- a/pkg/modules/migration/create_from_structure.go
+++ b/pkg/modules/migration/create_from_structure.go
@@ -29,6 +29,7 @@ import (
 	"code.vikunja.io/api/pkg/events"
 	"code.vikunja.io/api/pkg/log"
 	"code.vikunja.io/api/pkg/models"
+	"code.vikunja.io/api/pkg/modules/background"
 	"code.vikunja.io/api/pkg/modules/background/handler"
 	"code.vikunja.io/api/pkg/user"
 	"code.vikunja.io/api/pkg/utils"
@@ -222,7 +223,7 @@ func createProjectWithEverything(s *xorm.Session, project *models.ProjectWithTas
 
 		log.Debugf("[creating structure] Creating a background file for project %d", project.ID)
 
-		err = handler.SaveBackgroundFile(s, user, &project.Project, backgroundFile, "", uint64(backgroundFile.Len()))
+		err = handler.SaveBackgroundFile(s, user, &project.Project, backgroundFile, "", uint64(backgroundFile.Len()), background.TargetBackground)
 		if err != nil {
 			log.Errorf("[creating structure] Could not create background for project %d, error was %v", project.ID, err)
 		}

--- a/pkg/routes/api/v2/backgrounds.go
+++ b/pkg/routes/api/v2/backgrounds.go
@@ -268,7 +268,7 @@ func backgroundUpload(ctx context.Context, in *backgroundUploadInput) (*singleBo
 	file := in.RawBody.Data().Background
 	defer func() { _ = file.Close() }()
 
-	if err := backgroundHandler.ValidateAndSaveBackgroundUpload(s, a, project, file, file.Filename, uint64(file.Size)); err != nil {
+	if err := backgroundHandler.ValidateAndSaveBackgroundUpload(s, a, project, file, file.Filename, uint64(file.Size), background.TargetBackground); err != nil {
 		_ = s.Rollback()
 		if backgroundHandler.IsErrFileIsNoImage(err) || backgroundHandler.IsErrFileUnsupportedImageFormat(err) {
 			return nil, huma.Error400BadRequest(err.Error())

--- a/pkg/routes/api/v2/card_backgrounds.go
+++ b/pkg/routes/api/v2/card_backgrounds.go
@@ -1,0 +1,291 @@
+// Vikunja is a to-do list application to facilitate your life.
+// Copyright 2018-present Vikunja and contributors. All rights reserved.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package apiv2
+
+import (
+	"context"
+	"net/http"
+
+	"code.vikunja.io/api/pkg/config"
+	"code.vikunja.io/api/pkg/db"
+	"code.vikunja.io/api/pkg/models"
+	"code.vikunja.io/api/pkg/modules/background"
+	backgroundHandler "code.vikunja.io/api/pkg/modules/background/handler"
+	"code.vikunja.io/api/pkg/modules/background/unsplash"
+	webfiles "code.vikunja.io/api/pkg/web/files"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/danielgtaylor/huma/v2/adapters/humaecho"
+)
+
+// RegisterCardBackgroundRoutes wires the project-card-image actions onto the Huma
+// API. It reuses the Unsplash search/proxy endpoints already registered by
+// RegisterBackgroundRoutes (they're generic, not tied to the full background) and
+// only adds the project-scoped get/delete/upload/unsplash-set endpoints for the
+// separate card image field.
+func RegisterCardBackgroundRoutes(api huma.API) {
+	if !config.BackgroundsEnabled.GetBool() {
+		return
+	}
+
+	tags := []string{"project"}
+
+	Register(api, huma.Operation{
+		OperationID: "projects-card-background-delete",
+		Summary:     "Remove a project card image",
+		Description: "Removes a project's card image, whichever provider set it. Succeeds even when the project has no card image. Requires write access to the project. Returns the updated project. Does not affect the project's full background.",
+		Method:      http.MethodDelete,
+		Path:        "/projects/{project}/card-background",
+		// Return the updated project with 200, not the wrapper's DELETE default 204.
+		DefaultStatus: http.StatusOK,
+		Tags:          tags,
+	}, cardBackgroundRemove)
+
+	Register(api, huma.Operation{
+		OperationID: "projects-card-background-get",
+		Summary:     "Get a project card image",
+		Description: "Streams a project's card image, whichever provider set it. Requires read access to the project. Always served as image/jpeg with a revalidation Last-Modified header, so a conditional If-Modified-Since request gets a 304. Returns 404 when the project has no card image.",
+		Method:      http.MethodGet,
+		Path:        "/projects/{project}/card-background",
+		Tags:        tags,
+		// Spell out the binary response; the default would be modeled as JSON.
+		Responses: map[string]*huma.Response{
+			"200": {
+				Description: "The project card image as a jpeg image.",
+				Content: map[string]*huma.MediaType{
+					"image/jpeg": {
+						Schema: &huma.Schema{Type: huma.TypeString, Format: "binary"},
+					},
+				},
+			},
+		},
+	}, cardBackgroundGet)
+
+	if config.BackgroundsUploadEnabled.GetBool() {
+		Register(api, huma.Operation{
+			OperationID: "projects-card-background-upload",
+			Summary:     "Upload a project card image",
+			Description: "Uploads an image via multipart/form-data under the \"background\" field and sets it as the project's card image. Requires write access to the project. The image is resized server-side and stored as JPEG; it replaces any previous card image (idempotent replace, hence PUT). Returns the updated project. Does not affect the project's full background.",
+			Method:      http.MethodPut,
+			Path:        "/projects/{project}/card-backgrounds/upload",
+			// Return the updated project with 200, the natural code for an idempotent PUT.
+			DefaultStatus: http.StatusOK,
+			Tags:          tags,
+			// +2 MB mirrors Echo's global BodyLimit overhead so a max-sized file isn't rejected by multipart boundary/header bytes.
+			// #nosec G115 - configured value won't exceed int64 max in practice.
+			MaxBodyBytes: (int64(config.GetMaxFileSizeInMBytes()) + 2) * 1024 * 1024,
+		}, cardBackgroundUpload)
+	}
+
+	if config.BackgroundsUnsplashEnabled.GetBool() {
+		Register(api, huma.Operation{
+			OperationID: "projects-card-background-unsplash-set",
+			Summary:     "Set an Unsplash image as project card image",
+			Description: "Sets a previously searched Unsplash image (from GET /backgrounds/unsplash/search) as the project's card image, identified by the image id from the search results. Requires write access to the project. Does not affect the project's full background.",
+			Method:      http.MethodPut,
+			Path:        "/projects/{project}/card-backgrounds/unsplash",
+			Tags:        tags,
+		}, cardBackgroundUnsplashSet)
+	}
+}
+
+func init() { AddRouteRegistrar(RegisterCardBackgroundRoutes) }
+
+func cardBackgroundUnsplashSet(ctx context.Context, in *struct {
+	ProjectID int64 `path:"project"`
+	Body      background.Image
+}) (*singleBody[models.Project], error) {
+	a, err := authFromCtx(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	s := db.NewSession()
+	defer s.Close()
+
+	project := &models.Project{ID: in.ProjectID}
+	can, err := project.CanWrite(s, a)
+	if err != nil {
+		_ = s.Rollback()
+		return nil, translateDomainError(err)
+	}
+	if !can {
+		_ = s.Rollback()
+		return nil, huma.Error403Forbidden("forbidden")
+	}
+	project, err = models.GetProjectSimpleByID(s, in.ProjectID)
+	if err != nil {
+		_ = s.Rollback()
+		return nil, translateDomainError(err)
+	}
+
+	in.Body.Target = background.TargetCard
+
+	p := &unsplash.Provider{}
+	if err := p.Set(s, &in.Body, project, a); err != nil {
+		_ = s.Rollback()
+		return nil, translateDomainError(err)
+	}
+	if err := project.ReadOne(s, a); err != nil {
+		_ = s.Rollback()
+		return nil, translateDomainError(err)
+	}
+	if err := s.Commit(); err != nil {
+		return nil, translateDomainError(err)
+	}
+
+	return &singleBody[models.Project]{Body: project}, nil
+}
+
+type cardBackgroundUploadInput struct {
+	ProjectID int64 `path:"project" doc:"The id of the project to set the card image on."`
+	// Allow-list mirrors the formats background uploads can actually be decoded as
+	// (handler.ValidateAndSaveBackgroundUpload's allowedImageMimes); octet-stream covers
+	// programmatic clients. Huma's MimeTypeValidator rejects the part pre-handler, so the
+	// byte-level image check in the shared function is the real gate.
+	RawBody huma.MultipartFormFiles[struct {
+		Background huma.FormFile `form:"background" contentType:"image/jpeg,image/png,image/gif,image/bmp,image/tiff,image/webp,application/octet-stream" required:"true" doc:"The card image to upload. Must be a decodable raster image (JPEG, PNG, GIF, BMP, TIFF or WebP); it is resized server-side and re-encoded as JPEG."`
+	}]
+}
+
+// cardBackgroundUpload mirrors backgroundUpload (backgrounds.go): owns auth, the
+// session and the permission check because there is no handler.Do* for multipart
+// uploads (see the api-v2-routes skill's "Non-CRUDable / custom routes" section).
+func cardBackgroundUpload(ctx context.Context, in *cardBackgroundUploadInput) (*singleBody[models.Project], error) {
+	a, err := authFromCtx(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	s := db.NewSession()
+	defer s.Close()
+
+	project := &models.Project{ID: in.ProjectID}
+	can, err := project.CanWrite(s, a)
+	if err != nil {
+		_ = s.Rollback()
+		return nil, translateDomainError(err)
+	}
+	if !can {
+		_ = s.Rollback()
+		return nil, huma.Error403Forbidden("forbidden")
+	}
+	project, err = models.GetProjectSimpleByID(s, in.ProjectID)
+	if err != nil {
+		_ = s.Rollback()
+		return nil, translateDomainError(err)
+	}
+
+	file := in.RawBody.Data().Background
+	defer func() { _ = file.Close() }()
+
+	if err := backgroundHandler.ValidateAndSaveBackgroundUpload(s, a, project, file, file.Filename, uint64(file.Size), background.TargetCard); err != nil {
+		_ = s.Rollback()
+		if backgroundHandler.IsErrFileIsNoImage(err) || backgroundHandler.IsErrFileUnsupportedImageFormat(err) {
+			return nil, huma.Error400BadRequest(err.Error())
+		}
+		return nil, translateDomainError(err)
+	}
+
+	if err := s.Commit(); err != nil {
+		return nil, translateDomainError(err)
+	}
+
+	return &singleBody[models.Project]{Body: project}, nil
+}
+
+// cardBackgroundGet mirrors backgroundGet (backgrounds.go).
+func cardBackgroundGet(ctx context.Context, in *struct {
+	ProjectID int64 `path:"project" doc:"The id of the project whose card image to fetch."`
+}) (*huma.StreamResponse, error) {
+	a, err := authFromCtx(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	s := db.NewSession()
+	defer s.Close()
+
+	project := &models.Project{ID: in.ProjectID}
+	can, _, err := project.CanRead(s, a)
+	if err != nil {
+		_ = s.Rollback()
+		return nil, translateDomainError(err)
+	}
+	if !can {
+		_ = s.Rollback()
+		return nil, huma.Error403Forbidden("forbidden")
+	}
+
+	bgFile, stat, err := backgroundHandler.LoadProjectCardBackgroundForDownload(s, project)
+	if err != nil {
+		_ = s.Rollback()
+		return nil, translateDomainError(err)
+	}
+
+	// The file reader comes from object storage, not the DB session, so it stays
+	// valid after the commit; the StreamResponse callback runs after this returns.
+	if err := s.Commit(); err != nil {
+		_ = s.Rollback()
+		// The stream callback (which closes the reader) won't run on this error path.
+		_ = bgFile.File.Close()
+		return nil, translateDomainError(err)
+	}
+
+	return &huma.StreamResponse{Body: func(hctx huma.Context) {
+		defer func() { _ = bgFile.File.Close() }()
+		c := humaecho.Unwrap(hctx)
+		webfiles.WriteProjectBackground((*c).Response(), (*c).Request(), bgFile, stat)
+	}}, nil
+}
+
+func cardBackgroundRemove(ctx context.Context, in *struct {
+	ProjectID int64 `path:"project"`
+}) (*singleBody[models.Project], error) {
+	a, err := authFromCtx(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	s := db.NewSession()
+	defer s.Close()
+
+	project := &models.Project{ID: in.ProjectID}
+	can, err := project.CanWrite(s, a)
+	if err != nil {
+		_ = s.Rollback()
+		return nil, translateDomainError(err)
+	}
+	if !can {
+		_ = s.Rollback()
+		return nil, huma.Error403Forbidden("forbidden")
+	}
+
+	if err := project.DeleteCardBackgroundFileIfExists(s); err != nil {
+		_ = s.Rollback()
+		return nil, translateDomainError(err)
+	}
+	if err := models.ClearProjectCardBackground(s, project.ID); err != nil {
+		_ = s.Rollback()
+		return nil, translateDomainError(err)
+	}
+	if err := s.Commit(); err != nil {
+		return nil, translateDomainError(err)
+	}
+
+	return &singleBody[models.Project]{Body: project}, nil
+}

--- a/pkg/webtests/huma_card_background_test.go
+++ b/pkg/webtests/huma_card_background_test.go
@@ -1,0 +1,218 @@
+// Vikunja is a to-do list application to facilitate your life.
+// Copyright 2018-present Vikunja and contributors. All rights reserved.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package webtests
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"code.vikunja.io/api/pkg/config"
+	"code.vikunja.io/api/pkg/db"
+	"code.vikunja.io/api/pkg/models"
+	"code.vikunja.io/api/pkg/routes"
+
+	"github.com/labstack/echo/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func uploadCardBackgroundRequest(t *testing.T, e *echo.Echo, project, token string, body *bytes.Buffer, contentType string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPut, "/api/v2/projects/"+project+"/card-backgrounds/upload", body)
+	req.Header.Set("Content-Type", contentType)
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	return rec
+}
+
+func getCardBackgroundRequest(t *testing.T, e *echo.Echo, project, token string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/api/v2/projects/"+project+"/card-background", nil)
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	return rec
+}
+
+// TestHumaProjectCardBackgroundDelete mirrors TestHumaProjectBackgroundDelete but
+// also asserts the key independence guarantee: deleting the card image must not
+// touch the project's separate full background (project 35 has both, on distinct
+// files: background_file_id 1, card_background_file_id 2).
+func TestHumaProjectCardBackgroundDelete(t *testing.T) {
+	e, err := setupTestEnv()
+	require.NoError(t, err)
+
+	t.Run("Owner clears the card image, background untouched", func(t *testing.T) {
+		rec := humaRequest(t, e, http.MethodDelete, "/api/v2/projects/35/card-background", "", humaTokenFor(t, &testuser6), "")
+		require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+
+		s := db.NewSession()
+		defer s.Close()
+		project := models.Project{ID: 35}
+		has, err := s.Get(&project)
+		require.NoError(t, err)
+		require.True(t, has)
+		assert.Equal(t, "Test35 with background", project.Title)
+		assert.Equal(t, int64(0), project.CardBackgroundFileID)
+		assert.Equal(t, int64(1), project.BackgroundFileID, "the full background must be unaffected")
+	})
+	t.Run("Read-only user is forbidden", func(t *testing.T) {
+		rec := humaRequest(t, e, http.MethodDelete, "/api/v2/projects/35/card-background", "", humaTokenFor(t, &testuser15), "")
+		assert.Equal(t, http.StatusForbidden, rec.Code, "body: %s", rec.Body.String())
+	})
+	t.Run("No access at all is forbidden", func(t *testing.T) {
+		rec := humaRequest(t, e, http.MethodDelete, "/api/v2/projects/35/card-background", "", humaTokenFor(t, &testuser1), "")
+		assert.Equal(t, http.StatusForbidden, rec.Code, "body: %s", rec.Body.String())
+	})
+}
+
+// TestHumaCardBackgroundDisabledByConfig mirrors TestHumaBackgroundDisabledByConfig:
+// card routes reuse the same backgrounds.enabled gate.
+func TestHumaCardBackgroundDisabledByConfig(t *testing.T) {
+	_, err := setupTestEnv()
+	require.NoError(t, err)
+
+	config.BackgroundsEnabled.Set(false)
+	defer config.BackgroundsEnabled.Set(true)
+
+	e := routes.NewEcho()
+	routes.RegisterRoutes(e)
+
+	rec := humaRequest(t, e, http.MethodDelete, "/api/v2/projects/35/card-background", "", humaTokenFor(t, &testuser6), "")
+	assert.Equal(t, http.StatusNotFound, rec.Code, "route must be absent when backgrounds are disabled; body: %s", rec.Body.String())
+}
+
+// TestHumaProjectCardBackgroundUpload mirrors TestHumaProjectBackgroundUpload and
+// additionally verifies uploading a card image on project 35 does not disturb its
+// existing full background.
+func TestHumaProjectCardBackgroundUpload(t *testing.T) {
+	e, err := setupTestEnv()
+	require.NoError(t, err)
+
+	t.Run("Owner uploads a card image", func(t *testing.T) {
+		// testuser1 owns project 1, which starts without a card image.
+		body, contentType := multipartFileBody(t, "background", "card.png", pngBytes(t))
+		rec := uploadCardBackgroundRequest(t, e, "1", humaTokenFor(t, &testuser1), body, contentType)
+		require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+
+		s := db.NewSession()
+		defer s.Close()
+		project := models.Project{ID: 1}
+		has, err := s.Get(&project)
+		require.NoError(t, err)
+		require.True(t, has)
+		assert.NotZero(t, project.CardBackgroundFileID, "the upload must set a card image file id")
+		assert.NotEmpty(t, project.CardBackgroundBlurHash, "the upload must compute a blur hash")
+	})
+
+	t.Run("Uploading a card image leaves the existing background untouched", func(t *testing.T) {
+		body, contentType := multipartFileBody(t, "background", "card.png", pngBytes(t))
+		rec := uploadCardBackgroundRequest(t, e, "35", humaTokenFor(t, &testuser6), body, contentType)
+		require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+
+		s := db.NewSession()
+		defer s.Close()
+		project := models.Project{ID: 35}
+		has, err := s.Get(&project)
+		require.NoError(t, err)
+		require.True(t, has)
+		assert.Equal(t, int64(1), project.BackgroundFileID, "the full background must be unaffected")
+	})
+
+	t.Run("Non-image rejected with 400", func(t *testing.T) {
+		body, contentType := multipartFileBody(t, "background", "not-an-image.txt", []byte("this is plain text, not an image"))
+		rec := uploadCardBackgroundRequest(t, e, "1", humaTokenFor(t, &testuser1), body, contentType)
+		require.Equal(t, http.StatusBadRequest, rec.Code, "body: %s", rec.Body.String())
+	})
+
+	t.Run("Read-only user is forbidden", func(t *testing.T) {
+		body, contentType := multipartFileBody(t, "background", "card.png", pngBytes(t))
+		rec := uploadCardBackgroundRequest(t, e, "35", humaTokenFor(t, &testuser15), body, contentType)
+		assert.Equal(t, http.StatusForbidden, rec.Code, "body: %s", rec.Body.String())
+	})
+
+	t.Run("Unauthenticated", func(t *testing.T) {
+		body, contentType := multipartFileBody(t, "background", "card.png", pngBytes(t))
+		rec := uploadCardBackgroundRequest(t, e, "1", "", body, contentType)
+		require.Equal(t, http.StatusUnauthorized, rec.Code, "body: %s", rec.Body.String())
+	})
+}
+
+// TestHumaProjectCardBackgroundDownload covers GET .../card-background, mirroring
+// TestHumaProjectBackgroundDownload's upload-then-download pattern.
+func TestHumaProjectCardBackgroundDownload(t *testing.T) {
+	e, err := setupTestEnv()
+	require.NoError(t, err)
+
+	t.Run("Owner uploads then downloads the card image", func(t *testing.T) {
+		body, contentType := multipartFileBody(t, "background", "card.png", pngBytes(t))
+		up := uploadCardBackgroundRequest(t, e, "1", humaTokenFor(t, &testuser1), body, contentType)
+		require.Equal(t, http.StatusOK, up.Code, "upload body: %s", up.Body.String())
+
+		rec := getCardBackgroundRequest(t, e, "1", humaTokenFor(t, &testuser1))
+		require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+		assert.Equal(t, "image/jpg", rec.Header().Get("Content-Type"))
+		assert.NotEmpty(t, rec.Body.Bytes(), "the download must return the stored bytes")
+	})
+
+	t.Run("Project without a card image returns 404", func(t *testing.T) {
+		// testuser1 owns project 21, which has neither a background nor a card image.
+		rec := getCardBackgroundRequest(t, e, "21", humaTokenFor(t, &testuser1))
+		assert.Equal(t, http.StatusNotFound, rec.Code, "body: %s", rec.Body.String())
+	})
+
+	t.Run("No access at all is forbidden", func(t *testing.T) {
+		rec := getCardBackgroundRequest(t, e, "35", humaTokenFor(t, &testuser1))
+		assert.Equal(t, http.StatusForbidden, rec.Code, "body: %s", rec.Body.String())
+	})
+
+	t.Run("Unauthenticated", func(t *testing.T) {
+		rec := getCardBackgroundRequest(t, e, "35", "")
+		assert.Equal(t, http.StatusUnauthorized, rec.Code, "body: %s", rec.Body.String())
+	})
+}
+
+// TestHumaCardBackgroundUnsplash covers the card-image Unsplash "set" route's auth
+// and permission gates, mirroring TestHumaUnsplashBackground. The shared
+// /backgrounds/unsplash/search and proxy routes are already covered there.
+func TestHumaCardBackgroundUnsplash(t *testing.T) {
+	_, err := setupTestEnv()
+	require.NoError(t, err)
+
+	config.BackgroundsEnabled.Set(true)
+	config.BackgroundsUnsplashEnabled.Set(true)
+	defer config.BackgroundsUnsplashEnabled.Set(false)
+
+	e := routes.NewEcho()
+	routes.RegisterRoutes(e)
+
+	t.Run("Set requires auth", func(t *testing.T) {
+		rec := humaRequest(t, e, http.MethodPut, "/api/v2/projects/35/card-backgrounds/unsplash", `{"id":"abc"}`, "", "")
+		assert.Equal(t, http.StatusUnauthorized, rec.Code, "body: %s", rec.Body.String())
+	})
+	t.Run("Set forbidden for read-only user", func(t *testing.T) {
+		rec := humaRequest(t, e, http.MethodPut, "/api/v2/projects/35/card-backgrounds/unsplash", `{"id":"abc"}`, humaTokenFor(t, &testuser15), "")
+		assert.Equal(t, http.StatusForbidden, rec.Code, "body: %s", rec.Body.String())
+	})
+}


### PR DESCRIPTION
## Summary

Closes #3590.

Adds a per-project **card image**, shown on the project's square card in the project grid, fully independent from the existing full-bleed **background** (shown on the project header). Setting, removing, or duplicating one never affects the other — a project can have both, either, or neither.

- New `CardBackgroundFileID`/`CardBackgroundInformation`/`CardBackgroundBlurHash` fields on `Project`, mirroring the existing background fields (migration included).
- Supports both upload and Unsplash search, same as the background picker. A shared `Target` enum lets the existing upload/Unsplash providers write to either field pair instead of duplicating those providers.
- New `/api/v2` routes for get/delete/upload/unsplash-set (`pkg/routes/api/v2/card_backgrounds.go`); reuses the existing generic Unsplash search/proxy endpoints rather than duplicating them.
- New "Card image settings" page and menu entry. The background and card-image settings pages now share a `ProjectImagePicker.vue` component instead of being a near-duplicate of each other.
- Project duplication, export, and project deletion all handle the new fields, via the same generalized helpers used for the background (`duplicateProjectImage` in `pkg/models/project_duplicate.go`).

## Test plan

- [x] New `pkg/webtests/huma_card_background_test.go` covering get/delete/upload/unsplash-gate, plus a regression test proving deleting/uploading the card image never touches the background and vice versa
- [x] Existing background webtests still pass unchanged
- [x] `pkg/models` test suite passes, including `TestProjectDuplicate` against the refactored duplication helper
- [x] Full `mage test:feature` suite passes
- [x] Migration applied and re-applied (idempotent) against a real SQLite DB, columns verified in the schema
- [x] `mage lint:fix` (0 issues) and frontend `pnpm lint`/`pnpm lint:styles` (0 errors)
- [x] Manually tested end-to-end against a live local instance: uploaded a background and a card image to the same project via the running frontend/backend, confirmed both show independently and persist through a project duplication

## Disclosure

This PR was implemented with AI assistance (Claude). I reviewed the diff, ran it against a live local instance, and tested the flows above myself before opening this PR, per CONTRIBUTING.md.