### PR TITLE
docs: add swagger annotations for the OAuth 2.0 endpoints

### DIFF
--- a/pkg/modules/auth/oauth2server/authorize.go
+++ b/pkg/modules/auth/oauth2server/authorize.go
@@ -46,6 +46,18 @@ type AuthorizeResponse struct {
 // HandleAuthorize handles POST /oauth/authorize.
 // It validates the OAuth parameters, creates an authorization code, and
 // returns it as JSON. Authentication is handled by the token middleware.
+// @Summary OAuth 2.0 authorize endpoint
+// @Description Creates an authorization code for an OAuth 2.0 client on behalf of the authenticated user. PKCE is required. API tokens cannot be used to authorize a client.
+// @tags auth
+// @Accept json
+// @Produce json
+// @Security JWTKeyAuth
+// @Param request body AuthorizeRequest true "The authorization request"
+// @Success 200 {object} AuthorizeResponse "The authorization code and the redirect URI to return it to."
+// @Failure 400 {object} web.HTTPError "response_type is not 'code', the redirect URI is invalid, or the PKCE challenge is missing."
+// @Failure 403 {object} models.Message "An API token was used to authorize an OAuth client."
+// @Failure 500 {object} models.Message "Internal server error."
+// @Router /oauth/authorize [post]
 func HandleAuthorize(c *echo.Context) error {
 	if c.Get("api_token") != nil {
 		return echo.NewHTTPError(http.StatusForbidden, "API tokens cannot be used to authorize OAuth clients")

--- a/pkg/modules/auth/oauth2server/token.go
+++ b/pkg/modules/auth/oauth2server/token.go
@@ -54,6 +54,17 @@ type TokenRequest struct {
 
 // HandleToken handles POST /oauth/token.
 // Supports grant_type=authorization_code and grant_type=refresh_token.
+// @Summary OAuth 2.0 token endpoint
+// @Description Exchanges an authorization code for an access token, or a refresh token for a new one. Part of the OAuth 2.0 Authorization Code flow with PKCE. Needs no authentication: the grant itself is the credential.
+// @tags auth
+// @Accept json
+// @Produce json
+// @Param grant body TokenRequest true "The token request"
+// @Success 200 {object} TokenResponse "The access token, its type, lifetime and refresh token."
+// @Failure 400 {object} web.HTTPError "Unsupported grant type, or an invalid, expired or already-used authorization code."
+// @Failure 401 {object} web.HTTPError "Invalid or expired refresh token."
+// @Failure 500 {object} models.Message "Internal server error."
+// @Router /oauth/token [post]
 func HandleToken(c *echo.Context) error {
 	var req TokenRequest
 	if err := c.Bind(&req); err != nil {

--- a/pkg/swagger/docs.go
+++ b/pkg/swagger/docs.go
@@ -2087,6 +2087,115 @@ const docTemplate = `{
                 }
             }
         },
+        "/oauth/authorize": {
+            "post": {
+                "security": [
+                    {
+                        "JWTKeyAuth": []
+                    }
+                ],
+                "description": "Creates an authorization code for an OAuth 2.0 client on behalf of the authenticated user. PKCE is required. API tokens cannot be used to authorize a client.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "auth"
+                ],
+                "summary": "OAuth 2.0 authorize endpoint",
+                "parameters": [
+                    {
+                        "description": "The authorization request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/oauth2server.AuthorizeRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "The authorization code and the redirect URI to return it to.",
+                        "schema": {
+                            "$ref": "#/definitions/oauth2server.AuthorizeResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "response_type is not 'code', the redirect URI is invalid, or the PKCE challenge is missing.",
+                        "schema": {
+                            "$ref": "#/definitions/web.HTTPError"
+                        }
+                    },
+                    "403": {
+                        "description": "An API token was used to authorize an OAuth client.",
+                        "schema": {
+                            "$ref": "#/definitions/models.Message"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error.",
+                        "schema": {
+                            "$ref": "#/definitions/models.Message"
+                        }
+                    }
+                }
+            }
+        },
+        "/oauth/token": {
+            "post": {
+                "description": "Exchanges an authorization code for an access token, or a refresh token for a new one. Part of the OAuth 2.0 Authorization Code flow with PKCE. Needs no authentication: the grant itself is the credential.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "auth"
+                ],
+                "summary": "OAuth 2.0 token endpoint",
+                "parameters": [
+                    {
+                        "description": "The token request",
+                        "name": "grant",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/oauth2server.TokenRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "The access token, its type, lifetime and refresh token.",
+                        "schema": {
+                            "$ref": "#/definitions/oauth2server.TokenResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Unsupported grant type, or an invalid, expired or already-used authorization code.",
+                        "schema": {
+                            "$ref": "#/definitions/web.HTTPError"
+                        }
+                    },
+                    "401": {
+                        "description": "Invalid or expired refresh token.",
+                        "schema": {
+                            "$ref": "#/definitions/web.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error.",
+                        "schema": {
+                            "$ref": "#/definitions/models.Message"
+                        }
+                    }
+                }
+            }
+        },
         "/projects": {
             "get": {
                 "security": [
@@ -10799,6 +10908,83 @@ const docTemplate = `{
                 },
                 "read_at": {
                     "description": "When this notification is marked as read, this will be updated with the current timestamp.",
+                    "type": "string"
+                }
+            }
+        },
+        "oauth2server.AuthorizeRequest": {
+            "type": "object",
+            "properties": {
+                "client_id": {
+                    "type": "string"
+                },
+                "code_challenge": {
+                    "type": "string"
+                },
+                "code_challenge_method": {
+                    "type": "string"
+                },
+                "redirect_uri": {
+                    "type": "string"
+                },
+                "response_type": {
+                    "type": "string"
+                },
+                "state": {
+                    "type": "string"
+                }
+            }
+        },
+        "oauth2server.AuthorizeResponse": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "string"
+                },
+                "redirect_uri": {
+                    "type": "string"
+                },
+                "state": {
+                    "type": "string"
+                }
+            }
+        },
+        "oauth2server.TokenRequest": {
+            "type": "object",
+            "properties": {
+                "client_id": {
+                    "type": "string"
+                },
+                "code": {
+                    "type": "string"
+                },
+                "code_verifier": {
+                    "type": "string"
+                },
+                "grant_type": {
+                    "type": "string"
+                },
+                "redirect_uri": {
+                    "type": "string"
+                },
+                "refresh_token": {
+                    "type": "string"
+                }
+            }
+        },
+        "oauth2server.TokenResponse": {
+            "type": "object",
+            "properties": {
+                "access_token": {
+                    "type": "string"
+                },
+                "expires_in": {
+                    "type": "integer"
+                },
+                "refresh_token": {
+                    "type": "string"
+                },
+                "token_type": {
                     "type": "string"
                 }
             }

--- a/pkg/swagger/swagger.json
+++ b/pkg/swagger/swagger.json
@@ -2079,6 +2079,115 @@
                 }
             }
         },
