### PR TITLE
fix(task): ensure the Due Date hotkey ('d') also opens the datepicker popup

### DIFF
--- a/frontend/src/components/input/Datepicker.vue
+++ b/frontend/src/components/input/Datepicker.vue
@@ -13,7 +13,7 @@
 					v-tooltip="date ? formatDateLong(date) : undefined"
 					class="show"
 					:disabled="disabled || undefined"
-					@click.stop="toggleFromTrigger($event, toggle)"
+					@click.stop="toggle()"
 				>
 					<i v-if="date === null && emptyLabel !== ''">{{ emptyLabel }}</i>
 					<template v-else>
@@ -32,7 +32,6 @@
 			<template #content="{isOpen}">
 				<div
 					v-if="isOpen"
-					ref="datepickerPopup"
 					class="datepicker-popup"
 					:class="{'datepicker-popup--no-shortcuts': !showShortcuts}"
 					:role="isMobile ? undefined : 'dialog'"
@@ -158,15 +157,8 @@ function clear() {
 	updateData()
 }
 
-const datepickerPopup = ref<HTMLElement | null>(null)
 const triggerButton = ref<InstanceType<typeof SimpleButton> | null>(null)
 const triggerEl = computed<HTMLElement | null>(() => triggerButton.value?.$el ?? null)
