### PR TITLE
fix(migration): parse more todoist recurrence formats per language

### DIFF
--- a/pkg/modules/migration/todoist/todoist.go
+++ b/pkg/modules/migration/todoist/todoist.go
@@ -20,9 +20,11 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"net/http"
 	"net/url"
 	"regexp"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -263,74 +265,144 @@ const (
 	secondsPerYear        = secondsPerDay * 365
 )
 
-var repeatUnitWords = map[string]int64{
-	"day":     secondsPerDay,
-	"days":    secondsPerDay,
-	"dag":     secondsPerDay,
-	"dagen":   secondsPerDay,
-	"week":    secondsPerWeek,
-	"weeks":   secondsPerWeek,
-	"weken":   secondsPerWeek,
-	"month":   secondsPerMonth,
-	"months":  secondsPerMonth,
-	"maand":   secondsPerMonth,
-	"maanden": secondsPerMonth,
-	"year":    secondsPerYear,
-	"years":   secondsPerYear,
-	"jaar":    secondsPerYear,
-	"jaren":   secondsPerYear,
-}
-
-// English and Dutch month names, full and abbreviated.
-var todoistMonthNames = map[string]struct{}{
-	"january": {}, "januari": {}, "jan": {},
-	"february": {}, "februari": {}, "feb": {},
-	"march": {}, "maart": {}, "mar": {}, "mrt": {},
-	"april": {}, "apr": {},
-	"may": {}, "mei": {},
-	"june": {}, "juni": {}, "jun": {},
-	"july": {}, "juli": {}, "jul": {},
-	"august": {}, "augustus": {}, "aug": {},
-	"september": {}, "sept": {}, "sep": {},
-	"october": {}, "oktober": {}, "oct": {}, "okt": {},
-	"november": {}, "nov": {},
-	"december": {}, "dec": {},
-}
-
-var todoistWeekdayNames = map[string]struct{}{
-	"monday": {}, "tuesday": {}, "wednesday": {}, "thursday": {}, "friday": {}, "saturday": {}, "sunday": {},
-	"maandag": {}, "dinsdag": {}, "woensdag": {}, "donderdag": {}, "vrijdag": {}, "zaterdag": {}, "zondag": {},
-}
-
 var (
 	todoistRepeatTimeRegex = regexp.MustCompile(`\s+(?:at|@)\s+.*$`)
 
-	// Full date anchored to a day and month name: "yearly 1st May", "elke 16e jul".
-	// The trailing token is validated against todoistMonthNames separately.
-	todoistRepeatFullDateRegex = regexp.MustCompile(`^(?:every|elke|elk|yearly|annually)\s+(\d{1,2})(?:ste|st|nd|rd|th|de|e)?\s+([a-z]+)$`)
-	// Numeric day/month date: "every 15/03".
-	todoistRepeatNumericDateRegex = regexp.MustCompile(`^(?:every|elke|elk)\s+\d{1,2}/\d{1,2}$`)
-	// Plain interval: "every 3 weeks", "elke 4 weken", "every other day". The trailing
-	// token is validated against repeatUnitWords separately.
-	todoistRepeatIntervalRegex = regexp.MustCompile(`^(?:(?:every|elke|elk)\s+)?(?:(\d+)\s+|(other)\s+)?([a-z]+)$`)
-	// Day of the month without a month name: "every 15th", "every 1st day".
-	todoistRepeatDayOfMonthRegex = regexp.MustCompile(`^(?:every|elke|elk)\s+\d{1,2}(?:ste|st|nd|rd|th|de|e)?(?:\s+(?:day|dag))?$`)
-	// Last day of the month: "elke laatste dag".
-	todoistRepeatLastDayRegex = regexp.MustCompile(`^(?:every|elke|elk)\s+(?:laatste|last)\s+(?:day|dag)$`)
-	// Weekday: "every monday", "elke maandag". The trailing token is validated against
-	// todoistWeekdayNames separately.
-	todoistRepeatWeekdayRegex = regexp.MustCompile(`^(?:every|elke|elk)\s+([a-z]+)$`)
+	todoistRepeatNumberRegex = regexp.MustCompile(`^\d+$`)
+	// Day/month date token like "15/03".
+	todoistRepeatDayMonthRegex = regexp.MustCompile(`^\d{1,2}/\d{1,2}$`)
 )
