### PR TITLE
fix(migration): preserve todoist task descriptions

### DIFF
--- a/pkg/modules/migration/todoist/todoist.go
+++ b/pkg/modules/migration/todoist/todoist.go
@@ -83,6 +83,7 @@ type item struct {
 	UserID         string      `json:"user_id"`
 	ProjectID      string      `json:"project_id"`
 	Content        string      `json:"content"`
+	Description    string      `json:"description"`
 	Priority       int64       `json:"priority"`
 	Due            *dueDate    `json:"due"`
 	ParentID       string      `json:"parent_id"`
@@ -404,10 +405,11 @@ func convertTodoistToVikunja(sync *sync, doneItems map[string]*doneItem) (fullVi
 
 		task := &models.TaskWithComments{
 			Task: models.Task{
-				Title:    i.Content,
-				Created:  i.DateAdded.In(config.GetTimeZone()),
-				Done:     i.Checked,
-				BucketID: sections[i.SectionID],
+				Title:       i.Content,
+				Description: i.Description,
+				Created:     i.DateAdded.In(config.GetTimeZone()),
+				Done:        i.Checked,
+				BucketID:    sections[i.SectionID],
 			},
 		}
 

--- a/pkg/modules/migration/todoist/todoist_test.go
+++ b/pkg/modules/migration/todoist/todoist_test.go
@@ -17,6 +17,7 @@
 package todoist
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -690,6 +691,44 @@ func TestConvertTodoistToVikunjaWithBrokenAttachment(t *testing.T) {
 	require.Len(t, hierachie[1].Tasks, 1)
 	assert.Empty(t, hierachie[1].Tasks[0].Attachments)
 	assert.Equal(t, "Lorem Ipsum dolor sit amet", hierachie[1].Tasks[0].Description)
+}
+
+func TestConvertTodoistToVikunjaPreservesDescriptions(t *testing.T) {
+	// The Todoist v1 sync API returns a `description` field (markdown) on every
+	// item. It must become the task description, with notes appended after it.
+	testSync := &sync{}
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"projects": [{"id": "396936926", "name": "Project1"}],
+		"items": [
+			{"id": "400000001", "project_id": "396936926", "content": "With description and note", "description": "The task description"},
+			{"id": "400000002", "project_id": "396936926", "content": "With description only", "description": "Only a description"},
+			{"id": "400000003", "project_id": "396936926", "content": "With note only"}
+		],
+		"notes": [
+			{"id": "101478", "item_id": "400000001", "content": "A note"},
+			{"id": "101479", "item_id": "400000003", "content": "A note"}
+		]
+	}`), testSync))
+
+	hierachie, err := convertTodoistToVikunja(testSync, make(map[string]*doneItem))
+	require.NoError(t, err)
+	require.Len(t, hierachie, 2)
+	require.Len(t, hierachie[1].Tasks, 3)
+
+	assert.Equal(t, "The task description\nA note", hierachie[1].Tasks[0].Description)
+	assert.Equal(t, "Only a description", hierachie[1].Tasks[1].Description)
+	// Regression: without a description, notes alone still become the description.
+	assert.Equal(t, "A note", hierachie[1].Tasks[2].Description)
+}
+
+func TestTodoistItemDecoding(t *testing.T) {
+	// The v1 sync API returns `description` on every item, the decoder must not
+	// silently drop it.
+	payload := `{"items": [{"id": "400000001", "content": "Task1", "description": "Some markdown description"}]}`
+	s := &sync{}
+	require.NoError(t, json.Unmarshal([]byte(payload), s))
+	require.Len(t, s.Items, 1)
+	assert.Equal(t, "Some markdown description", s.Items[0].Description)
 }
 
 func TestIsDownloadableURL(t *testing.T) {


### PR DESCRIPTION
## Summary
- The Todoist v1 sync API returns a `description` field on every item, but the migrator's `item` struct had no such field, so Go's JSON decoder silently dropped it — every task description was lost during migration.
- Adds `Description string \`json:"description"\`` to the `item` struct and maps it onto `task.Description` during conversion.
- Existing behaviour (Todoist notes appended to the description) is preserved: notes are now appended *after* the migrated description with a newline, same as before for note-only tasks.

## Root cause evidence
Live sync payload (`POST /api/v1/sync` with `resource_types=["items"]`) includes `description` per item; after migrating a real account, all five tasks that had descriptions came over with empty descriptions.

## Test plan
- [x] New `TestTodoistItemDecoding` proves the field decodes (failed to compile before the struct change — RED)
- [x] New `TestConvertTodoistToVikunjaPreservesDescriptions`: desc-only, desc+note, note-only (regression) — failed before fix, passes after
- [x] Full package `go test ./pkg/modules/migration/todoist/` green
