### PR TITLE
feat(filter): support @me macro in task assignee queries

### DIFF
--- a/frontend/src/components/input/filter/FilterAutocomplete.ts
+++ b/frontend/src/components/input/filter/FilterAutocomplete.ts
@@ -22,6 +22,7 @@ import ProjectUserService from '@/services/projectUsers'
 import type { IUser } from '@/modelTypes/IUser'
 import type { IProject } from '@/modelTypes/IProject'
 import type { Label } from '@/client/generated'
+import {i18n} from '@/i18n'
 
 export interface FilterAutocompleteOptions {
 	projectId?: number
@@ -238,6 +239,15 @@ export default Extension.create<FilterAutocompleteOptions>({
 									userSuggestions = await projectUserService.getAll({projectId: this.options.projectId}, {s: autocompleteContext.search}) as SuggestionItem[]
 								} else {
 									userSuggestions = await userService.getAll({} as IUser, {s: autocompleteContext.search}) as SuggestionItem[]
+								}
+								if (autocompleteContext.search === '' || '@me'.startsWith(autocompleteContext.search.toLowerCase())) {
+									const meMacro = {
+										id: 0,
+										username: '@me',
+										title: '@me',
+										name: i18n.global.t('filters.query.you'),
+									} as unknown as SuggestionItem
+									userSuggestions = [meMacro, ...userSuggestions]
 								}
 								// Show suggestions even with empty search, but limit if we have many
 								if (autocompleteContext.search === '' && userSuggestions.length > 10) {

--- a/frontend/src/components/input/filter/FilterInputDocs.vue
+++ b/frontend/src/components/input/filter/FilterInputDocs.vue
@@ -63,6 +63,7 @@ const showDocs = ref(false)
 				{{ $t('filters.query.help.examples.undoneHighPriority') }}
 			</li>
 			<li><code>assignees in user1, user2</code>: {{ $t('filters.query.help.examples.assigneesIn') }}</li>
+			<li><code>assignees in @me</code>: {{ $t('filters.query.help.examples.assigneesInMe') }}</li>
 			<li><code>createdBy = user1</code>: {{ $t('filters.query.help.examples.createdByEqual') }}</li>
 			<li>
 				<code>(priority = 1 || priority = 2) &amp;&amp; dueDate &lt;= now</code>:

--- a/frontend/src/i18n/lang/en.json
+++ b/frontend/src/i18n/lang/en.json
@@ -614,6 +614,7 @@
     "query": {
       "label": "Filter query",
       "placeholder": "Type a search or filter query…",
+      "you": "You ({'@'}me)",
       "help": {
         "intro": "To filter tasks, you can use a query syntax similar to SQL. The available fields for filtering include:",
         "link": "How does this work?",
@@ -658,6 +659,7 @@
           "dueDatePast": "Matches tasks with a due date in the past",
           "undoneHighPriority": "Matches undone tasks with priority level 3 or higher",
           "assigneesIn": "Matches tasks assigned to either \"user1\" or \"user2\"",
+          "assigneesInMe": "Matches tasks assigned to the current user",
           "createdByEqual": "Matches tasks created by \"user1\"",
           "priorityOneOrTwoPastDue": "Matches tasks with priority level 1 or 2 and a due date in the past"
         }

--- a/pkg/models/task_search.go
+++ b/pkg/models/task_search.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"code.vikunja.io/api/pkg/db"
+	"code.vikunja.io/api/pkg/user"
 	"code.vikunja.io/api/pkg/web"
 
 	"xorm.io/builder"
@@ -503,8 +504,66 @@ func buildParentSearchCondition(search string) builder.Cond {
 	return cond
 }
 
+func replaceUserMacro(val string, username string) string {
+	valTrim := strings.TrimSpace(val)
+	if valTrim == "@me" {
+		return username
+	}
+	return val
+}
+
+func resolveCurrentUserMacros(filters []*taskFilter, username string) []*taskFilter {
+	if username == "" || len(filters) == 0 {
+		return filters
+	}
+
+	cloned := make([]*taskFilter, len(filters))
+	for i, f := range filters {
+		c := *f
+		switch v := f.value.(type) {
+		case string:
+			c.value = replaceUserMacro(v, username)
+		case []string:
+			newSlice := make([]string, len(v))
+			for idx, item := range v {
+				newSlice[idx] = replaceUserMacro(item, username)
+			}
+			c.value = newSlice
+		case []interface{}:
+			newSlice := make([]interface{}, len(v))
+			for idx, item := range v {
+				if strItem, ok := item.(string); ok {
+					newSlice[idx] = replaceUserMacro(strItem, username)
+				} else {
+					newSlice[idx] = item
+				}
+			}
+			c.value = newSlice
+		case []*taskFilter:
+			c.value = resolveCurrentUserMacros(v, username)
+		}
+		cloned[i] = &c
+	}
+	return cloned
+}
+
 //nolint:gocyclo
 func (d *dbTaskSearcher) Search(opts *taskSearchOptions) (tasks []*Task, totalCount int64, err error) {
+
+	if d.a != nil && d.a.GetID() > 0 {
+		var currentUsername string
+		if u, ok := d.a.(*user.User); ok && u.Username != "" {
+			currentUsername = u.Username
+		} else {
+			u, err := user.GetUserByID(d.s, d.a.GetID())
+			if err == nil && u != nil {
+				currentUsername = u.Username
+			}
+		}
+		if currentUsername != "" {
+			opts.parsedFilters = resolveCurrentUserMacros(opts.parsedFilters, currentUsername)
+		}
+	}
 
 	joinTaskBuckets := hasBucketIDInParsedFilter(opts.parsedFilters)
 

--- a/pkg/models/task_search_test.go
+++ b/pkg/models/task_search_test.go
@@ -336,3 +336,37 @@ func TestTaskSearchTitleBoost(t *testing.T) {
 		assert.Less(t, pos[descBoth.ID], pos[titleHit.ID], "two description matches (2.0) must outrank one boosted title match (1.5)")
 	})
 }
+
+func TestTaskSearchCurrentUserMacro(t *testing.T) {
+	t.Run("resolves @me macro to authenticated username", func(t *testing.T) {
+		filters := []*taskFilter{
+			{field: "assignees", value: "@me"},
+			{field: "assignees", value: []string{"@me", "john"}},
+			{field: "assignees", value: []interface{}{"@me", "alice"}},
+			{
+				field: "assignees",
+				value: []*taskFilter{
+					{field: "assignees", value: "@me"},
+				},
+			},
+		}
+
+		resolved := resolveCurrentUserMacros(filters, "samuel")
+		require.Len(t, resolved, 4)
+		assert.Equal(t, "samuel", resolved[0].value)
+		assert.Equal(t, []string{"samuel", "john"}, resolved[1].value)
+		assert.Equal(t, []interface{}{"samuel", "alice"}, resolved[2].value)
+
+		nested := resolved[3].value.([]*taskFilter)
+		require.Len(t, nested, 1)
+		assert.Equal(t, "samuel", nested[0].value)
+	})
+
+	t.Run("returns unchanged filters when username is empty", func(t *testing.T) {
+		filters := []*taskFilter{
+			{field: "assignees", value: "@me"},
+		}
+		resolved := resolveCurrentUserMacros(filters, "")
+		assert.Equal(t, "@me", resolved[0].value)
+	})
+}


### PR DESCRIPTION
Resolves #3413
Depends on #3816

## Summary
Supports the `@me` macro in filter queries (e.g. `assignees in @me` or `assignees = @me`), dynamically resolving `@me` to the logged-in user's username during search execution.

- **Dynamic Macro Resolution (`pkg/models/task_search.go`)**:
  - Replaces `@me` with the authenticated user's actual username in memory before query execution.
  - The stored filter string in the database retains `@me` so saved filters and kanban views resolve dynamically for whoever is querying.
  - Supports single values, `[]string` slices, `[]interface{}` arrays, and recursively resolves nested filter structures.

- **Frontend Autocomplete & Docs (`FilterAutocomplete.ts`, `FilterInputDocs.vue`)**:
  - Suggests `@me` with the localized display name `You (@me)` at the top of user autocomplete suggestions.
  - Adds an `assignees in @me` example in the filter query help modal.

- **i18n Localization (`en.json`)**:
  - Added translation keys `filters.query.you` (`"You (@me)"`) and `filters.query.help.examples.assigneesInMe` (`"Matches tasks assigned to the current user"`).
  - Based on the [Vikunja Translation Guide](https://vikunja.io/docs/translations/) and the contributing guide, no attempts were made with AI to translate localized strings. This will be left with Crowdlin.

## Testing
- Unit tests in `pkg/models/task_search_test.go` (`TestTaskSearchCurrentUserMacro`) covering string, slice, array, nested macro replacements, and unauthenticated/empty behavior.
- Translation sync checks (`mage check:translations`) and frontend lint/typechecks (`eslint`, `vue-tsc`) passing.