+
+// repeatLang is the word data of one language for the language-agnostic grammar in
+// parseRepeatTokens.
+type repeatLang struct {
+	intervals  map[string]int64
+	adverbs    map[string]int64
+	everyWords []string // typos like "elke!" are normalized away before the grammar runs
+	// otherWord stays empty for languages with no single fixed form for it.
+	otherWord       string
+	lastWord        string
+	dayWord         string
+	weekdays        map[string]struct{}
+	months          map[string]struct{}
+	ordinals        string // regex alternation of ordinal suffixes: "st|nd|rd|th"; nl: "e|ste|de"
+	ordinalDayRegex *regexp.Regexp
+}
+
+// langPacks is deliberately data-only: a new language is a new data block here, with zero
+// grammar changes. Todoist plans to move its date parsing upstream into a multilingual
+// parser, so keep this table and the small parseTodoistRepeat entry point swappable for it.
+var langPacks = compileRepeatLangs(map[string]*repeatLang{
+	"en": {
+		intervals: map[string]int64{
+			"day": secondsPerDay, "days": secondsPerDay,
+			"week": secondsPerWeek, "weeks": secondsPerWeek,
+			"month": secondsPerMonth, "months": secondsPerMonth,
+			"year": secondsPerYear, "years": secondsPerYear,
+		},
+		adverbs: map[string]int64{
+			"daily":    secondsPerDay,
+			"weekly":   secondsPerWeek,
+			"monthly":  secondsPerMonth,
+			"yearly":   secondsPerYear,
+			"annually": secondsPerYear,
+		},
+		everyWords: []string{"every"},
+		otherWord:  "other",
+		lastWord:   "last",
+		dayWord:    "day",
+		weekdays: map[string]struct{}{
+			"monday": {}, "tuesday": {}, "wednesday": {}, "thursday": {},
+			"friday": {}, "saturday": {}, "sunday": {},
+		},
+		months: map[string]struct{}{
+			"january": {}, "jan": {}, "february": {}, "feb": {},
+			"march": {}, "mar": {}, "april": {}, "apr": {},
+			"may": {}, "june": {}, "jun": {}, "july": {}, "jul": {},
+			"august": {}, "aug": {}, "september": {}, "sept": {}, "sep": {},
+			"october": {}, "oct": {}, "november": {}, "nov": {},
+			"december": {}, "dec": {},
+		},
+		ordinals: "st|nd|rd|th",
+	},
+	"nl": {
+		intervals: map[string]int64{
+			"dag": secondsPerDay, "dagen": secondsPerDay,
+			"week": secondsPerWeek, "weken": secondsPerWeek,
+			"maand": secondsPerMonth, "maanden": secondsPerMonth,
+			"jaar": secondsPerYear, "jaren": secondsPerYear,
+		},
+		adverbs: map[string]int64{
+			"dagelijks":   secondsPerDay,
+			"wekelijks":   secondsPerWeek,
+			"maandelijks": secondsPerMonth,
+			"jaarlijks":   secondsPerYear,
+		},
+		everyWords: []string{"elke", "elk"},
+		// Dutch inflects "other" ("elke andere dag"), so one fixed otherWord can only
+		// ever match half of the form - leave it unset instead.
+		otherWord: "",
+		lastWord:  "laatste",
+		dayWord:   "dag",
+		weekdays: map[string]struct{}{
+			"maandag": {}, "dinsdag": {}, "woensdag": {}, "donderdag": {},
+			"vrijdag": {}, "zaterdag": {}, "zondag": {},
+		},
+		months: map[string]struct{}{
+			"januari": {}, "jan": {}, "februari": {}, "feb": {},
+			"maart": {}, "mrt": {}, "april": {}, "apr": {},
+			"mei": {}, "juni": {}, "jun": {}, "juli": {}, "jul": {},
+			"augustus": {}, "aug": {}, "september": {}, "sept": {}, "sep": {},
+			"oktober": {}, "okt": {}, "november": {}, "nov": {},
+			"december": {}, "dec": {},
+		},
+		ordinals: "e|ste|de",
+	},
+})
+
+func compileRepeatLangs(packs map[string]*repeatLang) map[string]*repeatLang {
+	for _, pack := range packs {
+		pack.ordinalDayRegex = regexp.MustCompile(`^\d{1,2}(?:` + pack.ordinals + `)?$`)
+	}
+	return packs
+}
+
+func (l *repeatLang) isEveryWord(token string) bool {
+	return slices.Contains(l.everyWords, token)
+}
+
+func (l *repeatLang) isYearlyAdverb(token string) bool {
+	return l.adverbs[token] == secondsPerYear
+}
+
+// langPacksFor returns the word packs to try for a due object's language. Recurring due
+// objects from real Todoist exports always carry a lang; when it is missing there is
+// nothing to key on and every pack is tried as a whole. Unknown languages fall back to
+// English.
+func langPacksFor(lang string) []*repeatLang {
+	if pack, ok := langPacks[lang]; ok {
+		return []*repeatLang{pack}
+	}
+	if lang != "" {
+		return []*repeatLang{langPacks["en"]}
+	}
+
+	packs := make([]*repeatLang, 0, len(langPacks))
+	for _, l := range slices.Sorted(maps.Keys(langPacks)) {
+		packs = append(packs, langPacks[l])
+	}
+	return packs
+}
 
 // parseTodoistRepeat translates Todoist's recurrence into a repeat interval in seconds plus
 // the repeat mode to use with it. Todoist exposes recurrence only as free text in the user's