+        "/oauth/authorize": {
+            "post": {
+                "security": [
+                    {
+                        "JWTKeyAuth": []
+                    }
+                ],
+                "description": "Creates an authorization code for an OAuth 2.0 client on behalf of the authenticated user. PKCE is required. API tokens cannot be used to authorize a client.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "auth"
+                ],
+                "summary": "OAuth 2.0 authorize endpoint",
+                "parameters": [
+                    {
+                        "description": "The authorization request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/oauth2server.AuthorizeRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "The authorization code and the redirect URI to return it to.",
+                        "schema": {
+                            "$ref": "#/definitions/oauth2server.AuthorizeResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "response_type is not 'code', the redirect URI is invalid, or the PKCE challenge is missing.",
+                        "schema": {
+                            "$ref": "#/definitions/web.HTTPError"
+                        }
+                    },
+                    "403": {
+                        "description": "An API token was used to authorize an OAuth client.",
+                        "schema": {
+                            "$ref": "#/definitions/models.Message"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error.",
+                        "schema": {
+                            "$ref": "#/definitions/models.Message"
+                        }
+                    }
+                }
+            }
+        },
+        "/oauth/token": {
+            "post": {
+                "description": "Exchanges an authorization code for an access token, or a refresh token for a new one. Part of the OAuth 2.0 Authorization Code flow with PKCE. Needs no authentication: the grant itself is the credential.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "auth"
+                ],
+                "summary": "OAuth 2.0 token endpoint",
+                "parameters": [
+                    {
+                        "description": "The token request",
+                        "name": "grant",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/oauth2server.TokenRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "The access token, its type, lifetime and refresh token.",
+                        "schema": {
+                            "$ref": "#/definitions/oauth2server.TokenResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Unsupported grant type, or an invalid, expired or already-used authorization code.",
+                        "schema": {
+                            "$ref": "#/definitions/web.HTTPError"
+                        }
+                    },
+                    "401": {
+                        "description": "Invalid or expired refresh token.",
+                        "schema": {
+                            "$ref": "#/definitions/web.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error.",
+                        "schema": {
+                            "$ref": "#/definitions/models.Message"
+                        }
+                    }
+                }
+            }
+        },
         "/projects": {
             "get": {
                 "security": [
@@ -10791,6 +10900,83 @@
                 },
                 "read_at": {
                     "description": "When this notification is marked as read, this will be updated with the current timestamp.",
+                    "type": "string"
+                }
+            }
+        },
+        "oauth2server.AuthorizeRequest": {
+            "type": "object",
+            "properties": {
+                "client_id": {
+                    "type": "string"
+                },
+                "code_challenge": {
+                    "type": "string"
+                },
+                "code_challenge_method": {
+                    "type": "string"
+                },
+                "redirect_uri": {
+                    "type": "string"
+                },
+                "response_type": {
+                    "type": "string"
+                },
+                "state": {
+                    "type": "string"
+                }
+            }
+        },
+        "oauth2server.AuthorizeResponse": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "string"
+                },
+                "redirect_uri": {
+                    "type": "string"
+                },
+                "state": {
+                    "type": "string"
+                }
+            }
+        },
+        "oauth2server.TokenRequest": {
+            "type": "object",
+            "properties": {
+                "client_id": {
+                    "type": "string"
+                },
+                "code": {
+                    "type": "string"
+                },
+                "code_verifier": {
+                    "type": "string"
+                },
+                "grant_type": {
+                    "type": "string"
+                },
+                "redirect_uri": {
+                    "type": "string"
+                },
+                "refresh_token": {
+                    "type": "string"
+                }
+            }
+        },
+        "oauth2server.TokenResponse": {
+            "type": "object",
+            "properties": {
+                "access_token": {
+                    "type": "string"
+                },
+                "expires_in": {
+                    "type": "integer"
+                },
+                "refresh_token": {
+                    "type": "string"
+                },
+                "token_type": {
                     "type": "string"
                 }
             }

--- a/pkg/swagger/swagger.yaml
+++ b/pkg/swagger/swagger.yaml
@@ -1439,6 +1439,56 @@ definitions:
           with the current timestamp.
         type: string
     type: object
+  oauth2server.AuthorizeRequest:
+    properties:
+      client_id:
+        type: string
+      code_challenge:
+        type: string
+      code_challenge_method:
+        type: string
+      redirect_uri:
+        type: string
+      response_type:
+        type: string
+      state:
+        type: string
+    type: object
+  oauth2server.AuthorizeResponse:
+    properties:
+      code:
+        type: string
+      redirect_uri:
+        type: string
+      state:
+        type: string
+    type: object
+  oauth2server.TokenRequest:
+    properties:
+      client_id:
+        type: string
+      code:
+        type: string
+      code_verifier:
+        type: string
+      grant_type:
+        type: string
+      redirect_uri:
+        type: string
+      refresh_token:
+        type: string
+    type: object
+  oauth2server.TokenResponse:
+    properties:
+      access_token:
+        type: string
+      expires_in:
+        type: integer
+      refresh_token:
+        type: string
+      token_type:
+        type: string
+    type: object
   openid.Callback:
     properties:
       code:
@@ -3380,6 +3430,82 @@ paths:
       summary: Mark a notification as (un-)read
       tags:
       - subscriptions
+  /oauth/authorize:
+    post:
+      consumes:
+      - application/json
+      description: Creates an authorization code for an OAuth 2.0 client on behalf
+        of the authenticated user. PKCE is required. API tokens cannot be used to
+        authorize a client.
+      parameters:
+      - description: The authorization request
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/oauth2server.AuthorizeRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: The authorization code and the redirect URI to return it to.
+          schema:
+            $ref: '#/definitions/oauth2server.AuthorizeResponse'
+        "400":
+          description: response_type is not 'code', the redirect URI is invalid, or
+            the PKCE challenge is missing.
+          schema:
+            $ref: '#/definitions/web.HTTPError'
+        "403":
+          description: An API token was used to authorize an OAuth client.
+          schema:
+            $ref: '#/definitions/models.Message'
+        "500":
+          description: Internal server error.
+          schema:
+            $ref: '#/definitions/models.Message'
+      security:
+      - JWTKeyAuth: []
+      summary: OAuth 2.0 authorize endpoint
+      tags:
+      - auth
+  /oauth/token:
+    post:
+      consumes:
+      - application/json
+      description: 'Exchanges an authorization code for an access token, or a refresh
+        token for a new one. Part of the OAuth 2.0 Authorization Code flow with PKCE.
+        Needs no authentication: the grant itself is the credential.'
+      parameters:
+      - description: The token request
+        in: body
+        name: grant
+        required: true
+        schema:
+          $ref: '#/definitions/oauth2server.TokenRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: The access token, its type, lifetime and refresh token.
+          schema:
+            $ref: '#/definitions/oauth2server.TokenResponse'
+        "400":
+          description: Unsupported grant type, or an invalid, expired or already-used
+            authorization code.
+          schema:
+            $ref: '#/definitions/web.HTTPError'
+        "401":
+          description: Invalid or expired refresh token.
+          schema:
+            $ref: '#/definitions/web.HTTPError'
+        "500":
+          description: Internal server error.
+          schema:
+            $ref: '#/definitions/models.Message'
+      summary: OAuth 2.0 token endpoint
+      tags:
+      - auth
   /projects:
     get:
       consumes:


### PR DESCRIPTION
`POST /api/v1/oauth/authorize` and `POST /api/v1/oauth/token` are served but missing from the generated OpenAPI docs: the handlers in `pkg/modules/auth/oauth2server` carry no swagger annotations, so neither path is in `swagger.json` — 126 paths, no `oauth` among them.

Found while building a third-party client. The API answers fine; the docs say the endpoints don't exist, so a client that validates its calls against them can't use OAuth at all.

Adds annotations for both handlers and regenerates `pkg/swagger`. No behaviour change — comments only, plus generated output. `mage generate:swagger-docs` produces 521 insertions and 0 deletions, so nothing else in the spec moved.

Checked against a 2.5.0 instance: `OPTIONS` on both paths returns `Allow: OPTIONS, POST`, and `POST /api/v1/oauth/token` with no grant type returns code 17007 naming `authorization_code` and `refresh_token`.

One judgement call worth a look: I annotated the token endpoint `@Accept json`, matching the comment on `TokenRequest` that v1 binds JSON and v2 takes the form-encoded body. In practice v1 binds a form body too — `Content-Type: application/x-www-form-urlencoded` with `grant_type=nope` returns the same 17007 — so if you'd rather document both, say the word and I'll widen it.

The `/api/v2` routes are untouched — happy to cover those too if you'd like them in.

AI-assisted: annotations drafted with Claude, reviewed and tested by me.