-let focusOnOpen = false
-
-function toggleFromTrigger(event: MouseEvent, toggle: () => boolean) {
-	focusOnOpen = event.detail === 0
-	toggle()
-}
 
 watch(show, async (isOpen) => {
 	if (!isOpen) {
@@ -174,17 +166,8 @@ watch(show, async (isOpen) => {
 		return
 	}
 	await nextTick()
-	if (!focusOnOpen) {
-		if (!isMobile.value) {
-			triggerButton.value?.focus()
-		}
-		return
-	}
-	const firstShortcutEl = datepickerPopup.value?.querySelector<HTMLElement>('.datepicker__quick-select-date')
-	if (firstShortcutEl) {
-		firstShortcutEl.focus({ focusVisible: true })
-	} else {
-		datepickerPopup.value?.focus({ focusVisible: true })
+	if (!isMobile.value) {
+		triggerButton.value?.focus()
 	}
 })
 
@@ -192,9 +175,8 @@ function close() {
 	show.value = false
 }
 
-function open(event?: MouseEvent) {
+function open() {
 	if (!props.disabled) {
-		focusOnOpen = !event || event.detail === 0
 		show.value = true
 	}
 }

--- a/frontend/src/components/input/Datepicker.vue
+++ b/frontend/src/components/input/Datepicker.vue
@@ -167,7 +167,12 @@ watch(show, async (isOpen) => {
 		return
 	}
 	await nextTick()
-	datepickerPopup.value?.focus()
+	const firstShortcutEl = datepickerPopup.value?.querySelector<HTMLElement>('.datepicker__quick-select-date')
+	if (firstShortcutEl) {
+		firstShortcutEl.focus({ focusVisible: true })
+	} else {
+		datepickerPopup.value?.focus({ focusVisible: true })
+	}
 })
 
 function close() {

--- a/frontend/src/components/input/Datepicker.vue
+++ b/frontend/src/components/input/Datepicker.vue
@@ -13,7 +13,7 @@
 					v-tooltip="date ? formatDateLong(date) : undefined"
 					class="show"
 					:disabled="disabled || undefined"
-					@click.stop="toggle()"
+					@click.stop="toggleFromTrigger($event, toggle)"
 				>
 					<i v-if="date === null && emptyLabel !== ''">{{ emptyLabel }}</i>
 					<template v-else>
@@ -161,6 +161,12 @@ function clear() {
 const datepickerPopup = ref<HTMLElement | null>(null)
 const triggerButton = ref<InstanceType<typeof SimpleButton> | null>(null)
 const triggerEl = computed<HTMLElement | null>(() => triggerButton.value?.$el ?? null)
+let focusOnOpen = false
+
+function toggleFromTrigger(event: MouseEvent, toggle: () => boolean) {
+	focusOnOpen = event.detail === 0
+	toggle()
+}
 
 watch(show, async (isOpen) => {
 	if (!isOpen) {
@@ -168,6 +174,12 @@ watch(show, async (isOpen) => {
 		return
 	}
 	await nextTick()
+	if (!focusOnOpen) {
+		if (!isMobile.value) {
+			triggerButton.value?.focus()
+		}
+		return
+	}
 	const firstShortcutEl = datepickerPopup.value?.querySelector<HTMLElement>('.datepicker__quick-select-date')
 	if (firstShortcutEl) {
 		firstShortcutEl.focus({ focusVisible: true })
@@ -180,8 +192,9 @@ function close() {
 	show.value = false
 }
 
-function open() {
+function open(event?: MouseEvent) {
 	if (!props.disabled) {
+		focusOnOpen = !event || event.detail === 0
 		show.value = true
 	}
 }

--- a/frontend/src/components/input/Datepicker.vue
+++ b/frontend/src/components/input/Datepicker.vue
@@ -174,6 +174,12 @@ function close() {
 	show.value = false
 }
 
+function open() {
+	if (!props.disabled) {
+		show.value = true
+	}
+}
+
 function emitClose() {
 	// Kind of dirty, but the timeout allows us to enter a time and click on "confirm" without
 	// having to click on another input field before it is actually used.
@@ -185,6 +191,10 @@ function emitClose() {
 		}
 	}, 200)
 }
+
+defineExpose({
+	open,
+})
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/src/components/input/Datepicker.vue
+++ b/frontend/src/components/input/Datepicker.vue
@@ -46,6 +46,7 @@
 						:large="isMobile"
 						:min-date="minDate"
 						@update:modelValue="updateData"
+						@quickSelectConfirmed="close"
 					/>
 
 					<div class="datepicker-popup__footer">

--- a/frontend/src/components/input/DatepickerInline.vue
+++ b/frontend/src/components/input/DatepickerInline.vue
@@ -8,6 +8,7 @@
 			layout="chips"
 			:active="date"
 			@select="setShortcut"
+			@confirm="emit('quickSelectConfirmed')"
 		/>
 
 		<div class="datepicker-inline__body">
@@ -16,6 +17,7 @@
 				layout="list"
 				:active="date"
 				@select="setShortcut"
+				@confirm="emit('quickSelectConfirmed')"
 			/>
 			<CalendarMonth
 				class="datepicker-inline__calendar"
@@ -61,6 +63,7 @@ const props = withDefaults(defineProps<{
 
 const emit = defineEmits<{
 	'update:modelValue': [Date | null],
+	'quickSelectConfirmed': [],
 }>()
 
 const date = ref<Date | null>(null)

--- a/frontend/src/components/input/datepicker/DateShortcuts.vue
+++ b/frontend/src/components/input/datepicker/DateShortcuts.vue
@@ -10,11 +10,15 @@
 			{{ $t('input.datepicker.quickSelect') }}
 		</div>
 		<BaseButton
-			v-for="shortcut in shortcuts"
+			v-for="(shortcut, index) in shortcuts"
 			:key="shortcut.key"
+			:ref="el => shortcutButtons.set(shortcut.key, el as InstanceType<typeof BaseButton> | null)"
 			class="datepicker__quick-select-date date-shortcuts__item"
 			:class="{'is-active': isSameDay(shortcut.date, active)}"
 			@click.stop="emit('select', shortcut.date)"
+			@keydown.up.prevent="focusShortcut(index - 1)"
+			@keydown.down.prevent="focusShortcut(index + 1)"
+			@keydown.enter.prevent="confirmShortcut(shortcut.date)"
 		>
 			<span class="date-shortcuts__icon">
 				<Icon :icon="shortcut.icon" />
@@ -48,6 +52,7 @@ withDefaults(defineProps<{
 
 const emit = defineEmits<{
 	select: [date: Date]
+	confirm: []
 }>()
 
 const ICONS: Record<DateShortcutKey, IconProp> = {
@@ -67,6 +72,19 @@ const shortcuts = computed(() => buildDateShortcuts().map(shortcut => ({
 	icon: ICONS[shortcut.key],
 	weekday: formatDate(shortcut.date, 'ddd'),
 })))
+const shortcutButtons = new Map<DateShortcutKey, InstanceType<typeof BaseButton> | null>()
+
+function focusShortcut(index: number) {
+	const shortcut = shortcuts.value[index]
+	if (shortcut) {
+		shortcutButtons.get(shortcut.key)?.focus()
+	}
+}
+
+function confirmShortcut(date: Date) {
+	emit('select', date)
+	emit('confirm')
+}
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/src/helpers/scrollIntoView.ts
+++ b/frontend/src/helpers/scrollIntoView.ts
@@ -1,4 +1,4 @@
-export function scrollIntoView(el: HTMLElement | null | undefined) {
+export function scrollIntoView(el: HTMLElement | null | undefined, behavior: ScrollBehavior = 'smooth') {
 	if (!el) {
 		return
 	}
@@ -11,7 +11,7 @@ export function scrollIntoView(el: HTMLElement | null | undefined) {
 		boundingRect.top < scrollY
 	) {
 		el.scrollIntoView({
-			behavior: 'smooth',
+			behavior,
 			block: 'center',
 			inline: 'nearest',
 		})

--- a/frontend/src/views/tasks/TaskDetailView.vue
+++ b/frontend/src/views/tasks/TaskDetailView.vue
@@ -131,7 +131,7 @@
 								</div>
 								<div class="date-input">
 									<Datepicker
-										:ref="e => setFieldRef('dueDate', e)"
+										ref="dueDatePicker"
 										v-model="task.dueDate"
 										:choose-date-label="$t('task.detail.chooseDueDate')"
 										:title="$t('task.attributes.dueDate')"
@@ -187,7 +187,7 @@
 								</div>
 								<div class="date-input">
 									<Datepicker
-										:ref="e => setFieldRef('startDate', e)"
+										ref="startDatePicker"
 										v-model="task.startDate"
 										:choose-date-label="$t('task.detail.chooseStartDate')"
 										:title="$t('task.attributes.startDate')"
@@ -222,7 +222,7 @@
 								</div>
 								<div class="date-input">
 									<Datepicker
-										:ref="e => setFieldRef('endDate', e)"
+										ref="endDatePicker"
 										v-model="task.endDate"
 										:choose-date-label="$t('task.detail.chooseEndDate')"
 										:title="$t('task.attributes.endDate')"
@@ -655,7 +655,7 @@
 </template>
 
 <script lang="ts" setup>
-import {ref, reactive, shallowReactive, computed, watch, nextTick, onMounted} from 'vue'
+import {ref, reactive, shallowReactive, computed, watch, nextTick, onMounted, useTemplateRef} from 'vue'
 import {useRouter, useRoute, type RouteLocation, onBeforeRouteLeave} from 'vue-router'
 import {useI18n} from 'vue-i18n'
 import {unrefElement, useDebounceFn, useElementSize, useIntersectionObserver, useMutationObserver} from '@vueuse/core'
@@ -1054,14 +1054,30 @@ const activeFieldElements: { [id in FieldType]: HTMLElement | null } = reactive(
 	startDate: null,
 })
 
-function setFieldRef(name, e) {
+const dueDatePicker = useTemplateRef<InstanceType<typeof Datepicker>>('dueDatePicker')
+const startDatePicker = useTemplateRef<InstanceType<typeof Datepicker>>('startDatePicker')
+const endDatePicker = useTemplateRef<InstanceType<typeof Datepicker>>('endDatePicker')
+
+function setFieldRef(name: FieldType, e) {
 	activeFieldElements[name] = unrefElement(e)
 }
 
 function setFieldActive(fieldName: keyof typeof activeFields) {
 	activeFields[fieldName] = true
 	nextTick(() => {
-		const el = activeFieldElements[fieldName]
+		let datepicker: InstanceType<typeof Datepicker> | null = null
+		switch (fieldName) {
+			case 'dueDate':
+				datepicker = dueDatePicker.value
+				break
+			case 'startDate':
+				datepicker = startDatePicker.value
+				break
+			case 'endDate':
+				datepicker = endDatePicker.value
+				break
+		}
+		const el: HTMLElement | null = datepicker?.$el ?? activeFieldElements[fieldName]
 
 		if (!el) {
 			return
@@ -1069,8 +1085,12 @@ function setFieldActive(fieldName: keyof typeof activeFields) {
 
 		el.focus()
 
-		// scroll the field to the center of the screen if not in viewport already
-		scrollIntoView(el)
+		// Finish scrolling before the datepicker sheet locks the page.
+		scrollIntoView(el, datepicker ? 'instant' : 'smooth')
+
+		// setTimeout(..., 0) is preventing the *original* click to open a field from also being
+		// detected as an outside click and immediately closing the popup.
+		setTimeout(() => datepicker?.open(), 0)
 	})
 }
 

--- a/frontend/src/views/tasks/TaskDetailView.vue
+++ b/frontend/src/views/tasks/TaskDetailView.vue
@@ -568,21 +568,21 @@
 							v-shortcut="SHORTCUTS.taskDetail.dueDate"
 							variant="secondary"
 							icon="calendar"
-							@click="setFieldActive('dueDate', $event)"
+							@click="setFieldActive('dueDate')"
 						>
 							{{ $t('task.detail.actions.dueDate') }}
 						</XButton>
 						<XButton
 							variant="secondary"
 							icon="play"
-							@click="setFieldActive('startDate', $event)"
+							@click="setFieldActive('startDate')"
 						>
 							{{ $t('task.detail.actions.startDate') }}
 						</XButton>
 						<XButton
 							variant="secondary"
 							icon="stop"
-							@click="setFieldActive('endDate', $event)"
+							@click="setFieldActive('endDate')"
 						>
 							{{ $t('task.detail.actions.endDate') }}
 						</XButton>
@@ -1062,7 +1062,7 @@ function setFieldRef(name: FieldType, e) {
 	activeFieldElements[name] = unrefElement(e)
 }
 
-function setFieldActive(fieldName: keyof typeof activeFields, event?: MouseEvent) {
+function setFieldActive(fieldName: keyof typeof activeFields) {
 	activeFields[fieldName] = true
 	nextTick(() => {
 		let datepicker: InstanceType<typeof Datepicker> | null = null
@@ -1090,7 +1090,7 @@ function setFieldActive(fieldName: keyof typeof activeFields, event?: MouseEvent
 
 		// setTimeout(..., 0) is preventing the *original* click to open a field from also being
 		// detected as an outside click and immediately closing the popup.
-		setTimeout(() => datepicker?.open(event), 0)
+		setTimeout(() => datepicker?.open(), 0)
 	})
 }
 

--- a/frontend/src/views/tasks/TaskDetailView.vue
+++ b/frontend/src/views/tasks/TaskDetailView.vue
@@ -568,21 +568,21 @@
 							v-shortcut="SHORTCUTS.taskDetail.dueDate"
 							variant="secondary"
 							icon="calendar"
-							@click="setFieldActive('dueDate')"
+							@click="setFieldActive('dueDate', $event)"
 						>
 							{{ $t('task.detail.actions.dueDate') }}
 						</XButton>
 						<XButton
 							variant="secondary"
 							icon="play"
-							@click="setFieldActive('startDate')"
+							@click="setFieldActive('startDate', $event)"
 						>
 							{{ $t('task.detail.actions.startDate') }}
 						</XButton>
 						<XButton
 							variant="secondary"
 							icon="stop"
-							@click="setFieldActive('endDate')"
+							@click="setFieldActive('endDate', $event)"
 						>
 							{{ $t('task.detail.actions.endDate') }}
 						</XButton>
@@ -1062,7 +1062,7 @@ function setFieldRef(name: FieldType, e) {
 	activeFieldElements[name] = unrefElement(e)
 }
 
-function setFieldActive(fieldName: keyof typeof activeFields) {
+function setFieldActive(fieldName: keyof typeof activeFields, event?: MouseEvent) {
 	activeFields[fieldName] = true
 	nextTick(() => {
 		let datepicker: InstanceType<typeof Datepicker> | null = null
@@ -1090,7 +1090,7 @@ function setFieldActive(fieldName: keyof typeof activeFields) {
 
 		// setTimeout(..., 0) is preventing the *original* click to open a field from also being
 		// detected as an outside click and immediately closing the popup.
-		setTimeout(() => datepicker?.open(), 0)
+		setTimeout(() => datepicker?.open(event), 0)
 	})
 }
 

--- a/frontend/tests/e2e/task/mobile-bottom-sheet.spec.ts
+++ b/frontend/tests/e2e/task/mobile-bottom-sheet.spec.ts
@@ -34,7 +34,6 @@ async function openDueDateSheet(page: Page) {
 
 	const datepickerShow = page.locator('.task-view .columns.details .column').filter({hasText: 'Due Date'}).locator('.date-input .datepicker .show')
 	await expect(datepickerShow).toBeVisible()
-	await datepickerShow.click()
 
 	const panel = page.locator('.bottom-sheet__panel')
 	await expect(panel).toBeVisible()

--- a/frontend/tests/e2e/task/mobile-bottom-sheet.spec.ts
+++ b/frontend/tests/e2e/task/mobile-bottom-sheet.spec.ts
@@ -55,6 +55,7 @@ test.describe('Mobile bottom sheet', () => {
 
 		const panel = await openDueDateSheet(page)
 		await expect(panel.locator('.datepicker-popup .calendar-month')).toBeVisible()
+		await expect(panel.locator('.datepicker__quick-select-date').first()).not.toBeFocused()
 
 		await panel.locator(`.calendar-month__day[data-date="${tomorrow}"]`).click()
 

--- a/frontend/tests/e2e/task/task.spec.ts
+++ b/frontend/tests/e2e/task/task.spec.ts
@@ -19,7 +19,7 @@ import {createDefaultViews} from '../project/prepareProjects'
 import {TaskBucketFactory} from '../../factories/task_buckets'
 import {pasteFile, pasteHtmlFromClipboard} from '../../support/commands'
 import {login} from '../../support/authenticateUser'
-import type {Page} from '@playwright/test'
+import type {Locator, Page} from '@playwright/test'
 import {readFileSync} from 'fs'
 import {join, dirname} from 'path'
 import {fileURLToPath} from 'url'
@@ -641,6 +641,125 @@ test.describe('Task', () => {
 			await page.locator('.task-view .action-buttons').click()
 			await page.locator('body').press('d')
 			await expect(dueDateColumn).toBeVisible()
+
+			const popup = dueDateColumn.locator('.datepicker .datepicker-popup')
+			await expect(popup).toBeVisible()
+			await expect(popup.locator('.datepicker__quick-select-date').first()).toBeFocused()
+		})
+
+		async function openDueDatePopupWithShortcut(page: Page): Promise<Locator> {
+			await page.locator('.task-view .action-buttons').click()
+			await page.locator('body').press('d')
+
+			const column = page.locator('.task-view .columns.details .column').filter({hasText: 'Due Date'})
+			const popup = column.locator('.datepicker .datepicker-popup')
+			await expect(popup).toBeVisible()
+			await expect(popup.locator('.datepicker__quick-select-date').first()).toBeFocused()
+			return popup
+		}
+
+		test('Opens the due date popup when clicking the action button and focuses the first quick-select option', async ({authenticatedPage: page}) => {
+			const tasks = await TaskFactory.create(1, {
+				id: 1,
+				done: false,
+			})
+			await page.goto(`/tasks/${tasks[0].id}`)
+			await page.waitForLoadState('networkidle')
+
+			const setDueDateButton = page.locator('.task-view .action-buttons .button').filter({hasText: 'Set Due Date'})
+			await expect(setDueDateButton).toBeVisible({timeout: 10000})
+			await setDueDateButton.click()
+
+			const popup = page.locator('.task-view .columns.details .column').filter({hasText: 'Due Date'}).locator('.datepicker .datepicker-popup')
+			await expect(popup).toBeVisible()
+			await expect(popup.locator('.datepicker__quick-select-date').first()).toBeFocused()
+		})
+
+		test('Opens the due date popup via the keyboard shortcut when the task already has a due date', async ({authenticatedPage: page}) => {
+			const tasks = await TaskFactory.create(1, {
+				id: 1,
+				done: false,
+				due_date: (new Date()).toISOString(),
+			})
+			await page.goto(`/tasks/${tasks[0].id}`)
+			await page.waitForLoadState('networkidle')
+
+			await openDueDatePopupWithShortcut(page)
+		})
+
+		test('Opens the start and end date popups from the actions menu and focuses the first quick-select option', async ({authenticatedPage: page}) => {
+			const tasks = await TaskFactory.create(1, {
+				id: 1,
+				done: false,
+			})
+			await page.goto(`/tasks/${tasks[0].id}`)
+			await page.waitForLoadState('networkidle')
+
+			for (const [buttonLabel, columnTitle] of [
+				['Set Start Date', 'Start Date'],
+				['Set End Date', 'End Date'],
+			] as const) {
+				const button = page.locator('.task-view .action-buttons .button').filter({hasText: buttonLabel})
+				await expect(button).toBeVisible({timeout: 10000})
+				await button.click()
+
+				const popup = page.locator('.task-view .columns.details .column').filter({hasText: columnTitle}).locator('.datepicker .datepicker-popup')
+				await expect(popup).toBeVisible()
+				await expect(popup.locator('.datepicker__quick-select-date').first()).toBeFocused()
+
+				await page.keyboard.press('Escape')
+				await expect(popup).not.toBeVisible()
+			}
+		})
+
+		test('Navigates the due date quick-select options with the arrow keys', async ({authenticatedPage: page}) => {
+			const tasks = await TaskFactory.create(1, {
+				id: 1,
+				done: false,
+			})
+			await page.goto(`/tasks/${tasks[0].id}`)
+			await page.waitForLoadState('networkidle')
+
+			const popup = await openDueDatePopupWithShortcut(page)
+			const options = popup.locator('.datepicker__quick-select-date')
+			const optionCount = await options.count()
+			expect(optionCount).toBeGreaterThan(1)
+
+			for (let i = 1; i < optionCount; i++) {
+				await page.keyboard.press('ArrowDown')
+				await expect(options.nth(i)).toBeFocused()
+			}
+			await page.keyboard.press('ArrowDown')
+			await expect(options.nth(optionCount - 1)).toBeFocused()
+
+			for (let i = optionCount - 2; i >= 0; i--) {
+				await page.keyboard.press('ArrowUp')
+				await expect(options.nth(i)).toBeFocused()
+			}
+
+			await page.keyboard.press('ArrowUp')
+			await expect(options.first()).toBeFocused()
+		})
+
+		test('Saves and closes the due date popup when confirming a quick-select option with Enter', async ({authenticatedPage: page}) => {
+			const tasks = await TaskFactory.create(1, {
+				id: 1,
+				done: false,
+			})
+			await page.goto(`/tasks/${tasks[0].id}`)
+			await page.waitForLoadState('networkidle')
+
+			const popup = await openDueDatePopupWithShortcut(page)
+			const column = page.locator('.task-view .columns.details .column').filter({hasText: 'Due Date'})
+			const showButton = column.locator('.datepicker .show')
+			await expect(showButton).toContainText('Click here to set a due date')
+
+			await page.keyboard.press('ArrowDown')
+			await page.keyboard.press('Enter')
+
+			await expect(popup).not.toBeVisible()
+			await expect(page.locator('.global-notification')).toContainText('Success')
+			await expect(showButton).not.toContainText('Click here to set a due date')
 		})
 
 		test('Can set a due date for a task', async ({authenticatedPage: page}) => {
@@ -654,10 +773,6 @@ test.describe('Task', () => {
 			const setDueDateButton = page.locator('.task-view .action-buttons .button').filter({hasText: 'Set Due Date'})
 			await expect(setDueDateButton).toBeVisible({timeout: 10000})
 			await setDueDateButton.click()
-
-			const datepickerShow = page.locator('.task-view .columns.details .column').filter({hasText: 'Due Date'}).locator('.date-input .datepicker .show')
-			await expect(datepickerShow).toBeVisible()
-			await datepickerShow.click()
 
 			const tomorrowButton = page.locator('.datepicker .datepicker-popup button').filter({hasText: 'Tomorrow'})
 			await expect(tomorrowButton).toBeVisible()
@@ -685,7 +800,6 @@ test.describe('Task', () => {
 
 			const datepickerShow = page.locator('.task-view .columns.details .column').filter({hasText: 'Due Date'}).locator('.date-input .datepicker .show')
 			await expect(datepickerShow).toBeVisible()
-			await datepickerShow.click()
 
 			const todayButton = page.locator('.datepicker-popup .calendar-month__day.is-today')
 			await expect(todayButton).toBeVisible()
@@ -730,7 +844,6 @@ test.describe('Task', () => {
 
 			const datepickerShow = page.locator('.task-view .columns.details .column').filter({hasText: 'Due Date'}).locator('.date-input .datepicker .show')
 			await expect(datepickerShow).toBeVisible()
-			await datepickerShow.click()
 
 			const dateButton = page.locator(`.datepicker-popup .calendar-month__day[aria-label="${today.toLocaleString('en-US', {month: 'long'})} ${today.getDate()}, ${today.getFullYear()}"]`)
 			await expect(dateButton).toBeVisible()

--- a/frontend/tests/e2e/task/task.spec.ts
+++ b/frontend/tests/e2e/task/task.spec.ts
@@ -658,7 +658,7 @@ test.describe('Task', () => {
 			return popup
 		}
 
-		test('Opens the due date popup when clicking the action button and focuses the first quick-select option', async ({authenticatedPage: page}) => {
+		test('Tabs into the due date quick-select options after clicking the action button', async ({authenticatedPage: page}) => {
 			const tasks = await TaskFactory.create(1, {
 				id: 1,
 				done: false,
@@ -672,7 +672,38 @@ test.describe('Task', () => {
 
 			const popup = page.locator('.task-view .columns.details .column').filter({hasText: 'Due Date'}).locator('.datepicker .datepicker-popup')
 			await expect(popup).toBeVisible()
+			await expect(popup.locator('.datepicker__quick-select-date').first()).not.toBeFocused()
+			await expect(page.locator('.task-view .columns.details .column').filter({hasText: 'Due Date'}).locator('.datepicker .show')).toBeFocused()
+			await page.keyboard.press('Tab')
 			await expect(popup.locator('.datepicker__quick-select-date').first()).toBeFocused()
+		})
+
+		test('Keeps focus on the datepicker trigger after clicking until Tab is pressed', async ({authenticatedPage: page}) => {
+			const tasks = await TaskFactory.create(1, {
+				id: 1,
+				done: false,
+				due_date: (new Date()).toISOString(),
+			})
+			await page.goto(`/tasks/${tasks[0].id}`)
+			await page.waitForLoadState('networkidle')
+
+			const column = page.locator('.task-view .columns.details .column').filter({hasText: 'Due Date'})
+			const trigger = column.locator('.datepicker .show')
+			const popup = column.locator('.datepicker-popup')
+			const firstShortcut = popup.locator('.datepicker__quick-select-date').first()
+			await trigger.click()
+			await expect(popup).toBeVisible()
+			await expect(trigger).toBeFocused()
+			await expect(firstShortcut).not.toBeFocused()
+
+			await page.keyboard.press('Tab')
+			await expect(firstShortcut).toBeFocused()
+			await page.keyboard.press('Escape')
+			await expect(popup).not.toBeVisible()
+
+			await trigger.press('Enter')
+			await expect(popup).toBeVisible()
+			await expect(firstShortcut).toBeFocused()
 		})
 
 		test('Opens the due date popup via the keyboard shortcut when the task already has a due date', async ({authenticatedPage: page}) => {
@@ -687,7 +718,7 @@ test.describe('Task', () => {
 			await openDueDatePopupWithShortcut(page)
 		})
 
-		test('Opens the start and end date popups from the actions menu and focuses the first quick-select option', async ({authenticatedPage: page}) => {
+		test('Tabs into the start and end date quick-select options after clicking the actions', async ({authenticatedPage: page}) => {
 			const tasks = await TaskFactory.create(1, {
 				id: 1,
 				done: false,
@@ -705,6 +736,8 @@ test.describe('Task', () => {
 
 				const popup = page.locator('.task-view .columns.details .column').filter({hasText: columnTitle}).locator('.datepicker .datepicker-popup')
 				await expect(popup).toBeVisible()
+				await expect(popup.locator('.datepicker__quick-select-date').first()).not.toBeFocused()
+				await page.keyboard.press('Tab')
 				await expect(popup.locator('.datepicker__quick-select-date').first()).toBeFocused()
 
 				await page.keyboard.press('Escape')

--- a/frontend/tests/e2e/task/task.spec.ts
+++ b/frontend/tests/e2e/task/task.spec.ts
@@ -644,6 +644,9 @@ test.describe('Task', () => {
 
 			const popup = dueDateColumn.locator('.datepicker .datepicker-popup')
 			await expect(popup).toBeVisible()
+			await expect(dueDateColumn.locator('.datepicker .show')).toBeFocused()
+			await expect(popup.locator('.datepicker__quick-select-date').first()).not.toBeFocused()
+			await page.keyboard.press('Tab')
 			await expect(popup.locator('.datepicker__quick-select-date').first()).toBeFocused()
 		})
 
@@ -654,6 +657,9 @@ test.describe('Task', () => {
 			const column = page.locator('.task-view .columns.details .column').filter({hasText: 'Due Date'})
 			const popup = column.locator('.datepicker .datepicker-popup')
 			await expect(popup).toBeVisible()
+			await expect(column.locator('.datepicker .show')).toBeFocused()
+			await expect(popup.locator('.datepicker__quick-select-date').first()).not.toBeFocused()
+			await page.keyboard.press('Tab')
 			await expect(popup.locator('.datepicker__quick-select-date').first()).toBeFocused()
 			return popup
 		}
@@ -703,6 +709,9 @@ test.describe('Task', () => {
 
 			await trigger.press('Enter')
 			await expect(popup).toBeVisible()
+			await expect(trigger).toBeFocused()
+			await expect(firstShortcut).not.toBeFocused()
+			await page.keyboard.press('Tab')
 			await expect(firstShortcut).toBeFocused()
 		})
 


### PR DESCRIPTION
## Purpose

Resolves #3818 

This makes the due-date more keyboard accessible, by ensuring the keyboard short-cut 'd' opens the datepicker popup immediately. Previously pressing `d` would *add* the due date field to the task if it didn't exist, but it wouldn't allow you to edit the field. If the due date already existed on the task, then `d` effectively did nothing.

## UX Comparison

In lieu of screenshots (which don't show much with changes in keyboard navigation) here are a couple of keyboard navigation comparisons of some user flows

### Add due date of tomorrow to a task

In this change:

- `d` to add the due date and open the popup
- `⇩` to move from 'today' to 'tomorrow' (assuming 'today' is visible)
- `enter` to select the day and close the popup

In the existing environment:

- `d`  to add the due date field
- `tab` many times to move the focus to the "due date" field
- `space` (or `enter`) to open the popup
- `tab` to move focus into the popup
- `tab` to move focus from 'today' to 'tomorrow'
- `space` or `enter` to choose the selected due date
- `tab`x6 to move to the confirm button
- `space` or `enter` to confirm the change and close the modal

(You *can* close the popup with `esc` after making your select, but it feels unnatural to me. I'm always concerned it's going to close the popup *without* persisting the value)

## Changes

- The `d` hotkey now opens the Datepicker popup for the due date field in addition to adding the field if it needs to be added
  - Using the mouse to "set due date" / "set start due" / "set end date" in the date and time sidebar now opens the appropriate date-picker pop-over as well (instead of requiring the user to click the "Click here to set a start date" text.
- Places the focus on the first "quick select" option in the popup. This ensures that there is *something* in the popup with focus.
- Ensures the focus ring is always visible in the popup.
- Allows using the up-arrow and down-arrow keys to navigate the quick selection options
- Pressing "Enter" on a quick selection option now sets the value and closes the popup. Currently both "enter" and "space" on a quick selection option select the option, but you still need to navigate with tab down to the "Confirm" button. With this change

## AI Disclosure

AI was used to help me learn and understand the structure of the codebase, and especially the parts of the codebase related to this PR. AI was used to draft the test changes (though the test changes were reviewed, modified, and run manually). AI was not used to write any of the non-test code.