-// language (e.g. "every 3 weeks", "elke 6 maanden", "yearly 1st May"), so we parse the common
-// unambiguous English and Dutch phrases. Interval phrases map to a plain interval; weekday
-// phrases keep the weekly interval (the due date already anchors the weekday); phrases anchored
-// to a day of the month get TaskRepeatModeMonth so Vikunja preserves that day despite months
-// having different lengths. Patterns we can't represent return 0, leaving the task
-// non-repeating. Only the cadence is kept - the due date already anchors the actual day and
-// time.
+// language (e.g. "every 3 weeks", "elke 6 maanden", "yearly 1st May") together with that
+// language in due.lang, so the grammar in parseRepeatTokens runs with the matching word pack
+// from langPacks. Interval phrases map to a plain interval; weekday phrases keep the weekly
+// interval (the due date already anchors the weekday); phrases anchored to a day of the month
+// get TaskRepeatModeMonth so Vikunja preserves that day despite months having different
+// lengths. Patterns we can't represent return 0, leaving the task non-repeating. Only the
+// cadence is kept - the due date already anchors the actual day and time.
 func parseTodoistRepeat(due *dueDate) (repeatAfter int64, repeatMode models.TaskRepeatMode) {
 	if due == nil || !due.IsRecurring {
 		return 0, models.TaskRepeatModeDefault
@@ -340,67 +412,94 @@ func parseTodoistRepeat(due *dueDate) (repeatAfter int64, repeatMode models.Task
 	// The time of day is already on the due date, drop it so "every day at 9am" still matches.
 	s = todoistRepeatTimeRegex.ReplaceAllString(s, "")
 	// Users make typos like "elke! 4 maand" - treat a stray "!" as whitespace.
-	s = strings.ReplaceAll(s, "!", " ")
-	s = strings.Join(strings.Fields(s), " ")
+	tokens := strings.Fields(strings.ReplaceAll(s, "!", " "))
 
-	switch s {
-	case "daily":
-		return secondsPerDay, models.TaskRepeatModeDefault
-	case "weekly":
-		return secondsPerWeek, models.TaskRepeatModeDefault
-	case "monthly":
-		return secondsPerMonth, models.TaskRepeatModeDefault
-	case "yearly", "annually":
-		return secondsPerYear, models.TaskRepeatModeDefault
-	}
-
-	// Checks are ordered most specific first, so e.g. "elke 1 juni" is not read as "elke 1 <unit>"
-	// and "every 1st day" is not read as the interval "every 1 day".
-
-	// A full date (day plus month name) recurs yearly.
-	if matches := todoistRepeatFullDateRegex.FindStringSubmatch(s); matches != nil {
-		if _, isMonth := todoistMonthNames[matches[2]]; isMonth {
-			return secondsPerYear, models.TaskRepeatModeDefault
-		}
-	}
-
-	// A numeric day/month date recurs yearly.
-	if todoistRepeatNumericDateRegex.MatchString(s) {
-		return secondsPerYear, models.TaskRepeatModeDefault
-	}
-
-	// A plain interval phrase.
-	if matches := todoistRepeatIntervalRegex.FindStringSubmatch(s); matches != nil {
-		if seconds, isUnit := repeatUnitWords[matches[3]]; isUnit {
-			interval := int64(1)
-			switch {
-			case matches[1] != "":
-				n, err := strconv.ParseInt(matches[1], 10, 64)
-				if err != nil || n < 1 {
-					return 0, models.TaskRepeatModeDefault
-				}
-				interval = n
-			case matches[2] == "other":
-				interval = 2
-			}
-			return interval * seconds, models.TaskRepeatModeDefault
-		}
-	}
-
-	// A day of the month without a month name recurs monthly.
-	if todoistRepeatDayOfMonthRegex.MatchString(s) || todoistRepeatLastDayRegex.MatchString(s) {
-		return secondsPerMonth, models.TaskRepeatModeMonth
-	}
-
-	// A weekday recurs weekly.
-	if matches := todoistRepeatWeekdayRegex.FindStringSubmatch(s); matches != nil {
-		if _, isWeekday := todoistWeekdayNames[matches[1]]; isWeekday {
-			return secondsPerWeek, models.TaskRepeatModeDefault
+	for _, pack := range langPacksFor(due.Lang) {
+		if seconds, mode, matched := parseRepeatTokens(tokens, pack); matched {
+			return seconds, mode
 		}
 	}
 
 	log.Debugf("[Todoist Migration] Could not parse recurrence %q, leaving task non-repeating", due.String)
 	return 0, models.TaskRepeatModeDefault
+}
+
+// parseRepeatTokens runs the language-agnostic recurrence grammar over the normalized tokens
+// with one language's words. It reports whether the tokens matched a form in this language,
+// so another pack can be tried when they did not.
+func parseRepeatTokens(tokens []string, lang *repeatLang) (repeatAfter int64, repeatMode models.TaskRepeatMode, matched bool) {
+	// A bare adverb like "daily" or "wekelijks".
+	if len(tokens) == 1 {
+		if seconds, isAdverb := lang.adverbs[tokens[0]]; isAdverb {
+			return seconds, models.TaskRepeatModeDefault, true
+		}
+	}
+
+	// Checks are ordered most specific first, so e.g. "elke 1 juni" is not read as "elke 1 <unit>"
+	// and "every 1st day" is not read as the interval "every 1 day".
+
+	// A full date (day plus month name) recurs yearly. Yearly adverbs ("yearly 1st May")
+	// work as prefixes next to the every-words.
+	if len(tokens) == 3 &&
+		(lang.isEveryWord(tokens[0]) || lang.isYearlyAdverb(tokens[0])) &&
+		lang.ordinalDayRegex.MatchString(tokens[1]) {
+		if _, isMonth := lang.months[tokens[2]]; isMonth {
+			return secondsPerYear, models.TaskRepeatModeDefault, true
+		}
+	}
+
+	// A numeric day/month date recurs yearly.
+	if len(tokens) == 2 && lang.isEveryWord(tokens[0]) && todoistRepeatDayMonthRegex.MatchString(tokens[1]) {
+		return secondsPerYear, models.TaskRepeatModeDefault, true
+	}
+
+	// A plain interval phrase: "every 3 weeks", "elke 4 weken", "every other day", or a
+	// bare unit word. The trailing token is validated against lang.intervals separately.
+	rest := tokens
+	if len(rest) > 0 && lang.isEveryWord(rest[0]) {
+		rest = rest[1:]
+	}
+	switch len(rest) {
+	case 1:
+		if seconds, isUnit := lang.intervals[rest[0]]; isUnit {
+			return seconds, models.TaskRepeatModeDefault, true
+		}
+	case 2:
+		if seconds, isUnit := lang.intervals[rest[1]]; isUnit {
+			if lang.otherWord != "" && rest[0] == lang.otherWord {
+				return 2 * seconds, models.TaskRepeatModeDefault, true
+			}
+			if todoistRepeatNumberRegex.MatchString(rest[0]) {
+				n, err := strconv.ParseInt(rest[0], 10, 64)
+				if err != nil || n < 1 {
+					// The interval form matched but its count is unusable, so this is a
+					// verdict rather than a reason to try other forms or packs.
+					return 0, models.TaskRepeatModeDefault, true
+				}
+				return n * seconds, models.TaskRepeatModeDefault, true
+			}
+		}
+	}
+
+	// A day of the month without a month name recurs monthly, as does the last day of the
+	// month; both are anchored via TaskRepeatModeMonth.
+	if len(tokens) >= 2 && len(tokens) <= 3 && lang.isEveryWord(tokens[0]) &&
+		lang.ordinalDayRegex.MatchString(tokens[1]) &&
+		(len(tokens) == 2 || tokens[2] == lang.dayWord) {
+		return secondsPerMonth, models.TaskRepeatModeMonth, true
+	}
+	if len(tokens) == 3 && lang.isEveryWord(tokens[0]) && tokens[1] == lang.lastWord && tokens[2] == lang.dayWord {
+		return secondsPerMonth, models.TaskRepeatModeMonth, true
+	}
+
+	// A weekday recurs weekly - the due date already anchors the weekday.
+	if len(tokens) == 2 && lang.isEveryWord(tokens[0]) {
+		if _, isWeekday := lang.weekdays[tokens[1]]; isWeekday {
+			return secondsPerWeek, models.TaskRepeatModeDefault, true
+		}
+	}
+
+	return 0, models.TaskRepeatModeDefault, false
 }
 
 func isDownloadableURL(rawURL string) bool {

--- a/pkg/modules/migration/todoist/todoist.go
+++ b/pkg/modules/migration/todoist/todoist.go
@@ -263,62 +263,144 @@ const (
 	secondsPerYear        = secondsPerDay * 365
 )
 
-var repeatUnitSeconds = map[string]int64{
-	"day":   secondsPerDay,
-	"week":  secondsPerWeek,
-	"month": secondsPerMonth,
-	"year":  secondsPerYear,
+var repeatUnitWords = map[string]int64{
+	"day":     secondsPerDay,
+	"days":    secondsPerDay,
+	"dag":     secondsPerDay,
+	"dagen":   secondsPerDay,
+	"week":    secondsPerWeek,
+	"weeks":   secondsPerWeek,
+	"weken":   secondsPerWeek,
+	"month":   secondsPerMonth,
+	"months":  secondsPerMonth,
+	"maand":   secondsPerMonth,
+	"maanden": secondsPerMonth,
+	"year":    secondsPerYear,
+	"years":   secondsPerYear,
+	"jaar":    secondsPerYear,
+	"jaren":   secondsPerYear,
+}
+
+// English and Dutch month names, full and abbreviated.
+var todoistMonthNames = map[string]struct{}{
+	"january": {}, "januari": {}, "jan": {},
+	"february": {}, "februari": {}, "feb": {},
+	"march": {}, "maart": {}, "mar": {}, "mrt": {},
+	"april": {}, "apr": {},
+	"may": {}, "mei": {},
+	"june": {}, "juni": {}, "jun": {},
+	"july": {}, "juli": {}, "jul": {},
+	"august": {}, "augustus": {}, "aug": {},
+	"september": {}, "sept": {}, "sep": {},
+	"october": {}, "oktober": {}, "oct": {}, "okt": {},
+	"november": {}, "nov": {},
+	"december": {}, "dec": {},
+}
+
+var todoistWeekdayNames = map[string]struct{}{
+	"monday": {}, "tuesday": {}, "wednesday": {}, "thursday": {}, "friday": {}, "saturday": {}, "sunday": {},
+	"maandag": {}, "dinsdag": {}, "woensdag": {}, "donderdag": {}, "vrijdag": {}, "zaterdag": {}, "zondag": {},
 }
 
 var (
-	todoistRepeatRegex     = regexp.MustCompile(`^(?:every\s+)?(?:(\d+)\s+|(other)\s+)?(day|week|month|year)s?$`)
 	todoistRepeatTimeRegex = regexp.MustCompile(`\s+(?:at|@)\s+.*$`)
+
+	// Full date anchored to a day and month name: "yearly 1st May", "elke 16e jul".
+	// The trailing token is validated against todoistMonthNames separately.
+	todoistRepeatFullDateRegex = regexp.MustCompile(`^(?:every|elke|elk|yearly|annually)\s+(\d{1,2})(?:ste|st|nd|rd|th|de|e)?\s+([a-z]+)$`)
+	// Numeric day/month date: "every 15/03".
+	todoistRepeatNumericDateRegex = regexp.MustCompile(`^(?:every|elke|elk)\s+\d{1,2}/\d{1,2}$`)
+	// Plain interval: "every 3 weeks", "elke 4 weken", "every other day". The trailing
+	// token is validated against repeatUnitWords separately.
+	todoistRepeatIntervalRegex = regexp.MustCompile(`^(?:(?:every|elke|elk)\s+)?(?:(\d+)\s+|(other)\s+)?([a-z]+)$`)
+	// Day of the month without a month name: "every 15th", "every 1st day".
+	todoistRepeatDayOfMonthRegex = regexp.MustCompile(`^(?:every|elke|elk)\s+\d{1,2}(?:ste|st|nd|rd|th|de|e)?(?:\s+(?:day|dag))?$`)
+	// Last day of the month: "elke laatste dag".
+	todoistRepeatLastDayRegex = regexp.MustCompile(`^(?:every|elke|elk)\s+(?:laatste|last)\s+(?:day|dag)$`)
+	// Weekday: "every monday", "elke maandag". The trailing token is validated against
+	// todoistWeekdayNames separately.
+	todoistRepeatWeekdayRegex = regexp.MustCompile(`^(?:every|elke|elk)\s+([a-z]+)$`)
 )
 
-// parseTodoistRepeat translates Todoist's recurrence into a repeat interval in seconds.
-// Todoist exposes recurrence only as free text (e.g. "every 3 weeks"), so we parse the
-// common, unambiguous interval phrases. Patterns we can't represent (specific weekdays,
-// days of the month, non-English strings) return 0, leaving the task non-repeating. Only
-// the cadence is kept - the due date already anchors the actual day and time.
-func parseTodoistRepeat(due *dueDate) int64 {
+// parseTodoistRepeat translates Todoist's recurrence into a repeat interval in seconds plus
+// the repeat mode to use with it. Todoist exposes recurrence only as free text in the user's
+// language (e.g. "every 3 weeks", "elke 6 maanden", "yearly 1st May"), so we parse the common
+// unambiguous English and Dutch phrases. Interval phrases map to a plain interval; weekday
+// phrases keep the weekly interval (the due date already anchors the weekday); phrases anchored
+// to a day of the month get TaskRepeatModeMonth so Vikunja preserves that day despite months
+// having different lengths. Patterns we can't represent return 0, leaving the task
+// non-repeating. Only the cadence is kept - the due date already anchors the actual day and
+// time.
+func parseTodoistRepeat(due *dueDate) (repeatAfter int64, repeatMode models.TaskRepeatMode) {
 	if due == nil || !due.IsRecurring {
-		return 0
+		return 0, models.TaskRepeatModeDefault
 	}
 
 	s := strings.ToLower(strings.TrimSpace(due.String))
 	// The time of day is already on the due date, drop it so "every day at 9am" still matches.
 	s = todoistRepeatTimeRegex.ReplaceAllString(s, "")
+	// Users make typos like "elke! 4 maand" - treat a stray "!" as whitespace.
+	s = strings.ReplaceAll(s, "!", " ")
+	s = strings.Join(strings.Fields(s), " ")
 
 	switch s {
 	case "daily":
-		return secondsPerDay
+		return secondsPerDay, models.TaskRepeatModeDefault
 	case "weekly":
-		return secondsPerWeek
+		return secondsPerWeek, models.TaskRepeatModeDefault
 	case "monthly":
-		return secondsPerMonth
+		return secondsPerMonth, models.TaskRepeatModeDefault
 	case "yearly", "annually":
-		return secondsPerYear
+		return secondsPerYear, models.TaskRepeatModeDefault
 	}
 
-	matches := todoistRepeatRegex.FindStringSubmatch(s)
-	if matches == nil {
-		log.Debugf("[Todoist Migration] Could not parse recurrence %q, leaving task non-repeating", due.String)
-		return 0
-	}
+	// Checks are ordered most specific first, so e.g. "elke 1 juni" is not read as "elke 1 <unit>"
+	// and "every 1st day" is not read as the interval "every 1 day".
 
-	interval := int64(1)
-	switch {
-	case matches[1] != "":
-		n, err := strconv.ParseInt(matches[1], 10, 64)
-		if err != nil || n < 1 {
-			return 0
+	// A full date (day plus month name) recurs yearly.
+	if matches := todoistRepeatFullDateRegex.FindStringSubmatch(s); matches != nil {
+		if _, isMonth := todoistMonthNames[matches[2]]; isMonth {
+			return secondsPerYear, models.TaskRepeatModeDefault
 		}
-		interval = n
-	case matches[2] == "other":
-		interval = 2
 	}
 
-	return interval * repeatUnitSeconds[matches[3]]
+	// A numeric day/month date recurs yearly.
+	if todoistRepeatNumericDateRegex.MatchString(s) {
+		return secondsPerYear, models.TaskRepeatModeDefault
+	}
+
+	// A plain interval phrase.
+	if matches := todoistRepeatIntervalRegex.FindStringSubmatch(s); matches != nil {
+		if seconds, isUnit := repeatUnitWords[matches[3]]; isUnit {
+			interval := int64(1)
+			switch {
+			case matches[1] != "":
+				n, err := strconv.ParseInt(matches[1], 10, 64)
+				if err != nil || n < 1 {
+					return 0, models.TaskRepeatModeDefault
+				}
+				interval = n
+			case matches[2] == "other":
+				interval = 2
+			}
+			return interval * seconds, models.TaskRepeatModeDefault
+		}
+	}
+
+	// A day of the month without a month name recurs monthly.
+	if todoistRepeatDayOfMonthRegex.MatchString(s) || todoistRepeatLastDayRegex.MatchString(s) {
+		return secondsPerMonth, models.TaskRepeatModeMonth
+	}
+
+	// A weekday recurs weekly.
+	if matches := todoistRepeatWeekdayRegex.FindStringSubmatch(s); matches != nil {
+		if _, isWeekday := todoistWeekdayNames[matches[1]]; isWeekday {
+			return secondsPerWeek, models.TaskRepeatModeDefault
+		}
+	}
+
+	log.Debugf("[Todoist Migration] Could not parse recurrence %q, leaving task non-repeating", due.String)
+	return 0, models.TaskRepeatModeDefault
 }
 
 func isDownloadableURL(rawURL string) bool {
@@ -435,7 +517,7 @@ func convertTodoistToVikunja(sync *sync, doneItems map[string]*doneItem) (fullVi
 				return nil, err
 			}
 			task.DueDate = dueDate.In(config.GetTimeZone())
-			task.RepeatAfter = parseTodoistRepeat(i.Due)
+			task.RepeatAfter, task.RepeatMode = parseTodoistRepeat(i.Due)
 		}
 
 		// Put all labels together from earlier

--- a/pkg/modules/migration/todoist/todoist_test.go
+++ b/pkg/modules/migration/todoist/todoist_test.go
@@ -717,44 +717,132 @@ func TestIsDownloadableURL(t *testing.T) {
 
 func TestParseTodoistRepeat(t *testing.T) {
 	tests := []struct {
-		name string
-		due  *dueDate
-		want int64
+		name     string
+		due      *dueDate
+		want     int64
+		wantMode models.TaskRepeatMode
 	}{
-		{name: "nil due", due: nil, want: 0},
-		{name: "not recurring", due: &dueDate{String: "every day", IsRecurring: false}, want: 0},
+		{name: "nil due", due: nil, want: 0, wantMode: models.TaskRepeatModeDefault},
+		{name: "not recurring", due: &dueDate{String: "every day", IsRecurring: false}, want: 0, wantMode: models.TaskRepeatModeDefault},
 
-		{name: "every day", due: &dueDate{String: "every day", IsRecurring: true}, want: secondsPerDay},
-		{name: "daily", due: &dueDate{String: "daily", IsRecurring: true}, want: secondsPerDay},
-		{name: "every other day", due: &dueDate{String: "every other day", IsRecurring: true}, want: 2 * secondsPerDay},
-		{name: "every 3 days", due: &dueDate{String: "every 3 days", IsRecurring: true}, want: 3 * secondsPerDay},
+		{name: "every day", due: &dueDate{String: "every day", IsRecurring: true}, want: secondsPerDay, wantMode: models.TaskRepeatModeDefault},
+		{name: "daily", due: &dueDate{String: "daily", IsRecurring: true}, want: secondsPerDay, wantMode: models.TaskRepeatModeDefault},
+		{name: "every other day", due: &dueDate{String: "every other day", IsRecurring: true}, want: 2 * secondsPerDay, wantMode: models.TaskRepeatModeDefault},
+		{name: "every 3 days", due: &dueDate{String: "every 3 days", IsRecurring: true}, want: 3 * secondsPerDay, wantMode: models.TaskRepeatModeDefault},
+		{name: "every 1 day", due: &dueDate{String: "every 1 day", IsRecurring: true}, want: secondsPerDay, wantMode: models.TaskRepeatModeDefault},
 
-		{name: "every week", due: &dueDate{String: "every week", IsRecurring: true}, want: secondsPerWeek},
-		{name: "weekly", due: &dueDate{String: "weekly", IsRecurring: true}, want: secondsPerWeek},
-		{name: "every other week", due: &dueDate{String: "every other week", IsRecurring: true}, want: 2 * secondsPerWeek},
-		{name: "every 2 weeks", due: &dueDate{String: "every 2 weeks", IsRecurring: true}, want: 2 * secondsPerWeek},
+		{name: "every week", due: &dueDate{String: "every week", IsRecurring: true}, want: secondsPerWeek, wantMode: models.TaskRepeatModeDefault},
+		{name: "weekly", due: &dueDate{String: "weekly", IsRecurring: true}, want: secondsPerWeek, wantMode: models.TaskRepeatModeDefault},
+		{name: "every other week", due: &dueDate{String: "every other week", IsRecurring: true}, want: 2 * secondsPerWeek, wantMode: models.TaskRepeatModeDefault},
+		{name: "every 2 weeks", due: &dueDate{String: "every 2 weeks", IsRecurring: true}, want: 2 * secondsPerWeek, wantMode: models.TaskRepeatModeDefault},
 
-		{name: "every month", due: &dueDate{String: "every month", IsRecurring: true}, want: secondsPerMonth},
-		{name: "monthly", due: &dueDate{String: "monthly", IsRecurring: true}, want: secondsPerMonth},
-		{name: "every 3 months", due: &dueDate{String: "every 3 months", IsRecurring: true}, want: 3 * secondsPerMonth},
+		{name: "every month", due: &dueDate{String: "every month", IsRecurring: true}, want: secondsPerMonth, wantMode: models.TaskRepeatModeDefault},
+		{name: "monthly", due: &dueDate{String: "monthly", IsRecurring: true}, want: secondsPerMonth, wantMode: models.TaskRepeatModeDefault},
+		{name: "every 3 months", due: &dueDate{String: "every 3 months", IsRecurring: true}, want: 3 * secondsPerMonth, wantMode: models.TaskRepeatModeDefault},
+		{name: "every 6 months", due: &dueDate{String: "every 6 months", IsRecurring: true}, want: 6 * secondsPerMonth, wantMode: models.TaskRepeatModeDefault},
+		{name: "every 1 years", due: &dueDate{String: "every 1 years", IsRecurring: true}, want: secondsPerYear, wantMode: models.TaskRepeatModeDefault},
 
-		{name: "every year", due: &dueDate{String: "every year", IsRecurring: true}, want: secondsPerYear},
-		{name: "yearly", due: &dueDate{String: "yearly", IsRecurring: true}, want: secondsPerYear},
-		{name: "annually", due: &dueDate{String: "annually", IsRecurring: true}, want: secondsPerYear},
+		{name: "every year", due: &dueDate{String: "every year", IsRecurring: true}, want: secondsPerYear, wantMode: models.TaskRepeatModeDefault},
+		{name: "yearly", due: &dueDate{String: "yearly", IsRecurring: true}, want: secondsPerYear, wantMode: models.TaskRepeatModeDefault},
+		{name: "annually", due: &dueDate{String: "annually", IsRecurring: true}, want: secondsPerYear, wantMode: models.TaskRepeatModeDefault},
 
-		{name: "case insensitive", due: &dueDate{String: "Every Day", IsRecurring: true}, want: secondsPerDay},
-		{name: "time of day stripped", due: &dueDate{String: "every day at 9am", IsRecurring: true}, want: secondsPerDay},
+		{name: "case insensitive", due: &dueDate{String: "Every Day", IsRecurring: true}, want: secondsPerDay, wantMode: models.TaskRepeatModeDefault},
+		{name: "time of day stripped", due: &dueDate{String: "every day at 9am", IsRecurring: true}, want: secondsPerDay, wantMode: models.TaskRepeatModeDefault},
 
-		// Tier 1 doesn't understand these, so the task stays non-repeating.
-		{name: "specific weekday", due: &dueDate{String: "every monday", IsRecurring: true}, want: 0},
-		{name: "day of month", due: &dueDate{String: "every 27th", IsRecurring: true}, want: 0},
-		{name: "non-english", due: &dueDate{String: "cada día", IsRecurring: true}, want: 0},
-		{name: "gibberish", due: &dueDate{String: "whenever", IsRecurring: true}, want: 0},
+		// Dutch interval forms.
+		{name: "elke dag", due: &dueDate{String: "elke dag", IsRecurring: true}, want: secondsPerDay, wantMode: models.TaskRepeatModeDefault},
+		{name: "elke week", due: &dueDate{String: "elke week", IsRecurring: true}, want: secondsPerWeek, wantMode: models.TaskRepeatModeDefault},
+		{name: "elke 4 weken", due: &dueDate{String: "elke 4 weken", IsRecurring: true}, want: 4 * secondsPerWeek, wantMode: models.TaskRepeatModeDefault},
+		{name: "elke maand", due: &dueDate{String: "elke maand", IsRecurring: true}, want: secondsPerMonth, wantMode: models.TaskRepeatModeDefault},
+		{name: "elke 3 maanden", due: &dueDate{String: "elke 3 maanden", IsRecurring: true}, want: 3 * secondsPerMonth, wantMode: models.TaskRepeatModeDefault},
+		{name: "elke 6 maanden", due: &dueDate{String: "elke 6 maanden", IsRecurring: true}, want: 6 * secondsPerMonth, wantMode: models.TaskRepeatModeDefault},
+		{name: "elke 24 maanden", due: &dueDate{String: "elke 24 maanden", IsRecurring: true}, want: 24 * secondsPerMonth, wantMode: models.TaskRepeatModeDefault},
+		{name: "elke jaar", due: &dueDate{String: "elke jaar", IsRecurring: true}, want: secondsPerYear, wantMode: models.TaskRepeatModeDefault},
+		{name: "elke 2 jaren", due: &dueDate{String: "elke 2 jaren", IsRecurring: true}, want: 2 * secondsPerYear, wantMode: models.TaskRepeatModeDefault},
+		{name: "elke! 4 maand typo", due: &dueDate{String: "elke! 4 maand", IsRecurring: true}, want: 4 * secondsPerMonth, wantMode: models.TaskRepeatModeDefault},
+
+		// A full date (day + month name) recurs yearly.
+		{name: "yearly 1 April", due: &dueDate{String: "yearly 1 April", IsRecurring: true}, want: secondsPerYear, wantMode: models.TaskRepeatModeDefault},
+		{name: "yearly 1st May", due: &dueDate{String: "yearly 1st May", IsRecurring: true}, want: secondsPerYear, wantMode: models.TaskRepeatModeDefault},
+		{name: "yearly 21st September", due: &dueDate{String: "yearly 21st September", IsRecurring: true}, want: secondsPerYear, wantMode: models.TaskRepeatModeDefault},
+		{name: "every 1 june", due: &dueDate{String: "every 1 june", IsRecurring: true}, want: secondsPerYear, wantMode: models.TaskRepeatModeDefault},
+		{name: "elke 1 juni", due: &dueDate{String: "elke 1 juni", IsRecurring: true}, want: secondsPerYear, wantMode: models.TaskRepeatModeDefault},
+		{name: "elke 1 maart", due: &dueDate{String: "elke 1 maart", IsRecurring: true}, want: secondsPerYear, wantMode: models.TaskRepeatModeDefault},
+		{name: "elke 1 oktober", due: &dueDate{String: "elke 1 oktober", IsRecurring: true}, want: secondsPerYear, wantMode: models.TaskRepeatModeDefault},
+		{name: "elke 10 jan", due: &dueDate{String: "elke 10 jan", IsRecurring: true}, want: secondsPerYear, wantMode: models.TaskRepeatModeDefault},
+		{name: "elke 15 januari", due: &dueDate{String: "elke 15 januari", IsRecurring: true}, want: secondsPerYear, wantMode: models.TaskRepeatModeDefault},
+		{name: "elke 16e jul", due: &dueDate{String: "elke 16e jul", IsRecurring: true}, want: secondsPerYear, wantMode: models.TaskRepeatModeDefault},
+
+		// A numeric day/month date recurs yearly.
+		{name: "every 15/03", due: &dueDate{String: "every 15/03", IsRecurring: true}, want: secondsPerYear, wantMode: models.TaskRepeatModeDefault},
+		{name: "every 1/11", due: &dueDate{String: "every 1/11", IsRecurring: true}, want: secondsPerYear, wantMode: models.TaskRepeatModeDefault},
+
+		// A day of the month without a month name recurs monthly, anchored via RepeatModeMonth.
+		{name: "day of month", due: &dueDate{String: "every 27th", IsRecurring: true}, want: secondsPerMonth, wantMode: models.TaskRepeatModeMonth},
+		{name: "every 15th", due: &dueDate{String: "every 15th", IsRecurring: true}, want: secondsPerMonth, wantMode: models.TaskRepeatModeMonth},
+		{name: "every 10th", due: &dueDate{String: "every 10th", IsRecurring: true}, want: secondsPerMonth, wantMode: models.TaskRepeatModeMonth},
+		{name: "every 1st day", due: &dueDate{String: "every 1st day", IsRecurring: true}, want: secondsPerMonth, wantMode: models.TaskRepeatModeMonth},
+		{name: "elke laatste dag", due: &dueDate{String: "elke laatste dag", IsRecurring: true}, want: secondsPerMonth, wantMode: models.TaskRepeatModeMonth},
+
+		// A weekday recurs weekly - the due date already anchors the weekday.
+		{name: "specific weekday", due: &dueDate{String: "every monday", IsRecurring: true}, want: secondsPerWeek, wantMode: models.TaskRepeatModeDefault},
+		{name: "dutch weekday", due: &dueDate{String: "elke maandag", IsRecurring: true}, want: secondsPerWeek, wantMode: models.TaskRepeatModeDefault},
+		{name: "dutch weekday sunday", due: &dueDate{String: "elke zondag", IsRecurring: true}, want: secondsPerWeek, wantMode: models.TaskRepeatModeDefault},
+
+		// Recurrences we can't represent (other languages, unparseable text) stay non-repeating.
+		{name: "non-english", due: &dueDate{String: "cada día", IsRecurring: true}, want: 0, wantMode: models.TaskRepeatModeDefault},
+		{name: "gibberish", due: &dueDate{String: "whenever", IsRecurring: true}, want: 0, wantMode: models.TaskRepeatModeDefault},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, parseTodoistRepeat(tt.due))
+			repeatAfter, repeatMode := parseTodoistRepeat(tt.due)
+			assert.Equal(t, tt.want, repeatAfter)
+			assert.Equal(t, tt.wantMode, repeatMode)
+		})
+	}
+}
+
+// The recurring due.string values of a real Todoist export (recurring_strings.json in the
+// issue, not committed). Every one of them must migrate to a repeating task - exact
+// interval and mode expectations are covered by the table test above.
+func TestParseTodoistRepeatRealExportStrings(t *testing.T) {
+	for _, s := range []string{
+		"elke 1 juni",
+		"elke 1 maart",
+		"elke 1 oktober",
+		"elke 10 jan",
+		"elke 15 januari",
+		"elke 16e jul",
+		"elke 2 jaren",
+		"elke 24 maanden",
+		"elke 3 maanden",
+		"elke 4 maanden",
+		"elke 4 weken",
+		"elke 6 maanden",
+		"elke jaar",
+		"elke laatste dag",
+		"elke maandag",
+		"elke week",
+		"elke! 4 maand",
+		"every 1 years",
+		"every 1/11",
+		"every 10th",
+		"every 15/03",
+		"every 15th",
+		"every 1st day",
+		"every 3 months",
+		"every 6 months",
+		"every month",
+		"yearly",
+		"yearly 1 April",
+		"yearly 1 July",
+		"yearly 1st May",
+		"yearly 21st September",
+	} {
+		t.Run(s, func(t *testing.T) {
+			repeatAfter, _ := parseTodoistRepeat(&dueDate{String: s, IsRecurring: true})
+			assert.NotZero(t, repeatAfter, "recurrence from the real export must not migrate as non-repeating")
 		})
 	}
 }

--- a/pkg/modules/migration/todoist/todoist_test.go
+++ b/pkg/modules/migration/todoist/todoist_test.go
@@ -803,6 +803,24 @@ func TestParseTodoistRepeat(t *testing.T) {
 	}
 }
 
+// The word packs must really be keyed on due.lang: the same recurrence text may only
+// parse in the language Todoist says it is written in, instead of matching words from
+// every language everywhere.
+func TestParseTodoistRepeatLangKeyed(t *testing.T) {
+	repeatAfter, repeatMode := parseTodoistRepeat(&dueDate{String: "elke 3 maanden", Lang: "en", IsRecurring: true})
+	assert.Zero(t, repeatAfter)
+	assert.Equal(t, models.TaskRepeatModeDefault, repeatMode)
+
+	repeatAfter, repeatMode = parseTodoistRepeat(&dueDate{String: "elke 3 maanden", Lang: "nl", IsRecurring: true})
+	assert.Equal(t, 3*secondsPerMonth, repeatAfter)
+	assert.Equal(t, models.TaskRepeatModeDefault, repeatMode)
+
+	// An unknown language falls back to the English pack rather than trying every pack.
+	repeatAfter, repeatMode = parseTodoistRepeat(&dueDate{String: "elke 3 maanden", Lang: "de", IsRecurring: true})
+	assert.Zero(t, repeatAfter)
+	assert.Equal(t, models.TaskRepeatModeDefault, repeatMode)
+}
+
 // The recurring due.string values of a real Todoist export (recurring_strings.json in the
 // issue, not committed). Every one of them must migrate to a repeating task - exact
 // interval and mode expectations are covered by the table test above.


### PR DESCRIPTION
Todoist exposes recurrence only as free text in the user's language (`due.string`), so `parseTodoistRepeat` — which only knew bare English phrases like "every 3 months" — left most recurring tasks non-repeating: in a real 56-task export, 26 of 31 recurring tasks lost their recurrence entirely.

## What changed

- **Parsed forms:** bare adverbs ("daily", "wekelijks"), intervals ("every 3 weeks", "elke 4 weken", "every other day"), date-anchored yearlies ("yearly 1st May", "elke 16e jul", "every 15/03"), day-of-month monthlies ("every 15th" → `TaskRepeatModeMonth` so the day stays anchored despite unequal month lengths), and weekdays ("elke maandag" → weekly; the due date already anchors the weekday). Anything unparsed still returns 0 with the existing debug log — no behaviour change for unknown input.
- **Lang-keyed structure (rework after review feedback):** the shared EN+NL word maps and regexes are replaced by per-language data packs (`langPacks`, selected by `due.lang` — en and nl today) running through a language-agnostic grammar. A new language is a new data block with zero grammar changes; unknown languages fall back to `en`, and a missing `lang` (which real exports never produce) tries every pack as a whole so lang-less callers keep the old behaviour. The table and the small `parseTodoistRepeat` entry point are deliberately swappable for the planned multilingual date parser.

## How to verify

1. Run the Todoist migration (Settings → Migrations → Todoist) with an account that has recurring tasks using strings like "elke 4 weken", "elke 3 maanden", "yearly 1st May", "every 15th", "every 15/03", "elke maandag".
2. Open the migrated tasks in Vikunja.
3. **Expected:** each task shows a matching repeat interval and mode — e.g. "elke 4 weken" → repeats every 4 weeks; "every 15th" → monthly repeat anchored to day 15; "elke maandag" → weekly repeat.
4. **Before this PR:** all of these migrated as non-repeating tasks.
